### PR TITLE
Better method for finding install environment

### DIFF
--- a/R/util.r
+++ b/R/util.r
@@ -1,5 +1,5 @@
 inst_path <- function() {
-  envname <- environmentName(environment(inst_path))
+  envname <- environmentName(parent.env(environment()))
   
   if (envname == "staticdocs") {
     # Probably in package


### PR DESCRIPTION
This is (I think) a slightly better method for getting the environment containing the function.
