### PR TITLE
remove the depency on parser in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Imports:
     evaluate,
     whisker,
     highlight,
-    parser,
     tools,
     markdown,
     devtools (>= 0.8),


### PR DESCRIPTION
Dear Hadley,

I still had trouble installing staticdocs after fix #44 since DESCRIPTION file still referred to parser; it is fixed now

Najko
