### PR TITLE
fix for when directory "(inst|.)/staticdocs" does not exist.

### DIFF
--- a/R/settings.r
+++ b/R/settings.r
@@ -1,6 +1,6 @@
 load_settings <- function(package) {
   path <- file.path(pkg_sd_path(package), "index.r")
-  if (!file.exists(path)) return(list())
+  if (!isTRUE(file.exists(path))) return(list())
 
   source(path)$value
 }


### PR DESCRIPTION
Hi Hadley, 

Behavior: 
On Windows7 32/64 bits when directory "(inst|.)/staticdocs" is non-existent, `build_package` fails with the error
'Error in if (file == "") { : argument is of length zero:'.

Reason:
When directory "(inst|.)/staticdocs" is non-existent, `pkg_sd_path(package)` returns `NULL` and subsequently  `if (file.exists....)` fails because it is a `logical(0)`.
I only checked it on W32/W64

Best regards,

Edwin
