### PR TITLE
Fix error on empty template

### DIFF
--- a/R/render.r
+++ b/R/render.r
@@ -19,7 +19,8 @@ render_page <- function(package, name, data, path = "") {
 #' @importFrom whisker whisker.render
 render_template <- function(package, type, name, data) {
   template <- readLines(find_template(package, type, name))
-  if (length(template) <= 1 && str_trim(template) == "") return("")
+  if (length(template) == 0 || (length(template) == 1 && str_trim(template) == ""))
+    return("")
   
   whisker.render(template, data)
 }


### PR DESCRIPTION
One of my template files was completely empty, which caused str_trim to return `logical(0)`, which caused an error when used in a conditional.
