### PR TITLE
Add templates_path parameter to build_package, to allow overriding of built-in templates

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -15,14 +15,20 @@
 #' @param examples include examples or not?  Examples are particularly
 #'   slow to render because all code must be run, so turning them off makes
 #'   it easier to tweak templates etc.
+#' @param templates_path a specific directory path to use when searching for
+#'   rendering templates, in addition to the default locations of
+#'   packagedir/inst/staticdocs, packagedir/staticdocs, and the staticdocs
+#'   package's included templates directory.
 #' @export
 #' @import stringr
 #' @importFrom devtools load_all
 #' @aliases staticdocs-package
-build_package <- function(package, base_path = NULL, examples = NULL) {
+build_package <- function(package, base_path = NULL, examples = NULL,
+  templates_path = NULL) {
+  
   load_all(package)
   
-  package <- package_info(package, base_path, examples)
+  package <- package_info(package, base_path, examples, templates_path)
   if (!file.exists(package$base_path)) dir.create(package$base_path)
   copy_bootstrap(base_path)
 

--- a/R/package.r
+++ b/R/package.r
@@ -5,7 +5,9 @@
 #' @export
 #' @keywords internal
 #' @importFrom devtools as.package
-package_info <- function(package, base_path = NULL, examples = NULL) {
+package_info <- function(package, base_path = NULL, examples = NULL,
+  templates_path = NULL) {
+  
   out <- as.package(package)
 
   settings <- load_settings(out)
@@ -17,6 +19,8 @@ package_info <- function(package, base_path = NULL, examples = NULL) {
     stop("base_path not specified", call. = FALSE)
   out$examples <- examples %||% settings$examples %||% TRUE
 
+  out$templates_path <- templates_path
+    
   if (!is.null(out$url)) {
     out$urls <- str_trim(str_split(out$url, ",")[[1]])
     out$url <- NULL

--- a/R/render.r
+++ b/R/render.r
@@ -33,6 +33,9 @@ find_template <- function(package, type, name) {
     file.path(inst_path(), "templates")
   )
   
+  if (!is.null(package$templates_path))
+    paths <- c(package$templates_path, paths)
+  
   names <- c(
     str_c(type, "-", name, ".html"),
     str_c(type, ".html")

--- a/man/build_package.Rd
+++ b/man/build_package.Rd
@@ -3,7 +3,8 @@
 \alias{staticdocs-package}
 \title{Build complete static documentation for a package.}
 \usage{
-  build_package(package, base_path = NULL, examples = NULL)
+  build_package(package, base_path = NULL, examples = NULL,
+    templates_path = NULL)
 }
 \arguments{
   \item{package}{path to source version of package.  See
@@ -17,6 +18,12 @@
   particularly slow to render because all code must be run,
   so turning them off makes it easier to tweak templates
   etc.}
+
+  \item{templates_path}{a specific directory path to use
+  when searching for rendering templates, in addition to
+  the default locations of packagedir/inst/staticdocs,
+  packagedir/staticdocs, and the staticdocs package's
+  included templates directory.}
 }
 \description{
   Currently, knitr builds documentation for:

--- a/man/package_info.Rd
+++ b/man/package_info.Rd
@@ -2,7 +2,8 @@
 \alias{package_info}
 \title{Return information about a package}
 \usage{
-  package_info(package, base_path = NULL, examples = NULL)
+  package_info(package, base_path = NULL, examples = NULL,
+    templates_path = NULL)
 }
 \arguments{
   \item{package}{name of package, as character vector}


### PR DESCRIPTION
This lets us use multiple templates for a package, depending on where the docs are going.
