### PR TITLE
always write UTF8 file when render page

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -219,7 +219,7 @@ init_site <- function(pkg = ".", path = "docs") {
   extras <- dir(file.path(pkg$path, "pkgdown"), pattern = "^extra", full.names = TRUE)
   assets <- data_assets(pkg)
 
-  # Generate site meta data file (avaiable to website viewers)
+  # Generate site meta data file (available to website viewers)
   path_meta <- file.path(path, "pkgdown.yml")
   if (!is.null(pkg$meta$url)) {
     meta <- list(reference_url = paste0(pkg$meta$url, "/reference"))

--- a/R/render.r
+++ b/R/render.r
@@ -137,9 +137,7 @@ write_if_different <- function(contents, path) {
   }
 
   message("Writing '", path, "'")
-  file <- file(path, open = "w", encoding = "UTF-8")
-  on.exit(close(file))
-  cat(contents, file = file)
+  write_utf8(contents, path = file)
   TRUE
 }
 

--- a/R/render.r
+++ b/R/render.r
@@ -137,7 +137,7 @@ write_if_different <- function(contents, path) {
   }
 
   message("Writing '", path, "'")
-  write_utf8(contents, path = file)
+  write_utf8(contents, path = path)
   TRUE
 }
 

--- a/R/render.r
+++ b/R/render.r
@@ -137,7 +137,9 @@ write_if_different <- function(contents, path) {
   }
 
   message("Writing '", path, "'")
-  cat(contents, file = path)
+  file <- file(path, open = "w", encoding = "UTF-8")
+  on.exit(close(file))
+  cat(contents, file = file)
   TRUE
 }
 

--- a/R/util.r
+++ b/R/util.r
@@ -20,7 +20,7 @@ markdown_text <- function(text, ...) {
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
 
-  writeLines(text, tmp)
+  write_utf8(text, path = tmp, sep = "\n")
   markdown(tmp, ...)
 }
 
@@ -208,7 +208,7 @@ read_file <- function(path) {
 }
 
 write_yaml <- function(x, path) {
-  cat(yaml::as.yaml(x), "\n", sep = "", file = path)
+  write_utf8(yaml::as.yaml(x), "\n", path = path, sep = "")
 }
 
 invert_index <- function(x) {

--- a/R/util.r
+++ b/R/util.r
@@ -227,6 +227,12 @@ a <- function(text, href) {
   ifelse(is.na(href), text, paste0("<a href='", href, "'>", text, "</a>"))
 }
 
+write_utf8 <- function(..., path, sep = " ") {
+  file <- file(path, open = "w", encoding = "UTF-8")
+  on.exit(close(file))
+  cat(..., file = file, sep = sep)
+}
+
 # Used for testing
 #' @keywords internal
 #' @importFrom MASS addterm

--- a/R/util.r
+++ b/R/util.r
@@ -227,7 +227,7 @@ a <- function(text, href) {
   ifelse(is.na(href), text, paste0("<a href='", href, "'>", text, "</a>"))
 }
 
-write_utf8 <- function(..., path, sep = " ") {
+write_utf8 <- function(..., path, sep = "") {
   file <- file(path, open = "w", encoding = "UTF-8")
   on.exit(close(file))
   cat(..., file = file, sep = sep)


### PR DESCRIPTION
closes #339 

As I explained in the issue, `render_page` write HTML page using `write_if_different` with `cat` function which use `getOption("encoding")`. 

When it is not UTF-8, it seems to cause some issues with reference page that are not write as UTF-8 but HTML page has a  `<meta charset="utf-8">` and is expecting UTF-8.

I fix the issue forcing UTF-8 writing for HTML page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hadley/pkgdown/362)
<!-- Reviewable:end -->
