### PR TITLE
fixes #342 partially

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -246,8 +246,8 @@ update_article_filetypes <- function(pkg, encoding) {
       if (!length(output_idx)) stop("if pkgdown_asis set to true, you must specify output document type")
       article_filetypes[i] <- paste0(".", sub("_.*", "", names(article_front_matters[[i]]$output)))
 
-      pkg$article_index[i] <- gsub("\\.Rmd$", article_filetypes[i], pkg$article_index[i])
-      pkg$vignettes$file_out[i] <- gsub("\\.Rmd$", article_filetypes[i], pkg$vignettes$file_out[i])
+      pkg$article_index[i] <- gsub("\\.html$", article_filetypes[i], pkg$article_index[i])
+      pkg$vignettes$file_out[i] <- gsub("\\.html$", article_filetypes[i], pkg$vignettes$file_out[i])
     }
   }
   pkg

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -61,6 +61,7 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L,
 
   pkg <- as_pkgdown(pkg)
   path <- rel_path(path, pkg$path)
+  pkg <- update_article_filetypes(pkg, encoding)
   if (!has_vignettes(pkg$path)) {
     return(invisible())
   }
@@ -74,6 +75,7 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L,
     exclude_matching = "rsconnect"
   )
 
+
   # Render each Rmd then delete them
   articles <- tibble::tibble(
     input = file.path(path, pkg$vignettes$file_in),
@@ -85,7 +87,8 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L,
     pkg = pkg,
     data = data,
     encoding = encoding,
-    quiet = quiet
+    quiet = quiet,
+    render_asis = pkg$meta$pkgdown_asis
   )
   purrr::walk(articles$input, unlink)
 
@@ -102,36 +105,63 @@ render_rmd <- function(pkg,
                        toc = TRUE,
                        depth = 1L,
                        encoding = "UTF-8",
+                       render_asis = FALSE,
                        quiet = TRUE) {
 
   message("Building article '", output_file, "'")
   scoped_package_context(pkg$package, pkg$topic_index, pkg$article_index)
   scoped_file_context(depth = depth)
 
-  format <- build_rmarkdown_format(pkg, depth = depth, data = data, toc = toc)
-  on.exit(unlink(format$path), add = TRUE)
+  if (!render_asis)
+  {
+    format <- build_rmarkdown_format(pkg, depth = depth, data = data, toc = toc)
+    on.exit(unlink(format$path), add = TRUE)
+  }
 
-  path <- callr::r_safe(
-    function(...) rmarkdown::render(...),
-    args = list(
+  args <- if (render_asis) {
+    list(
+      input,
+      output_file = basename(output_file),
+      quiet = quiet,
+      envir = globalenv()
+    )
+  } else
+  {
+
+    list(
       input,
       output_format = format$format,
       output_file = basename(output_file),
       quiet = quiet,
       encoding = encoding,
       envir = globalenv()
-    ),
+    )
+  }
+
+  path <- callr::r_safe(
+    function(...) rmarkdown::render(...),
+    args = args,
     show = !quiet
   )
-  update_rmarkdown_html(path, strip_header = strip_header, depth = depth)
+
+  if (!render_asis)
+  {
+    update_rmarkdown_html(path, strip_header = strip_header, depth = depth)
+  }
 }
 
 build_rmarkdown_format <- function(pkg = ".",
                                    depth = 1L,
                                    data = list(),
                                    toc = TRUE) {
+
+  if (pkg$meta$pkgdown_asis) {
+    #front_matter <- rmarkdown:::parse_yaml_front_matter
+  }
+
   # Render vignette template to temporary file
   path <- tempfile(fileext = ".html")
+
   suppressMessages(
     render_page(pkg, "vignette", data, path, depth = depth)
   )
@@ -197,6 +227,30 @@ data_articles_index <- function(pkg = ".", depth = 1L) {
     pagetitle = "Articles",
     sections = sections
   ))
+}
+
+update_article_filetypes <- function(pkg, encoding) {
+
+  # replace html with the filetype specified if pkgdown_asis == TRUE.
+  if (pkg$meta$pkgdown_asis)
+  {
+    # read the input files
+    article_lines <- lapply(file.path(pkg$path, "vignettes", pkg$vignettes$file_in),
+                            function(file) rmarkdown:::read_lines_utf8(file, encoding))
+    # parse the yaml / front matter
+    article_front_matters <- lapply(article_lines, rmarkdown:::parse_yaml_front_matter)
+
+    article_filetypes <- numeric(length(article_front_matters))
+    for (i in 1:length(article_front_matters)) {
+      output_idx <- grep("_document", names(article_front_matters[[i]]$output) )
+      if (!length(output_idx)) stop("if pkgdown_asis set to true, you must specify output document type")
+      article_filetypes[i] <- paste0(".", sub("_.*", "", names(article_front_matters[[i]]$output)))
+
+      pkg$article_index[i] <- gsub("\\.Rmd$", article_filetypes[i], pkg$article_index[i])
+      pkg$vignettes$file_out[i] <- gsub("\\.Rmd$", article_filetypes[i], pkg$vignettes$file_out[i])
+    }
+  }
+  pkg
 }
 
 data_articles_index_section <- function(section, pkg, depth = 1L) {

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -30,6 +30,7 @@ build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8")
 
   pkg <- as_pkgdown(pkg)
   path <- rel_path(path, pkg$path)
+  pkg <- update_article_filetypes(pkg, encoding)
   data <- data_home(pkg)
 
   rule("Building home")

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -32,12 +32,14 @@
 build_news <- function(pkg = ".",
                        path = "docs/news",
                        one_page = TRUE,
-                       depth = 1L) {
+                       depth = 1L,
+                       encoding = "UTF-8") {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
 
   pkg <- as_pkgdown(pkg)
   path <- rel_path(path, pkg$path)
+  pkg <- update_article_filetypes(pkg, encoding)
   if (!has_news(pkg$path))
     return()
 

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -90,13 +90,15 @@ build_reference <- function(pkg = ".",
                             mathjax = TRUE,
                             seed = 1014,
                             path = "docs/reference",
-                            depth = 1L
+                            depth = 1L,
+                            encoding = "UTF-8"
                             ) {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
 
   pkg <- as_pkgdown(pkg)
   path <- rel_path(path, pkg$path)
+  pkg <- update_article_filetypes(pkg, encoding)
 
   rule("Building function reference")
 

--- a/R/build.r
+++ b/R/build.r
@@ -176,7 +176,7 @@ build_site <- function(pkg = ".",
     depth = 1L
   )
   build_articles(pkg, path = file.path(path, "articles"), depth = 1L, encoding = encoding)
-  build_news(pkg, path = file.path(path, "news"), depth = 1L)
+  build_news(pkg, path = file.path(path, "news"), depth = 1L, encoding = encoding)
 
   if (preview) {
     preview_site(path)

--- a/R/link-article-index.R
+++ b/R/link-article-index.R
@@ -19,6 +19,7 @@ article_index_local <- function(package, path = find.package(package)) {
     pattern = "\\.Rmd$",
     recursive = TRUE
   )
+
   out_path <- gsub("\\.Rmd$", ".html", vig_path)
   vig_name <- gsub("\\.Rmd$", "", basename(vig_path))
 


### PR DESCRIPTION
this pull request allows for rendering of vignette articles using the yaml supplied by each vignette article using the "pkgdown_asis" argument in the _pkgdown.yml file (and hence allows users to generate pdf articles for their vignettes).

this code is unfortunately *not* in the tidyverse idiom (as I am not well-versed in it), so it's not particularly pretty, but could be modified to fit into that idiom I would assume fairly straightforwardly. 

more files needed to be changed than I would have liked, so perhaps there's a better way of going about doing this. 

the one thing this does *not* do is "warn" a visitor of the resulting pkgdown-generated site that he or she will load a pdf.

an example of it in use is here: http://jaredhuling.org/vennLasso/