### PR TITLE
Improve detection of badges on homepage

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -22,6 +22,11 @@
 #' The "developers" list is populated by the maintainer ("cre"), authors
 #' ("aut"), and funder ("fnd").
 #'
+#' @section Badges:
+#' Status badges are displayed in the sidebar under the section "Dev status".
+#' This section is automatically populated if the first paragraph of the
+#' homepage consists solely of status badges as linked images.
+#'
 #' @inheritParams build_articles
 #' @export
 build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8") {

--- a/R/html.R
+++ b/R/html.R
@@ -73,7 +73,10 @@ tweak_rmarkdown_html <- function(html, strip_header = FALSE, depth = 1L) {
 tweak_homepage_html <- function(html, strip_header = FALSE) {
   first_para <- xml2::xml_find_first(html, "//p")
   badges <- first_para %>% xml2::xml_children()
-  has_badges <- length(badges) > 0 && all(xml2::xml_name(badges) %in% "a")
+  has_badges <-
+    trimws(xml2::xml_text(first_para)) == "" &&
+    length(badges) > 0 &&
+    all(xml2::xml_name(badges) %in% "a")
 
   if (has_badges) {
     list <- list_with_heading(badges, "Dev status")

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -44,3 +44,10 @@ The "developers" list is populated by the maintainer ("cre"), authors
 ("aut"), and funder ("fnd").
 }
 
+\section{Badges}{
+
+Status badges are displayed in the sidebar under the section "Dev status".
+This section is automatically populated if the first paragraph of the
+homepage consists solely of status badges as linked images.
+}
+


### PR DESCRIPTION
This adds "must not have text" as an additional constraint for has_badges, fixing first paragraphs with links but no other markup being mistaken for a list of badges.

A workable definition for the badges paragraph which doesn't look at the content itself should be "contains only images with links". To strictly check for this, something along these lines would be required in addition:
```
length(xml2::xml_children(badges)) > 0 &&
all(xml2::xml_name(xml2::xml_children(badges)) %in% "img")
```
which gets a bit unwieldy, and I can't think of a sensible case not already covered by the proposed version. 