### PR TITLE
prevent sidebar from disappearing at page bottom

### DIFF
--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -1,5 +1,14 @@
 $(function() {
-  $("#sidebar").stick_in_parent({offset_top: 40});
+
+  $("#sidebar")
+    .stick_in_parent({offset_top: 40})
+    .on('sticky_kit:bottom', function(e) {
+      $(this).parent().css('position', 'static');
+    })
+    .on('sticky_kit:unbottom', function(e) {
+      $(this).parent().css('position', 'relative');
+    });
+
   $('body').scrollspy({
     target: '#sidebar',
     offset: 60

--- a/inst/assets/pkgdown.js
+++ b/inst/assets/pkgdown.js
@@ -1,5 +1,14 @@
 $(function() {
-  $("#sidebar").stick_in_parent({offset_top: 40});
+
+  $("#sidebar")
+    .stick_in_parent({offset_top: 40})
+    .on('sticky_kit:bottom', function(e) {
+      $(this).parent().css('position', 'static');
+    })
+    .on('sticky_kit:unbottom', function(e) {
+      $(this).parent().css('position', 'relative');
+    });
+
   $('body').scrollspy({
     target: '#sidebar',
     offset: 60


### PR DESCRIPTION
Srolling to the bottom on some pages causes the sidebar to disappear. This extra JS prevents it from disappearing.

Based on https://github.com/leafo/sticky-kit/issues/31#issuecomment-51740033

See the disappearing behavior at:

- https://rnabioco.github.io/valr/index.html
- http://usethis.r-lib.org/index.html