### PR TITLE
Make local hrefs even when explicitly referencing local package

### DIFF
--- a/R/link-href.R
+++ b/R/link-href.R
@@ -106,6 +106,10 @@ href_topic_local <- function(topic) {
 }
 
 href_topic_remote <- function(topic, package) {
+  if (package == context_get("package")) {
+    return(href_topic_local(topic))
+  }
+
   rdname <- find_rdname(package, topic)
   if (is.null(rdname)) {
     return(NA_character_)
@@ -131,6 +135,9 @@ href_article_local <- function(article) {
 }
 
 href_article_remote <- function(package, article) {
+  if (package == context_get("package")) {
+    return(href_article_local(article))
+  }
   path <- find_article(package, article)
   if (is.null(path)) {
     return(NA_character_)

--- a/R/link-href.R
+++ b/R/link-href.R
@@ -34,36 +34,27 @@ href_expr <- function(expr, bare_symbol = FALSE) {
     if (fun_name == "vignette") {
       expr <- lang_standardise(expr)
       topic <- as.character(expr[[2]])
-
-      if (is.null(expr$package)) {
-        href_article_local(topic)
-      } else {
-        href_article_remote(expr$package, topic)
-      }
+      href_article(topic, expr$package)
     } else if (fun_name == "?") {
       if (n_args == 1) {
         topic <- expr[[2]]
         if (is_lang(topic, "::")) {
           # ?pkg::x
-          href_topic_remote(as.character(topic[[3]]), as.character(topic[[2]]))
+          href_topic(as.character(topic[[3]]), as.character(topic[[2]]))
         } else if (is_symbol(topic) || is_string(topic)) {
           # ?x
-          href_topic_local(as.character(expr[[2]]))
+          href_topic(as.character(expr[[2]]))
         } else {
           NA_character_
         }
       } else if (n_args == 2) {
         # package?x
-        href_topic_local(paste0(expr[[3]], "-", expr[[2]]))
+        href_topic(paste0(expr[[3]], "-", expr[[2]]))
       }
     } else if (fun_name == "::") {
-      href_topic_remote(as.character(expr[[3]]), as.character(expr[[2]]))
+      href_topic(as.character(expr[[3]]), as.character(expr[[2]]))
     } else {
-      if (is.null(pkg)) {
-        href_topic_local(fun_name)
-      } else {
-        href_topic_remote(fun_name, pkg)
-      }
+      href_topic(fun_name, pkg)
     }
   } else {
     NA_character_
@@ -73,6 +64,14 @@ href_expr <- function(expr, bare_symbol = FALSE) {
 # Helper for testing
 href_expr_ <- function(expr, ...) {
   href_expr(substitute(expr), ...)
+}
+
+href_topic <- function(topic, package = NULL) {
+  if (is.null(package) || package == context_get("package")) {
+    href_topic_local(topic)
+  } else {
+    href_topic_remote(topic, package)
+  }
 }
 
 href_topic_local <- function(topic) {
@@ -106,10 +105,6 @@ href_topic_local <- function(topic) {
 }
 
 href_topic_remote <- function(topic, package) {
-  if (package == context_get("package")) {
-    return(href_topic_local(topic))
-  }
-
   rdname <- find_rdname(package, topic)
   if (is.null(rdname)) {
     return(NA_character_)
@@ -125,28 +120,26 @@ href_topic_remote <- function(topic, package) {
   }
 }
 
-href_article_local <- function(article) {
-  path <- find_article(NULL, article)
-  if (is.null(path)) {
-    return(NA_character_)
-  }
+href_article <- function(article, package = NULL) {
+  local <- is.null(package) || package == context_get("package")
+  if (local) {
+    path <- find_article(NULL, article)
+    if (is.null(path)) {
+      return(NA_character_)
+    }
 
-  paste0(up_path(context_get("depth")), "articles/", path)
-}
-
-href_article_remote <- function(package, article) {
-  if (package == context_get("package")) {
-    return(href_article_local(article))
-  }
-  path <- find_article(package, article)
-  if (is.null(path)) {
-    return(NA_character_)
-  }
-
-  base_url <- remote_package_article_url(package)
-  if (is.null(base_url)) {
-    paste0("https://cran.rstudio.com/web/packages/", package, "/vignettes/", path)
+    paste0(up_path(context_get("depth")), "articles/", path)
   } else {
-    paste0(base_url, "/", path)
+    path <- find_article(package, article)
+    if (is.null(path)) {
+      return(NA_character_)
+    }
+
+    base_url <- remote_package_article_url(package)
+    if (is.null(base_url)) {
+      paste0("https://cran.rstudio.com/web/packages/", package, "/vignettes/", path)
+    } else {
+      paste0(base_url, "/", path)
+    }
   }
 }

--- a/tests/testthat/test-href.R
+++ b/tests/testthat/test-href.R
@@ -1,8 +1,5 @@
 context("href")
 
-# This test file fails if run in isolation unless this context is set
-scoped_package_context("test", local_packages = character())
-
 test_that("can link function calls", {
   scoped_package_context("test", c(foo = "bar"))
   scoped_file_context("test")

--- a/tests/testthat/test-href.R
+++ b/tests/testthat/test-href.R
@@ -1,5 +1,8 @@
 context("href")
 
+# This test file fails if run in isolation unless this context is set
+scoped_package_context("test", local_packages = character())
+
 test_that("can link function calls", {
   scoped_package_context("test", c(foo = "bar"))
   scoped_file_context("test")
@@ -58,6 +61,7 @@ test_that("can link ? calls", {
 
   expect_equal(href_expr_(?foo), "foo.html")
   expect_equal(href_expr_(?"foo"), "foo.html")
+  expect_equal(href_expr_(test::foo), "foo.html")
   expect_equal(href_expr_(package?foo), "foo-package.html")
 })
 
@@ -69,6 +73,7 @@ test_that("can link to local articles", {
   scoped_file_context(depth = 0)
 
   expect_equal(href_expr_(vignette("x")), "articles/y.html")
+  expect_equal(href_expr_(vignette("x", package="test")), "articles/y.html")
   expect_equal(href_expr_(vignette("y")), NA_character_)
 })
 

--- a/tests/testthat/test-href.R
+++ b/tests/testthat/test-href.R
@@ -70,7 +70,7 @@ test_that("can link to local articles", {
   scoped_file_context(depth = 0)
 
   expect_equal(href_expr_(vignette("x")), "articles/y.html")
-  expect_equal(href_expr_(vignette("x", package="test")), "articles/y.html")
+  expect_equal(href_expr_(vignette("x", package = "test")), "articles/y.html")
   expect_equal(href_expr_(vignette("y")), NA_character_)
 })
 


### PR DESCRIPTION
The autolinking feature is really great! One edge case I hit where it didn't work exactly as expected was when there were explicit references to the package itself. `vignette("my-vignette")` would correctly link to my-vignette in the pkgdown site, but `vignette("my-vignette", package="mypackage")` would link to a CRAN mirror as it would for any other non-local package.

This change adds a check in `href_topic_remote` and `href_article_remote`: if the given `package` is the same as what has been set by `scoped_package_context`, they call the `_local` function instead. So `vignette("my-vignette", package="mypackage")` will link to the pkgdown site itself, as will `mypackge::func`.

Obviously this isn't hugely important, but I have found some legitimate cases where the explicit vignette/function reference makes sense (a generic-sounding vignette name, a function or method with the same name as one in another package), and the code change needed to make these links work is small. 