### PR TITLE
Fix bug with navigation highlighting and zero-length paths

### DIFF
--- a/inst/assets/pkgdown.js
+++ b/inst/assets/pkgdown.js
@@ -36,6 +36,9 @@ function is_prefix(needle, haystack) {
   if (needle.length > haystack.lengh)
     return(false);
 
+  if (haystack.length == 0)
+    return(false);
+
   for (var i = 0; i < haystack.length; i++) {
     if (needle[i] != haystack[i])
       return(false);


### PR DESCRIPTION
Currently, if your navbar contains an item (or a list containing an item) which links to the root of a domain or subdomain, and your pkgdown site is also hosted at the root of a domain or subdomain, that item will be marked as "active".

Example:
Package hosted at: http://package.example.com/
Navbar link to: http://other_subdomain.example.com/

This patch fixes this bug by not marking active any case where the haystack has length zero.