### PR TITLE
ignore vignette files starting with '_'

### DIFF
--- a/R/package.r
+++ b/R/package.r
@@ -141,6 +141,7 @@ package_vignettes <- function(path = ".") {
     pattern = "\\.[rR]md$",
     recursive = TRUE
   )
+  vig_path <- vig_path[!grepl("^_", basename(vig_path))]
 
   title <- file.path(path, "vignettes", vig_path) %>%
     purrr::map(rmarkdown::yaml_front_matter) %>%

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -75,7 +75,7 @@ pkgdown will warn if you've forgotten to include any non-internal functions.
 
 ## Articles
 
-pkgdown will automatically build all `.Rmd` vignettes, including those in subdirectories, and render output to `articles/`. pkgdown will ignore the output format defined in the yaml header, and always use `html_fragment(toc = TRUE, toc_float = TRUE)`.
+pkgdown will automatically build all `.Rmd` vignettes, including those in subdirectories. The only exception are `.Rmd` vignettes that start with '_'. This enables the use of child documents in [bookdown](https://bookdown.org/yihui/bookdown/). The output of the vignettes is rendered to `articles/`. pkgdown will ignore the output format defined in the yaml header, and always use `html_fragment(toc = TRUE, toc_float = TRUE)`.
 
 If you want to include an article on the website, but not in the package (e.g. because it's large), you can either place it in a subdirectory of `vignettes/` or add to `.Rbuildignore`. As well, you must ensure that there is no `vignettes:` section in the article's yaml header. In the extreme case where you want to produce only articles but not vignettes, you can add the complete `vignettes/` directory to `.Rbuildignore`.
 


### PR DESCRIPTION
Concept taken from [bookdown](https://bookdown.org/yihui/bookdown/usage.html) which renders all `Rmd` files expect those starting with `_`. Such files can be used as child documents. See [inbo/INBOtheme](https://github.com/inbo/INBOtheme/commit/d9efda692538dd07992ea6047feedf315baa12e9) for an example.

Solves #463 
