### PR TITLE
Update pkgdown website URL everywhere: http://hadley.github.io/pkgdown/ 404s

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,6 @@ Remotes:
     r-lib/usethis
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1
-URL: http://hadley.github.io/pkgdown, https://github.com/hadley/pkgdown
+URL: http://pkgdown.r-lib.org, https://github.com/hadley/pkgdown
 BugReports: https://github.com/hadley/pkgdown/issues
 Roxygen: list(markdown = TRUE)

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/pkgdown)](https://cran.r-project.org/package=pkgdown)
 [![Coverage Status](https://img.shields.io/codecov/c/github/hadley/pkgdown/master.svg)](https://codecov.io/github/hadley/pkgdown?branch=master)
 
-pkgdown is designed to make it quick and easy to build a website for your package. You can see pkgdown in action at <http://hadley.github.io/pkgdown/>: this is the output of pkgdown applied to the latest version of pkgdown. Learn more in `vignette("pkgdown")` or `?build_site`.
+pkgdown is designed to make it quick and easy to build a website for your package. You can see pkgdown in action at <http://pkgdown.r-lib.org/>: this is the output of pkgdown applied to the latest version of pkgdown. Learn more in `vignette("pkgdown")` or `?build_site`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ pkgdown
 
 [![Travis-CI Build Status](https://travis-ci.org/hadley/pkgdown.svg?branch=master)](https://travis-ci.org/hadley/pkgdown) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/pkgdown)](https://cran.r-project.org/package=pkgdown) [![Coverage Status](https://img.shields.io/codecov/c/github/hadley/pkgdown/master.svg)](https://codecov.io/github/hadley/pkgdown?branch=master)
 
-pkgdown is designed to make it quick and easy to build a website for your package. You can see pkgdown in action at <http://hadley.github.io/pkgdown/>: this is the output of pkgdown applied to the latest version of pkgdown. Learn more in `vignette("pkgdown")` or `?build_site`.
+pkgdown is designed to make it quick and easy to build a website for your package. You can see pkgdown in action at <http://pkgdown.r-lib.org/>: this is the output of pkgdown applied to the latest version of pkgdown. Learn more in `vignette("pkgdown")` or `?build_site`.
 
 Installation
 ------------

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: http://hadley.github.io/pkgdown
+url: http://pkgdown.r-lib.org
 
 template:
   params:

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -113,7 +113,7 @@ COPYRIGHT HOLDER: Hadley Wickham and RStudio
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -116,7 +116,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/articles/pkgdown.html
+++ b/docs/articles/pkgdown.html
@@ -221,7 +221,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/articles/test/highlight.html
+++ b/docs/articles/test/highlight.html
@@ -134,7 +134,7 @@ MASS<span class="op">::</span><span class="kw"><a href="http://www.rdocumentatio
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -120,7 +120,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,7 @@
 <div class="page-header"><h1 class="hasAnchor">
 <a href="#pkgdown" class="anchor"></a>pkgdown</h1></div>
 
-<p>pkgdown is designed to make it quick and easy to build a website for your package. You can see pkgdown in action at <a href="http://hadley.github.io/pkgdown/" class="uri">http://hadley.github.io/pkgdown/</a>: this is the output of pkgdown applied to the latest version of pkgdown. Learn more in <code><a href="articles/pkgdown.html">vignette("pkgdown")</a></code> or <code><a href="reference/build_site.html">?build_site</a></code>.</p>
+<p>pkgdown is designed to make it quick and easy to build a website for your package. You can see pkgdown in action at <a href="http://pkgdown.r-lib.org/" class="uri">http://pkgdown.r-lib.org/</a>: this is the output of pkgdown applied to the latest version of pkgdown. Learn more in <code><a href="articles/pkgdown.html">vignette("pkgdown")</a></code> or <code><a href="reference/build_site.html">?build_site</a></code>.</p>
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
@@ -93,7 +93,7 @@ devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocument
 <h2 class="hasAnchor">
 <a href="#usage" class="anchor"></a>Usage</h2>
 <p>Run pkgdown from the package directory each time you release your package:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">pkgdown<span class="op">::</span><span class="kw"><a href="http://hadley.github.io/pkgdown/reference/build_site.html">build_site</a></span>()</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">pkgdown<span class="op">::</span><span class="kw"><a href="http://pkgdown.r-lib.org/reference/build_site.html">build_site</a></span>()</code></pre></div>
 <p>This will generate a <code>docs/</code> directory. The home page will be generated from your package’s <code>README.md</code>, and a function reference will be generated from the documentation in the <code>man/</code> directory. If you are using GitHub, the easiest way to make this your package website is to check into git, then go settings for your repo and make sure that the <strong>GitHub pages</strong> source is set to “master branch /docs folder”.</p>
 <p>The package also includes an RStudio add-in which you can bind to a keyboard shortcut. I recommend <code>Cmd + Shift + W</code>: it uses Cmd + Shift, like all other package development worksheets, it replaces a rarely used command (close all tabs), and the W is mnemonic for website.</p>
 <p>To customise your site, create <code>_pkgdown.yml</code> and modify it as described in the documentation. Alternatively, you can also use <code>pkgdown/_pkgdown.yml</code> if you need other files to customise your site.</p>
@@ -136,7 +136,7 @@ devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocument
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,6 +1,6 @@
 urls:
-  reference: http://hadley.github.io/pkgdown/reference
-  article: http://hadley.github.io/pkgdown/articles
+  reference: http://pkgdown.r-lib.org/reference
+  article: http://pkgdown.r-lib.org/articles
 articles:
   pkgdown: pkgdown.html
   highlight: test/highlight.html

--- a/docs/reference/as_pkgdown.html
+++ b/docs/reference/as_pkgdown.html
@@ -131,7 +131,7 @@ design and you're writing your own equivalent of <code><a href='build_site.html'
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/autolink_html.html
+++ b/docs/reference/autolink_html.html
@@ -168,7 +168,7 @@ to unqualified references.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/bacon.html
+++ b/docs/reference/bacon.html
@@ -125,7 +125,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/build_articles.html
+++ b/docs/reference/build_articles.html
@@ -195,7 +195,7 @@ customise the navbar. See <code><a href='build_site.html'>build_site()</a></code
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/build_home.html
+++ b/docs/reference/build_home.html
@@ -166,7 +166,7 @@ home:
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/build_news.html
+++ b/docs/reference/build_news.html
@@ -171,7 +171,7 @@ to adjust relative links in the navbar.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/build_reference.html
+++ b/docs/reference/build_reference.html
@@ -246,7 +246,7 @@ retina display). Icons are matched to topics by aliases.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/build_site.html
+++ b/docs/reference/build_site.html
@@ -299,7 +299,7 @@ for pkgdown templates to ensure that you use the correct components.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/clean_site.html
+++ b/docs/reference/clean_site.html
@@ -137,7 +137,7 @@ path.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/in_pkgdown.html
+++ b/docs/reference/in_pkgdown.html
@@ -125,7 +125,7 @@ pkgdown and regular documentation.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -226,7 +226,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/pulledpork.html
+++ b/docs/reference/pulledpork.html
@@ -129,7 +129,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/reexports.html
+++ b/docs/reference/reexports.html
@@ -122,7 +122,7 @@ below to see their documentation.</p><dl class='dl-horizontal'>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/rel_path.html
+++ b/docs/reference/rel_path.html
@@ -138,7 +138,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/render_page.html
+++ b/docs/reference/render_page.html
@@ -168,7 +168,7 @@ of the pkgdown templates and modify from there.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/templates.html
+++ b/docs/reference/templates.html
@@ -136,7 +136,7 @@ points if you want to customise your site.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/test-lists.html
+++ b/docs/reference/test-lists.html
@@ -137,7 +137,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/inst/templates/footer.html
+++ b/inst/templates/footer.html
@@ -3,6 +3,6 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 

--- a/tests/testthat/test-href.R
+++ b/tests/testthat/test-href.R
@@ -80,7 +80,7 @@ test_that("can link to remote articles", {
 
   expect_equal(
     href_expr_(vignette("highlight", "pkgdown")),
-    "http://hadley.github.io/pkgdown/articles/test/highlight.html"
+    "http://pkgdown.r-lib.org/articles/test/highlight.html"
   )
 })
 

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -3,7 +3,7 @@ context("remote")
 test_that("remote_package_url discovers pkgdown site", {
   expect_equal(
     remote_package_reference_url("pkgdown"),
-    "http://hadley.github.io/pkgdown/reference"
+    "http://pkgdown.r-lib.org/reference"
   )
 })
 


### PR DESCRIPTION
I was trying to look up something in the `pkgdown` reference the other day and got a 404 on http://hadley.github.io/pkgdown/. I noticed then that the site had moved to http://pkgdown.r-lib.org/. 

This commit just finds/replaces the URL everywhere. Two tests fail, but that's because http://pkgdown.r-lib.org/pkgdown.yml still reports 

```yaml
urls:
  reference: http://hadley.github.io/pkgdown/reference
  article: http://hadley.github.io/pkgdown/articles
```

which this commit will fix when it is merged and the site deploys.

I wonder also if you might be able to appeal to GitHub to redirect http://hadley.github.io/pkgdown/ to http://pkgdown.r-lib.org/. Unfortunately, every pkgdown site in the wild has a link to http://hadley.github.io/pkgdown/ in the page footer, and that link is currently broken.