### PR TITLE
fix typo

### DIFF
--- a/docs/articles/pkgdown.html
+++ b/docs/articles/pkgdown.html
@@ -105,7 +105,7 @@
 <li><code>README.Rmd</code></li>
 <li><code>README.md</code></li>
 </ol>
-<p>pkgdown tries them in order, which means that if you want different display for GitHub and pkgdown, you can have both <code>README.md</code> and a <code>index.md</code></p>
+<p>pkgdown tries them in order, which means that if you want different display for GitHub and pkgdown, you can have both <code>README.md</code> and an <code>index.md</code></p>
 <p>When including big graphics in the README, you may find it easier to use <code><a href="http://www.rdocumentation.org/packages/knitr/topics/include_graphics">knitr::include_graphics("foo.png")</a></code> combined with chunk option <code>out.width = '100%'</code>. This will make the graphic scale with the size of the page.</p>
 </div>
 <div id="reference" class="section level2">

--- a/docs/articles/pkgdown.html
+++ b/docs/articles/pkgdown.html
@@ -105,7 +105,7 @@
 <li><code>README.Rmd</code></li>
 <li><code>README.md</code></li>
 </ol>
-<p>pkgdown tries them in order, which means that if you want different display for GitHub and pkgdown, you can have both <code>README.md</code> and an <code>index.md</code></p>
+<p>pkgdown tries them in that order, which means that if you want different display for GitHub and pkgdown, you can have both a <code>README.md</code> and an <code>index.md</code></p>
 <p>When including big graphics in the README, you may find it easier to use <code><a href="http://www.rdocumentation.org/packages/knitr/topics/include_graphics">knitr::include_graphics("foo.png")</a></code> combined with chunk option <code>out.width = '100%'</code>. This will make the graphic scale with the size of the page.</p>
 </div>
 <div id="reference" class="section level2">

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -37,7 +37,7 @@ The home page will be automatically generated from one of the following four fil
 1. `README.Rmd`
 1. `README.md`
 
-pkgdown tries them in order, which means that if you want different display for GitHub and pkgdown, you can have both `README.md` and a `index.md`
+pkgdown tries them in order, which means that if you want different display for GitHub and pkgdown, you can have both `README.md` and an `index.md`
 
 When including big graphics in the README, you may find it easier to use `knitr::include_graphics("foo.png")` combined with chunk option `out.width = '100%'`. This will make the graphic scale with the size of the page.
 


### PR DESCRIPTION
Please see the diff. Nothing major :-)

Additionally, I'm wondering whether in the same line the wording could be improved by "tries them in **that** order" (related to #490) and "both **a** `README`". Please let me know if you agree, and I'll add those commits here.