### PR TITLE
handle DOI references and links in the package description

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -65,7 +65,7 @@ build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8",
   }
 
   if (is.null(data$path)) {
-    data$index <- pkg$desc$get("Description")[[1]]
+    data$index <- linkify(pkg$desc$get("Description")[[1]])
     render_page(pkg, "home", data, out_path(path, "index.html"), depth = depth)
   } else {
     file_name <- tools::file_path_sans_ext(basename(data$path))
@@ -284,4 +284,17 @@ repo_url <- function(pkg, cran = cran_mirror(), bioc = bioc_mirror()) {
 link_url <- function(text, href) {
   label <- gsub("(/+)", "\\1&#8203;", href)
   paste0(text, " at <br /><a href='", href, "'>", label, "</a>")
+}
+
+linkify <- function(text) {
+  text <- gsub("<doi:([^>]+)>",
+               "&lt;<a href='https://doi.org/\\1'>doi:\\1</a>&gt;",
+               text, ignore.case = TRUE)
+  text <- gsub("<arXiv:([^>]+)>",
+               "&lt;<a href='https://arxiv.org/abs/\\1'>arXiv:\\1</a>&gt;",
+               text, ignore.case = TRUE)
+  text <- gsub("<((http|ftp)[^>]+)>",
+               "&lt;<a href='\\1'>\\1</a>&gt;",
+               text)
+  text
 }

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -287,13 +287,14 @@ link_url <- function(text, href) {
 }
 
 linkify <- function(text) {
-  text <- gsub("<doi:([^>]+)>",
+  text <- escape_html(text)
+  text <- gsub("&lt;doi:([^&]+)&gt;",  # DOIs with < > & are not supported
                "&lt;<a href='https://doi.org/\\1'>doi:\\1</a>&gt;",
                text, ignore.case = TRUE)
-  text <- gsub("<arXiv:([^>]+)>",
+  text <- gsub("&lt;arXiv:([^&]+)&gt;",
                "&lt;<a href='https://arxiv.org/abs/\\1'>arXiv:\\1</a>&gt;",
                text, ignore.case = TRUE)
-  text <- gsub("<((http|ftp)[^>]+)>",
+  text <- gsub("&lt;((http|ftp)[^&]+)&gt;",  # URIs with & are not supported
                "&lt;<a href='\\1'>\\1</a>&gt;",
                text)
   text

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -82,3 +82,29 @@ test_that("package repo verification", {
 
 })
 
+
+# links and references in the package description -------------------------
+
+test_that("references in angle brackets are converted to HTML", {
+  ## URL
+  expect_identical(
+    linkify("see <https://CRAN.R-project.org/view=SpatioTemporal>."),
+    "see &lt;<a href='https://CRAN.R-project.org/view=SpatioTemporal'>https://CRAN.R-project.org/view=SpatioTemporal</a>&gt;."
+  )
+  ## DOI
+  expect_identical(
+    linkify("M & H (2017) <doi:10.1093/biostatistics/kxw051>"),
+    "M &amp; H (2017) &lt;<a href='https://doi.org/10.1093/biostatistics/kxw051'>doi:10.1093/biostatistics/kxw051</a>&gt;"
+  )
+  ## arXiv
+  expect_identical(
+    linkify("see <arXiv:1802.03967>."),
+    "see &lt;<a href='https://arxiv.org/abs/1802.03967'>arXiv:1802.03967</a>&gt;."
+  )
+  ## unsupported formats are left alone (just escaping special characters)
+  unsupported <- c(
+    "<doi:10.1002/(SICI)1097-0258(19980930)17:18<2045::AID-SIM943>3.0.CO;2-P>",
+    "<https://scholar.google.com/citations?view_op=top_venues&hl=de&vq=phy_probabilitystatistics>"
+  )
+  expect_identical(linkify(unsupported), escape_html(unsupported))
+})


### PR DESCRIPTION
Fixes #499.

Limitation: URL's with & and DOI's with &, <, or > are not supported (meaning they are not turned into links), see the tests for examples.