### PR TITLE
build_articles() no longer fails for a pkg with non-Rmd vignettes only

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -257,8 +257,3 @@ default_articles_index <- function(pkg = ".") {
   ))
 
 }
-
-has_vignettes <- function(path = ".") {
-  vign_path <- file.path(path, "vignettes")
-  file.exists(vign_path) && length(list.files(vign_path))
-}

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -64,7 +64,7 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L,
 
   pkg <- as_pkgdown(pkg)
   path <- rel_path(path, pkg$path)
-  if (!has_vignettes(pkg$path)) {
+  if (nrow(pkg$vignettes) == 0L) {
     return(invisible())
   }
 


### PR DESCRIPTION
`has_vignette()` would indicate whether there are any files in the vignettes folder. However, a package might well have vignettes but none of them in Rmd format, so none of them part of the `pkg$vignettes` tibble processed in `build_articles()`, which would subsequently fail from `data_articles_index()` trying to setup an index for `"All vignettes"` with contents `"``"`.