### PR TITLE
enforce UTF8 reading when internally writing to UTF-8

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -45,6 +45,6 @@ markdown_text <- function(text, ...) {
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
 
-  write_utf8(text, path = tmp, sep = "\n")
+  write_lines(text, path = tmp)
   markdown(tmp, ...)
 }

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -32,7 +32,7 @@ markdown <- function(path = NULL, ...) {
     xml2::xml_find_first(".//body") %>%
     xml2::write_html(tmp, format = FALSE)
 
-  lines <- readLines(tmp, warn = FALSE)
+  lines <- read_lines(tmp)
   lines <- sub("<body>", "", lines, fixed = TRUE)
   lines <- sub("</body>", "", lines, fixed = TRUE)
   paste(lines, collapse = "\n")

--- a/R/render.r
+++ b/R/render.r
@@ -114,7 +114,7 @@ template_path <- function(pkg = ".") {
 }
 
 render_template <- function(path, data) {
-  template <- readLines(path)
+  template <- read_lines(path)
   if (length(template) == 0)
     return("")
 
@@ -175,7 +175,7 @@ same_contents <- function(path, contents) {
 made_by_pkgdown <- function(path) {
   if (!file_exists(path)) return(TRUE)
 
-  first <- paste(readLines(path, n = 2), collapse = "\n")
+  first <- paste(read_lines(path, n = 2), collapse = "\n")
   check_made_by(first)
 }
 

--- a/R/render.r
+++ b/R/render.r
@@ -156,7 +156,7 @@ write_if_different <- function(pkg, contents, path, quiet = FALSE) {
   if (!quiet) {
     cat_line("Writing '", path, "'")
   }
-  write_utf8(contents, path = full_path)
+  write_lines(contents, path = full_path)
   TRUE
 }
 

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -7,14 +7,8 @@ read_file <- function(path) {
 
 # Writing -----------------------------------------------------------------
 
-write_utf8 <- function(..., path, sep = "") {
-  file <- file(path, open = "w", encoding = "UTF-8")
-  on.exit(close(file))
-  cat(..., file = file, sep = sep)
-}
-
 write_yaml <- function(x, path) {
-  write_utf8(yaml::as.yaml(x), "\n", path = path, sep = "")
+  write_lines(yaml::as.yaml(x), path = path)
 }
 
 # Inspired by roxygen2 utils-io.R (https://github.com/klutometis/roxygen/) -----------

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -16,3 +16,16 @@ write_utf8 <- function(..., path, sep = "") {
 write_yaml <- function(x, path) {
   write_utf8(yaml::as.yaml(x), "\n", path = path, sep = "")
 }
+
+# Inspired by roxygen2 utils-io.R (https://github.com/klutometis/roxygen/) -----------
+
+readLines <- function(...) stop("Use read_lines!")
+writeLines <- function(...) stop("Use write_lines!")
+
+read_lines <- function(path, n = -1L) {
+  base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
+}
+
+write_lines <- function(text, path) {
+  base::writeLines(enc2utf8(text), path, useBytes = TRUE)
+}

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -1,7 +1,7 @@
 # Reading -----------------------------------------------------------------
 
 read_file <- function(path) {
-  lines <- readLines(path, warn = FALSE)
+  lines <- read_lines(path)
   paste0(lines, "\n", collapse = "")
 }
 

--- a/tests/testthat/test-build_news.R
+++ b/tests/testthat/test-build_news.R
@@ -18,7 +18,7 @@ test_that("build_news() uses content in NEWS.md", {
   expect_output(build_news(pkg))
   on.exit(clean_site(pkg))
 
-  lines <- readLines(path(pkg, "docs", "news", "index.html"))
+  lines <- read_lines(path(pkg, "docs", "news", "index.html"))
   test_strings <- c("testpackage", "1.0.0.9000", "1.0.0[^\\.]",
                     "sub-heading", "@githubuser", "bullet", "#111")
   expect_true(all(

--- a/tests/testthat/test-open-graph.R
+++ b/tests/testthat/test-open-graph.R
@@ -6,7 +6,7 @@ setup(expect_output(build_site(pkg)))
 teardown(clean_site(pkg))
 
 test_that("og tags are populated on index.html", {
-  index_html <- readLines(path(pkg$dst_path, "index.html"))
+  index_html <- read_lines(path(pkg$dst_path, "index.html"))
   desc <- '<meta property="og:description" content="A longer statement about the package.">'
   expect_true(desc %in% index_html)
   img <- '<meta property="og:image" content="http://example.com/pkg/logo.png">'
@@ -14,7 +14,7 @@ test_that("og tags are populated on index.html", {
 })
 
 test_that("og tags are populated on reference pages", {
-  pork_html <- readLines(path(pkg$dst_path, "reference", "pulledpork.html"))
+  pork_html <- read_lines(path(pkg$dst_path, "reference", "pulledpork.html"))
   desc <- '<meta property="og:description" content="Pulled pork is delicious" />'
   expect_true(desc %in% pork_html)
   img <- '<meta property="og:image" content="http://example.com/pkg/logo.png" />'
@@ -22,7 +22,7 @@ test_that("og tags are populated on reference pages", {
 })
 
 test_that("og tags are populated on vignettes", {
-  vignette_html <- readLines(path(pkg$dst_path, "articles", "open-graph.html"))
+  vignette_html <- read_lines(path(pkg$dst_path, "articles", "open-graph.html"))
   desc <- '<meta property="og:description" content="The Open Graph protocol is a standard for web page metadata.">'
   expect_true(desc %in% vignette_html)
   img <- '<meta property="og:image" content="http://example.com/pkg/logo.png">'
@@ -34,6 +34,6 @@ test_that("if there is no logo.png, there is no og:image tag", {
   expect_output(build_site(pkg))
   on.exit(clean_site(pkg))
 
-  index_html <- readLines(path(pkg$dst_path, "index.html"))
+  index_html <- read_lines(path(pkg$dst_path, "index.html"))
   expect_false(any(grepl("og:image", index_html, fixed = TRUE)))
 })


### PR DESCRIPTION
fixes #514 encoding issue

Following #362, there is still an encoding issue with `build_news` and `build_home`. They do not render properly when building site for a 📦 in french on a computer with french locale. 

After investigation, I found that `build_news` and `build_home` both parsed `.md`  file using an internal `markdown` function. It uses pandoc to convert markdown to html then makes changes in html using `xml2`, writes back the temp html file and then reads it line by line with `readLines` with no encoding provided.
However, `xml2::write_html` enforces UTF-8 (see [source](https://github.com/r-lib/xml2/blob/master/R/xml_write.R), so `readLines` should assume UTF-8 input, but its default param is `encoding = "unknown"` that I think assumes an encoding based on `Sys.getlocale()`. 

Everything is working fine with this small change. 

Test was made with 📦 [COGuguaison](https://github.com/antuki/COGugaison) - a french one. (see the related issue)