### PR TITLE
automatic S4 documentation

### DIFF
--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -10,8 +10,9 @@ data_reference_index <- function(pkg = ".", depth = 1L) {
   
   # Write S4 documentation if available
   if(!is.null(pkg$meta[["reference"]])){
+	  extract_title <- function(x){x$title}
 	  s4_documentation <- 
-			  pkg$meta[["reference"]] %>% purrr::map(.$title) %>% 
+			  pkg$meta[["reference"]] %>% purrr::map(extract_title) %>% 
 			  unlist() %>% grepl(pattern="S4") %>% which()
 	  
 	  if(length(s4_documentation)>0){


### PR DESCRIPTION
This allows making S4 class documentation automated if @aliases <method_name>,<class_name>-method is given inside each method documentation. 

Additionally the _pkgdown.yml has to contain a reference section with the title "S4" as 
reference:
  - title: S4
    contents: 
    - no_content