### PR TITLE
Fix highlight use

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     desc,
     digest,
     evaluate,
-    highlight,
+    highlight (>= 0.5.0.9000),
     httr,
     MASS,
     magrittr,
@@ -45,7 +45,8 @@ Suggests:
     covr
 Remotes:
     r-lib/pkgload,
-    r-lib/usethis
+    r-lib/usethis, 
+    romainfrancois/highlight
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1
 URL: http://pkgdown.r-lib.org, https://github.com/hadley/pkgdown

--- a/R/highlight.r
+++ b/R/highlight.r
@@ -124,18 +124,7 @@ pkgdown_detective <- function(x, ...) {
   data$class[ is.na(data$class) ] <- ""
   data$style[ is.na(data$style) ] <- ""
 
-  tokens <- data$text
-  styles <- data$class
-  href <- href_tokens(tokens, styles )
-  linked <- !is.na(href)
-  tokens[linked] <- a(tokens[linked], href[linked])
-
-  styled <- !is.na(styles)
-  tokens[styled] <- sprintf("<span class='%s'>%s</span>",
-    styles[styled],
-    tokens[styled]
-  )
-  data$text <- tokens
+  data$href <- href_tokens(data$text, data$class )
 
   data
 }

--- a/R/highlight.r
+++ b/R/highlight.r
@@ -18,33 +18,12 @@ highlight_text <- function(text) {
   register_attached_packages(packages)
 
   out <- highlight::highlight(
-    parse.output = expr,
-    renderer = pkgdown_renderer(),
-    detective = pkgdown_detective,
-    output = NULL
+    x = text,
+    header = "",
+    footer = "",
+    detective = pkgdown_detective
   )
   paste0(out, collapse = "")
-}
-
-pkgdown_renderer <- function() {
-  formatter <- function(tokens, styles, ...) {
-    href <- href_tokens(tokens, styles)
-    linked <- !is.na(href)
-    tokens[linked] <- a(tokens[linked], href[linked])
-
-    styled <- !is.na(styles)
-    tokens[styled] <- sprintf("<span class='%s'>%s</span>",
-      styles[styled],
-      tokens[styled]
-    )
-    tokens
-  }
-
-  highlight::renderer_html(
-    header = function(...) character(),
-    footer = function(...) character(),
-    formatter = formatter
-  )
 }
 
 href_tokens <- function(tokens, styles) {
@@ -136,5 +115,27 @@ pkgdown_detective <- function(x, ...) {
     UMINUS               = "kw"
   )
 
-  unname(token_style[token])
+  token_data <- data.frame(
+    token = names(token_style), class = token_style, style = "",
+    stringsAsFactors = FALSE
+  )
+
+  data <- merge( data, token_data, by = "token", all.x = TRUE, sort = FALSE )
+  data$class[ is.na(data$class) ] <- ""
+  data$style[ is.na(data$style) ] <- ""
+
+  tokens <- data$text
+  styles <- data$class
+  href <- href_tokens(tokens, styles )
+  linked <- !is.na(href)
+  tokens[linked] <- a(tokens[linked], href[linked])
+
+  styled <- !is.na(styles)
+  tokens[styled] <- sprintf("<span class='%s'>%s</span>",
+    styles[styled],
+    tokens[styled]
+  )
+  data$text <- tokens
+
+  data
 }


### PR DESCRIPTION
This uses the simplified highlight interface where you only use the "detective" that takes a data frame and returns a data frame. 

I've refrained from using dplyr functions as `pkgdown` does not depend on it, so there is a bit of untidy code : 

```
  token_data <- data.frame(
    token = names(token_style), class = token_style, style = "",
    stringsAsFactors = FALSE
  )

  data <- merge( data, token_data, by = "token", all.x = TRUE, sort = FALSE )
  data$class[ is.na(data$class) ] <- ""
  data$style[ is.na(data$style) ] <- ""

  data$href <- href_tokens(data$text, data$class )
```

This passes the test suite on my machine: 

```
==> devtools::test()

Loading pkgdown
Loading required package: testthat
Testing pkgdown
✔ | OK F W S | Context
✔ | 49       | as_html [0.5 s]
✔ |  1       | autolink_html [0.1 s]
✔ | 17       | build_home [9.3 s]
✔ |  4       | test-build-news.R [0.3 s]
✔ |  1       | build_site [0.8 s]
✔ |  3       | highlight
✔ | 24       | href [0.8 s]
✔ |  3       | test-html.R
✔ |  9       | Open Graph meta tags [4.8 s]
✔ |  8       | packages
✔ |  4       | remote
✔ |  4       | replay
✔ | 15       | topics [0.1 s]
✔ |  3       | tweak
✔ | 12       | util

══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 17.2 s

OK:       157
Failed:   0
Warnings: 0
Skipped:  0

You rock!
Warning message:
`encoding` is deprecated; all files now assumed to be UTF-8 
```