### PR TITLE
use pluck to avoid error if no ORCID in comment

### DIFF
--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -105,7 +105,7 @@ author_list <- function(x, authors_info, comment = FALSE) {
   roles <- paste0(role_lookup[x$role], collapse = ", ")
   substr(roles, 1, 1) <- toupper(substr(roles, 1, 1))
 
-  orcid <- x$comment[["ORCID"]]
+  orcid <- x$comment %>% purrr::pluck("ORCID")
   x$comment <- remove_name(x$comment, "ORCID")
 
   list(


### PR DESCRIPTION
We need to use pluck to avoid an error if an ORCID is not present in the comment.