### PR TITLE
Wrap figures in <p>

### DIFF
--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -272,18 +272,19 @@ as_html.tag_figure <- function(x, ...) {
   path <- as.character(x[[1]])
 
   if (n == 1) {
-    paste0("<img src='figures/", path, "' alt='' />")
+    out <- paste0("<img src='figures/", path, "' alt='' />")
   } else if (n == 2) {
     opt <- as.character(x[[2]])
     if (substr(opt, 1, 9) == "options: ") {
       extra <- substr(opt, 9, nchar(opt))
-      paste0("<img src='figures/", path, "'",  extra, " />")
+      out <- paste0("<img src='figures/", path, "'",  extra, " />")
     } else {
-      paste0("<img src='figures/", path, "' alt='", opt, "' />")
+      out <- paste0("<img src='figures/", path, "' alt='", opt, "' />")
     }
   } else {
     stop("Invalid \\figure{} markup", call. = FALSE)
   }
+  paste0("<p>", out, "</p>")
 }
 
 # List -----------------------------------------------------------------------

--- a/tests/testthat/test-as_html.R
+++ b/tests/testthat/test-as_html.R
@@ -223,11 +223,11 @@ test_that("items are optional", {
 # figures -----------------------------------------------------------------
 
 test_that("figures are converted to img", {
-  expect_equal(rd2html("\\figure{a}"), "<img src='figures/a' alt='' />")
-  expect_equal(rd2html("\\figure{a}{b}"), "<img src='figures/a' alt='b' />")
+  expect_equal(rd2html("\\figure{a}"), "<p><img src='figures/a' alt='' /></p>")
+  expect_equal(rd2html("\\figure{a}{b}"), "<p><img src='figures/a' alt='b' /></p>")
   expect_equal(
     rd2html("\\figure{a}{options: height=1}"),
-    "<img src='figures/a' height=1 />"
+    "<p><img src='figures/a' height=1 /></p>"
   )
 })
 


### PR DESCRIPTION
Wrap figures in a paragraph to fix a layout problem in the rlang lifecycle page. AFAICT this is consistent with the HTML generated by R for doc topics.