### PR TITLE
improve error message if build_site fails due to empty README.md (#411)

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -24,8 +24,12 @@ markdown <- function(path = NULL, ...) {
 
   xml <- xml2::read_html(tmp, encoding = "UTF-8")
 
-  if (!inherits(xml, "xml_node"))
-    stop("cannot build homepage from '", path, "' without content")
+  if (!inherits(xml, "xml_node")) {
+    stop(
+      "'", path, "' must be a nonempty file or be deleted to build homepage.",
+      call. = FALSE
+    )
+  }
 
   tweak_code(xml)
   tweak_anchors(xml, only_contents = FALSE)

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -23,6 +23,10 @@ markdown <- function(path = NULL, ...) {
   )
 
   xml <- xml2::read_html(tmp, encoding = "UTF-8")
+
+  if (!inherits(xml, "xml_node"))
+    stop("cannot build homepage from '", path, "' without content")
+
   tweak_code(xml)
   tweak_anchors(xml, only_contents = FALSE)
 

--- a/tests/testthat/home-empty-readme-md/DESCRIPTION
+++ b/tests/testthat/home-empty-readme-md/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A test package
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = c("cph", "fnd"))
+    )

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -136,3 +136,14 @@ test_that("references in angle brackets are converted to HTML", {
   )
   expect_identical(linkify(unsupported), escape_html(unsupported))
 })
+
+# empty readme.md ---------------------------------------------------------
+
+test_that("build_home fails with empty readme.md", {
+  pkg <- test_path("home-empty-readme-md")
+  expect_error(
+    build_home(pkg),
+    "cannot build homepage from '.*/README.md' without content"
+  )
+  on.exit(clean_site(pkg))
+})

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -143,7 +143,7 @@ test_that("build_home fails with empty readme.md", {
   pkg <- test_path("home-empty-readme-md")
   expect_error(
     build_home(pkg),
-    "cannot build homepage from '.*/README.md' without content"
+    "'.*README.md' must be a nonempty file or be deleted to build homepage."
   )
   on.exit(clean_site(pkg))
 })


### PR DESCRIPTION
solves #411 by providing an explicit error message if tweak_code fails due to existing but empty README.md 

I added a test case as well which I checked that failed before adding the new error message to code.  