### PR TITLE
Fix "Full license" link.

### DIFF
--- a/R/build-home-license.R
+++ b/R/build-home-license.R
@@ -27,7 +27,7 @@ data_home_sidebar_license <- function(pkg = ".") {
     "<h2>License</h2>\n",
     "<p>",
     if (has_license_md) {
-      "<a href='license.html'>Full license</a><br /><small>"
+      "<a href='LICENSE.html'>Full license</a><br /><small>"
     },
     autolink_license(pkg$desc$get("License")[[1]]),
     if (has_license_md) {


### PR DESCRIPTION
* Change Full license url from license.html ⇨ LICENSE.html.
* Fixes #557.