### PR TITLE
init.R: Fix path_rel() for custom assets

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -38,7 +38,7 @@ data_assets <- function(pkg = ".") {
   template <- pkg$meta[["template"]]
 
   if (!is.null(template$assets)) {
-    path <- path_rel(pkg$src_path, template$assets)
+    path <- path_rel(template$assets, pkg$src_path)
     if (!file_exists(path))
       stop("Can not find asset path ", src_path(path), call. = FALSE)
 


### PR DESCRIPTION
With the current arrangement, I get the following when providing a custom assets path (`pkgdown/assets/`) in `_pkgdown.yml`:

```r
pkgdown::init_site()
── Initialising site ──────────────────────────────────────────────────────────────────────────────────────
Copying  '../../1440p.sh' to '1440p.sh'
Copying  '../../autostart' to 'autostart'
Copying  '../../Boostnote' to 'Boostnote'
Copying  '../../Desktop' to 'Desktop'
Copying  '../../Documents' to 'Documents'
Copying  '../../Downloads' to 'Downloads'
Copying  '../../Dropbox' to 'Dropbox'
```

After switching the arguments in

https://github.com/r-lib/pkgdown/blob/e937c92cffd8afb0c98c67ff1a5450fe6419f09b/R/init.R#L41

to `path_rel(template$assets, pkg$src_path)`

everything works as expected:

```r
pkgdown::init_site()
── Initialising site ──────────────────────────────────────────────────────────────────────────────────────
Copying  'pkgdown/assets/jquery.sticky-kit.min.js' to 'jquery.sticky-kit.min.js'
Copying  'pkgdown/assets/link.svg' to 'link.svg'
Copying  'pkgdown/assets/pkgdown.css' to 'pkgdown.css'
Copying  'pkgdown/assets/pkgdown.js' to 'pkgdown.js'
Copying  'pkgdown/extra.css' to 'extra.css'
Copying  'pkgdown/extra.js' to 'extra.js'
Copying  'man/figures/logo.png' to 'logo.png'
```

Maybe to "to_dir" should be `pkg$src_path/docs/dev/jquery.sticky-kit.min.js` instead of `jquery.sticky-kit.min.js`?