### PR TITLE
Fix warnings from github_source()

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -16,9 +16,11 @@ pkg_github_url <- function(desc) {
 
 github_source <- function(base, paths) {
   # Don't need to touch those that are already a full url
-  full_urls <- grepl("^https?://", paths)
-  paths[!full_urls] <- file.path(base, "blob" , "master", paths[!full_urls])
-  paths
+  ifelse(
+    grepl("^https?://", paths),
+    paths,
+    file.path(base, "blob" , "master", paths)
+  )
 }
 
 github_source_links <- function(base, paths) {

--- a/R/github.R
+++ b/R/github.R
@@ -14,13 +14,11 @@ pkg_github_url <- function(desc) {
   gh_links[[1]]
 }
 
-github_source <- function(base, path) {
-  # Already a full url
-  if (grepl("^https?://", path)) {
-    return(path)
-  }
-
-  file.path(base, "blob" , "master", path)
+github_source <- function(base, paths) {
+  # Don't need to touch those that are already a full url
+  full_urls <- grepl("^https?://", paths)
+  paths[!full_urls] <- file.path(base, "blob" , "master", paths[!full_urls])
+  paths
 }
 
 github_source_links <- function(base, paths) {

--- a/tests/testthat/test-href.R
+++ b/tests/testthat/test-href.R
@@ -101,3 +101,16 @@ test_that("or local sites, if registered", {
   scoped_package_context("pkgdown", local_packages = c("digest" = "digest"))
   expect_equal(href_expr_(vignette("sha1", "digest")), "digest/articles/sha1.html")
 })
+
+test_that("github_source linking", {
+  base <- "https://github.com/r-lib/pkgdown"
+  expect_silent(
+    expect_equal(
+      github_source(base, c("http://example.com", "R/example.R")),
+      c(
+        "http://example.com", # Already is a URL, so not modified
+        "https://github.com/r-lib/pkgdown/blob/master/R/example.R"
+      )
+    )
+  )
+})

--- a/tests/testthat/test-href.R
+++ b/tests/testthat/test-href.R
@@ -102,15 +102,13 @@ test_that("or local sites, if registered", {
   expect_equal(href_expr_(vignette("sha1", "digest")), "digest/articles/sha1.html")
 })
 
-test_that("github_source linking", {
+test_that("github_source returns (possibly many) URLs", {
   base <- "https://github.com/r-lib/pkgdown"
-  expect_silent(
-    expect_equal(
-      github_source(base, c("http://example.com", "R/example.R")),
-      c(
-        "http://example.com", # Already is a URL, so not modified
-        "https://github.com/r-lib/pkgdown/blob/master/R/example.R"
-      )
+  expect_equal(
+    github_source(base, c("http://example.com", "R/example.R")),
+    c(
+      "http://example.com", # Already is a URL, so not modified
+      "https://github.com/r-lib/pkgdown/blob/master/R/example.R"
     )
   )
 })


### PR DESCRIPTION
Rebuilding one of my sites with the latest `pkgdown` code, I noticed some warnings like this:

```
Reading 'man/teams.Rd'
Warning in if (grepl("^https?://", path)) { :
  the condition has length > 1 and only the first element will be used
```

I tracked it down to `github_source()`, which based on its logic and function signature, expected only a single `path` passed to it, while the function that calls it passes in `paths`. The condition that triggered the warning was when an .Rd file was created by roxygen from multiple .R files. 

This patch vectorizes `github_source` so that the logic is correct and no warnings are emitted. 