### PR TITLE
Always return a list

### DIFF
--- a/R/package.r
+++ b/R/package.r
@@ -90,8 +90,7 @@ read_meta <- function(path) {
   if (is.null(path)) {
     yaml <- list()
   } else {
-    yaml <- yaml::yaml.load_file(path)
-    if (is.null(yaml)) yaml <- list()
+    yaml <- yaml::yaml.load_file(path) %||% list()
   }
 
   yaml

--- a/R/package.r
+++ b/R/package.r
@@ -91,6 +91,7 @@ read_meta <- function(path) {
     yaml <- list()
   } else {
     yaml <- yaml::yaml.load_file(path)
+    if (is.null(yaml)) yaml <- list()
   }
 
   yaml


### PR DESCRIPTION
For example, when you use `usethis::use_pkgdown()`, you get an empty YAML file.

In this case, `meta <- read_meta(pkg)` (https://github.com/r-lib/pkgdown/blob/master/R/package.r#L20) returns `NULL` but `meta <- utils::modifyList(meta, override)` is expecting a list.