### PR TITLE
Let search results scroll

### DIFF
--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -217,3 +217,10 @@ a.sourceLine:hover {
 .hasCopyButton:hover button.btn-copy-ex {
   visibility: visible;
 }
+
+/* Docsearch -------------------------------------------------------------- */
+
+div.ds-dataset-1 {
+    overflow: auto;
+    max-height: 80vh;
+}


### PR DESCRIPTION
The new docsearch is really great! I added it to http://crunch.io/r/crunch/, and then I noticed that if I search for something that has a lot of hits, or if the results are wordy, the dropdown that appears can spill off the page and it doesn't scroll:

<img width="616" alt="screen shot 2018-04-05 at 1 37 31 pm" src="https://user-images.githubusercontent.com/2975928/38390562-8bbcf726-38d6-11e8-979b-e991cc1b38c4.png">

Adding this CSS lets the dropdown scroll if necessary:

<img width="592" alt="screen shot 2018-04-05 at 1 38 04 pm" src="https://user-images.githubusercontent.com/2975928/38390609-a9846f8c-38d6-11e8-9b8d-2df63158db3f.png">
