### PR TITLE
WIP: Docsearch results styling

### DIFF
--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -9,9 +9,9 @@ build_docsearch_json <- function(pkg = ".") {
     "sitemap_urls" = list(paste0(pkg$meta$url, "/", "sitemap.xml")),
     "selectors" = list(
       "lvl0" = ".contents h1",
-      "lvl1" = ".contents .name",
-      "lvl2" = ".contents h2",
-      "lvl3" = ".contents h3, .contents th",
+      "lvl1" = ".contents h2",
+      "lvl2" = ".contents h3, .contents th",
+      "lvl3" = ".contents .name",
       "lvl4" = ".contents h4",
       "text" = ".contents p, .contents li, .usage, .template-article .contents .pre"
     ),

--- a/docs/docsearch.json
+++ b/docs/docsearch.json
@@ -9,9 +9,9 @@
   ],
   "selectors": {
     "lvl0": ".contents h1",
-    "lvl1": ".contents .name",
-    "lvl2": ".contents h2",
-    "lvl3": ".contents h3, .contents th",
+    "lvl1": ".contents h2",
+    "lvl2": ".contents h3, .contents th",
+    "lvl3": ".contents .name",
     "lvl4": ".contents h4",
     "text": ".contents p, .contents li, .usage, .template-article .contents .pre"
   },

--- a/docs/pkgdown.css
+++ b/docs/pkgdown.css
@@ -217,3 +217,144 @@ a.sourceLine:hover {
 .hasCopyButton:hover button.btn-copy-ex {
   visibility: visible;
 }
+
+/* Docsearch -------------------------------------------------------------- */
+
+div.ds-dataset-1 {
+  overflow: auto;
+  max-height: 80vh;
+}
+
+.algolia-autocomplete {
+  display: block!important;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.algolia-autocomplete .ds-dropdown-menu {
+  width: 100%;
+  min-width: 0!important;
+  max-width: none!important;
+  padding: .75rem 0!important;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 3px solid rgba(0, 0, 0, .1);
+  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .175)
+}
+
+@media (min-width:768px) {
+  .algolia-autocomplete .ds-dropdown-menu {
+      width: 175%
+  }
+}
+
+.algolia-autocomplete .ds-dropdown-menu::before {
+  display: none!important
+}
+
+.algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-] {
+  padding: 0!important;
+  overflow: visible!important;
+  background-color: rgb(255,255,255)!important;
+  border: 0!important
+}
+
+.algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
+  margin-top: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion {
+  padding: 0!important;
+  overflow: visible!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header {
+  padding: .125rem 1rem!important;
+  margin-top: 0!important;
+  font-size: 1.1em!important;
+  font-weight: 500!important;
+  color: #00008B!important;
+  border-bottom: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--wrapper {
+    float: none!important;
+    padding-top: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
+  float: none!important;
+  width: auto!important;
+  padding: 0!important;
+  text-align: left!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content {
+  float: none!important;
+  width: auto!important;
+  padding: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content::before {
+  display: none!important
+}
+
+.algolia-autocomplete .ds-suggestion:not(:first-child) .algolia-docsearch-suggestion--category-header {
+  padding-top: .75rem!important;
+  margin-top: .75rem!important;
+  border-top: 1px solid rgba(0, 0, 0, .1)
+}
+
+.algolia-autocomplete .ds-suggestion .algolia-docsearch-suggestion--subcategory-column {
+  display: none!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--title {
+  display: block;
+  padding: .25rem 1rem!important;
+  margin-bottom: 0!important;
+  font-size: 1em;
+  font-weight: 400!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text {
+  padding: 0 1rem .5rem!important;
+  margin-top: -.25rem;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.25!important
+}
+
+.algolia-autocomplete .algolia-docsearch-footer {
+  float: none!important;
+  width: auto!important;
+  height: auto!important;
+  padding: .75rem 1rem 0;
+  font-size: .75rem!important;
+  line-height: 1!important;
+  color: #767676!important;
+  background-color: rgb(255, 255, 255)!important;
+  border-top: 1px solid rgba(0, 0, 0, .1)
+}
+
+.algolia-autocomplete .algolia-docsearch-footer--logo {
+  display: inline!important;
+  overflow: visible!important;
+  color: inherit!important;
+  text-indent: 0!important;
+  background: 0 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #5f2dab;
+  background-color: rgba(220, 220, 220, .12)
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+  box-shadow: inset 0 -2px 0 0 rgba(105, 105, 105, .5)!important
+}
+
+.algolia-autocomplete .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content {
+  background-color: rgba(105, 105, 105, .15)!important
+}

--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -221,6 +221,140 @@ a.sourceLine:hover {
 /* Docsearch -------------------------------------------------------------- */
 
 div.ds-dataset-1 {
-    overflow: auto;
-    max-height: 80vh;
+  overflow: auto;
+  max-height: 80vh;
+}
+
+.algolia-autocomplete {
+  display: block!important;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.algolia-autocomplete .ds-dropdown-menu {
+  width: 100%;
+  min-width: 0!important;
+  max-width: none!important;
+  padding: .75rem 0!important;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 3px solid rgba(0, 0, 0, .1);
+  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .175)
+}
+
+@media (min-width:768px) {
+  .algolia-autocomplete .ds-dropdown-menu {
+      width: 175%
+  }
+}
+
+.algolia-autocomplete .ds-dropdown-menu::before {
+  display: none!important
+}
+
+.algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-] {
+  padding: 0!important;
+  overflow: visible!important;
+  background-color: rgb(255,255,255)!important;
+  border: 0!important
+}
+
+.algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
+  margin-top: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion {
+  padding: 0!important;
+  overflow: visible!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header {
+  padding: .125rem 1rem!important;
+  margin-top: 0!important;
+  font-size: 1.1em!important;
+  font-weight: 500!important;
+  color: #00008B!important;
+  border-bottom: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--wrapper {
+    float: none!important;
+    padding-top: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
+  float: none!important;
+  width: auto!important;
+  padding: 0!important;
+  text-align: left!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content {
+  float: none!important;
+  width: auto!important;
+  padding: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content::before {
+  display: none!important
+}
+
+.algolia-autocomplete .ds-suggestion:not(:first-child) .algolia-docsearch-suggestion--category-header {
+  padding-top: .75rem!important;
+  margin-top: .75rem!important;
+  border-top: 1px solid rgba(0, 0, 0, .1)
+}
+
+.algolia-autocomplete .ds-suggestion .algolia-docsearch-suggestion--subcategory-column {
+  display: none!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--title {
+  display: block;
+  padding: .25rem 1rem!important;
+  margin-bottom: 0!important;
+  font-size: 1em;
+  font-weight: 400!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text {
+  padding: 0 1rem .5rem!important;
+  margin-top: -.25rem;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.25!important
+}
+
+.algolia-autocomplete .algolia-docsearch-footer {
+  float: none!important;
+  width: auto!important;
+  height: auto!important;
+  padding: .75rem 1rem 0;
+  font-size: .75rem!important;
+  line-height: 1!important;
+  color: #767676!important;
+  background-color: rgb(255, 255, 255)!important;
+  border-top: 1px solid rgba(0, 0, 0, .1)
+}
+
+.algolia-autocomplete .algolia-docsearch-footer--logo {
+  display: inline!important;
+  overflow: visible!important;
+  color: inherit!important;
+  text-indent: 0!important;
+  background: 0 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #5f2dab;
+  background-color: rgba(220, 220, 220, .12)
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+  box-shadow: inset 0 -2px 0 0 rgba(105, 105, 105, .5)!important
+}
+
+.algolia-autocomplete .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content {
+  background-color: rgba(105, 105, 105, .15)!important
 }


### PR DESCRIPTION
More work from #626 

Demoting `.name` puts it in the place I would expect.

But I think it would be better if instead of the filename (init_site.Rd), it appeared as a function (`init_site()`). But it looks like any `<code>` or `<pre>` tags are stripped out in the index, so you just get the raw text. Styling the right CSS selector for that specific result is tricky.

<img width="373" alt="screenshot 2018-04-06 05 18 18" src="https://user-images.githubusercontent.com/355367/38418542-fb6cb25e-3959-11e8-8ab3-20fb99c7f198.png">
