### PR TITLE
add pagetitle to suppress build warning

### DIFF
--- a/vignettes/test/jss.Rmd
+++ b/vignettes/test/jss.Rmd
@@ -13,6 +13,7 @@ title:
   plain:     "Test: JSS article"
   formatted: "Test: JSS article"
   short:     "Test: JSS article"
+pagetitle:   "Test: JSS article"
 abstract: >
   The abstract of the article.
 keywords:


### PR DESCRIPTION
eliminates this warning to during pkgdown build:

```
[WARNING] This document format requires a nonempty <title> element.
  Please specify either 'title' or 'pagetitle' in the metadata.
  Falling back to 'file14a8921c4b6df.utf8'
```