### PR TITLE
Custom GitHub URL for NEWS

### DIFF
--- a/R/build-news.R
+++ b/R/build-news.R
@@ -56,6 +56,13 @@
 #' - one_page: false
 #' ```
 #'
+#' To use the custom GitHub URL, set `github_url` field.
+#'
+#' ```
+#' news:
+#'   github_url: https://example.github.com/
+#' ```
+#'
 #' @inheritParams build_articles
 #' @export
 build_news <- function(pkg = ".",

--- a/R/github.R
+++ b/R/github.R
@@ -1,4 +1,6 @@
-pkg_github_url <- function(desc) {
+github_url_regex <- "^https?://github\\.com/"
+
+pkg_github_url <- function(desc, meta = list()) {
   if (!desc$has_fields("URL"))
     return()
 
@@ -6,7 +8,13 @@ pkg_github_url <- function(desc) {
     strsplit(",") %>%
     `[[`(1) %>%
     str_trim()
-  gh_links <- grep("^https?://github.com/", gh_links, value = TRUE)
+
+  github_url <- purrr::pluck(meta, "news", "github_url")
+  if (!is.null(github_url)) {
+    gh_links <- grep(github_url, gh_links, value = TRUE, fixed = TRUE)
+  } else {
+    gh_links <- grep(github_url_regex, gh_links, value = TRUE)
+  }
 
   if (length(gh_links) == 0)
     return()
@@ -45,10 +53,13 @@ github_source_links <- function(base, paths) {
 }
 
 add_github_links <- function(x, pkg) {
-  user_link <- paste0("<a href='http://github.com/\\1'>@\\1</a>")
-  x <- gsub("@(\\w+)", user_link, x)
-
   github_url <- pkg$github_url
+
+  if (is.null(github_url) || grepl(github_url_regex, github_url)) {
+    user_link <- paste0("<a href='http://github.com/\\1'>@\\1</a>")
+    x <- gsub("@(\\w+)", user_link, x)
+  }
+
   if (is.null(github_url)) {
     return(x)
   }

--- a/R/package.r
+++ b/R/package.r
@@ -42,7 +42,7 @@ as_pkgdown <- function(pkg = ".", override = list()) {
 
       src_path = path_abs(pkg),
       dst_path = path_abs(dst_path),
-      github_url = pkg_github_url(desc),
+      github_url = pkg_github_url(desc, meta),
 
       desc = desc,
       meta = meta,

--- a/man/build_news.Rd
+++ b/man/build_news.Rd
@@ -61,5 +61,9 @@ Control whether news is present on one page or multiple pages with the
 \code{one_page} field. The default is \code{true}.\preformatted{news:
 - one_page: false
 }
+
+To use the custom GitHub URL, set \code{github_url} field.\preformatted{news:
+  github_url: https://example.github.com/
+}
 }
 

--- a/tests/testthat/news-github-links-custom/DESCRIPTION
+++ b/tests/testthat/news-github-links-custom/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A test package
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = c("cph", "fnd"))
+    )
+URL: https://github.example.com/hadley/pkgdown

--- a/tests/testthat/news-github-links-custom/NEWS.md
+++ b/tests/testthat/news-github-links-custom/NEWS.md
@@ -1,0 +1,5 @@
+# pkgdown 0.1.0
+
+## Major changes
+
+- Bug fixes (@hadley, #100)

--- a/tests/testthat/news-github-links-custom/_pkgdown.yml
+++ b/tests/testthat/news-github-links-custom/_pkgdown.yml
@@ -1,0 +1,2 @@
+news:
+  github_url: https://github.example.com/

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -12,6 +12,18 @@ test_that("github links are added to news items", {
   expect_true(grepl(issue_link, news_tbl$html))
 })
 
+test_that("custom github links are added to news items", {
+  path <- test_path("news-github-links-custom")
+  pkg <- as_pkgdown(path)
+  news_tbl <- data_news(pkg)
+
+  user_link <- "<a href='https?://.*'>@hadley</a>"
+  issue_link <- "<a href='https://github.example.com/hadley/pkgdown/issues/100'>#100</a>"
+
+  expect_true(!grepl(user_link, news_tbl$html))
+  expect_true(grepl(issue_link, news_tbl$html))
+})
+
 test_that("build_news() uses content in NEWS.md", {
   pkg <- test_path("news")
 


### PR DESCRIPTION
Currently, `add_github_links()` only supports github.com. It would be would if GitHub Enterprise gets supported, too. This PR adds the feature to customize the URL by specifying `github_url` in `_pkgdown.yml`.

```yaml
news:
  github_url: https://github.example.com/
```

Note that, since guessing the URL of a user's profile is hard, if the custom `github_url` is specified, `@user` is left as is.