### PR TITLE
Fix re-exporting non-function object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown 1.0.0.9000
 
+* Support re-exported non-function objects (#666, #669).
+
 * Improved display for icons - icons now must be 30px and are embedded in 
   separate column of reference index table (instead of being inside 
   a comment!) (#607).

--- a/R/link-href.R
+++ b/R/link-href.R
@@ -97,7 +97,7 @@ href_topic_local <- function(topic) {
       return(NA_character_)
     } else {
       obj <- env_get(ns, topic, inherit = TRUE)
-      package <- ns_env_name(get_env(obj))
+      package <- find_reexport_source(obj, ns, topic)
       return(href_topic_remote(topic, package))
     }
   }

--- a/R/utils.r
+++ b/R/utils.r
@@ -39,6 +39,30 @@ is_syntactic <- function(x) x == make.names(x)
 
 str_trim <- function(x) gsub("^\\s+|\\s+$", "", x)
 
+## For functions, we can just take their environment.
+
+find_reexport_source <- function(obj, ns, topic) {
+  if (is.function(obj)) {
+    ns_env_name(get_env(obj))
+  } else {
+    find_reexport_source_from_imports(ns, topic)
+  }
+}
+
+## For other objects, we need to check the import env of the package,
+## to see where 'topic' is coming from. The import env has redundant
+## information. It seems that we just need to find a named list
+## entry that contains `topic`. We take the last match, in case imports
+## have name clashes.
+
+find_reexport_source_from_imports  <- function(ns, topic)  {
+  imp <- getNamespaceImports(ns)
+  imp <- imp[names(imp) != ""]
+  wpkgs <- purrr::map_lgl(imp, `%in%`, x = topic)
+  if (!any(wpkgs)) stop("Cannot find reexport source for `", topic, "`")
+  pkgs <- names(wpkgs)[wpkgs]
+  pkgs[[length(pkgs)]]
+}
 
 # devtools metadata -------------------------------------------------------
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,21 @@
+context("utils")
+
+test_that("find_reexport_source", {
+  ns <- asNamespace("pkgdown")
+  expect_equal(
+    find_reexport_source(rlang::ns_env_name, ns, "ns_env_name"),
+    "rlang"
+  )
+})
+
+test_that("find_reexport_source_from_imports", {
+  ns <- asNamespace("pkgdown")
+  expect_equal(
+    find_reexport_source_from_imports(ns, "ns_env_name"),
+    "rlang"
+  )
+  expect_equal(
+    find_reexport_source_from_imports(ns, "R6Class"),
+    "R6"
+  )
+})


### PR DESCRIPTION
We cannot take the package name from the
environment of the function in this case,
but need to look at the import env of the package.

Fixes #666.
