### PR TITLE
Fix citation(auto=meta) with non-native encoding

### DIFF
--- a/R/build-home-citation.R
+++ b/R/build-home-citation.R
@@ -6,10 +6,13 @@ has_citation <- function(path = ".") {
 create_meta <- function(path) {
   path <- path(path, "DESCRIPTION")
 
-  dcf <- read.dcf(path)
-  meta <- as.list(dcf[1, ])
+  dcf <- read.dcf(path)[1, ]
+  if ("Encoding" %in% names(dcf)) {
+    Encoding(dcf) <- dcf[["Encoding"]]
+    dcf <- enc2utf8(dcf)
+  }
 
-  meta
+  as.list(dcf)
 }
 
 read_citation <- function(path = ".") {

--- a/tests/testthat/assets/site-citation/DESCRIPTION
+++ b/tests/testthat/assets/site-citation/DESCRIPTION
@@ -3,6 +3,6 @@ Type: Package
 Title: Test package 
 Version: 0.2.5
 Date: 2018-02-02
-Authors@R: person("Florian", "PrivÃ©")
+Authors@R: person("Florian", "Privé", role = c("aut", "cre"))
 Description: Test non-ASCII characters in Authors@R 
-Encoding: UTF-8
+Encoding: latin1

--- a/tests/testthat/assets/site-citation/inst/CITATION
+++ b/tests/testthat/assets/site-citation/inst/CITATION
@@ -1,6 +1,6 @@
 citEntry(entry = "Article",
          title="test non-ASCII character in authors *and* citation(auto = meta)",
-         author="Florian PrivÃ©",
+         author="Florian Privé",
          journal="test",
          year="2017",
          publisher="test",


### PR DESCRIPTION
The encoding of the citation test package is changed to latin1.
On Linux, this lets `test-build-citation-authors.R` fail from `read_citation()` with
```
Error in parse(text = x) : 
  invalid multibyte character in parser at line 1
```
To fix this, the modified `create_meta()` function re-encodes the character strings obtained from `read.dcf()` to UTF-8.