### PR TITLE
fix multi-page news rendering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown 1.0.0.9000
 
+* Multi-page Changelogs (generated from `NEWS.md` by setting `news: one_page:
+  false` in _pkgdown.yml) are now rendered correctly.
+
 * CITATION files with non-UTF-8 encodings (latin1) no longer generate an error.
   For non-UTF-8 locales, ensure you have e.g. `Encoding: latin1` in your `DESCRIPTION`
   (#689).

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -63,7 +63,7 @@ build_news <- function(pkg = ".",
                        preview = NA) {
   pkg <- section_init(pkg, depth = 1L, override = override)
 
-  one_page <- purrr::pluck(pkg, "meta", "news", "one_page", .default = TRUE)
+  one_page <- purrr::pluck(pkg, "meta", "news", 1, "one_page", .default = TRUE)
 
   if (!has_news(pkg$src_path))
     return()
@@ -122,7 +122,7 @@ build_news_multi <- function(pkg) {
   render_page(
     pkg,
     "news-index",
-    list(versions = news %>% purrr::transpose(), pagetitle = "News"),
+    list(versions = news_paged %>% purrr::transpose(), pagetitle = "News"),
     path("news", "index.html")
   )
 }

--- a/inst/templates/content-news-index.html
+++ b/inst/templates/content-news-index.html
@@ -3,7 +3,11 @@
     <div class="page-header">
       <h1>Release notes</h1>
     </div>
-    {{{index}}}
+    <ul>
+    {{#versions}}
+    <li><a href="{{{file_out}}}">Version {{{version}}}</a></li>
+    {{/versions}}
+    </ul>
   </div>
 </div>
 

--- a/tests/testthat/assets/news-multi-page/DESCRIPTION
+++ b/tests/testthat/assets/news-multi-page/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A test package
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = c("cph", "fnd"))
+    )

--- a/tests/testthat/assets/news-multi-page/NEWS.md
+++ b/tests/testthat/assets/news-multi-page/NEWS.md
@@ -1,0 +1,19 @@
+# testpackage 2.0
+
+* bullet (#222 @someone)
+
+# testpackage 1.1
+
+* bullet (#222 @someone)
+
+# testpackage 1.0.1
+
+* bullet (#222 @someone)
+
+# testpackage 1.0.0
+
+## sub-heading
+
+* first thing (#111 @githubuser)
+
+* second thing

--- a/tests/testthat/assets/news-multi-page/_pkgdown.yml
+++ b/tests/testthat/assets/news-multi-page/_pkgdown.yml
@@ -1,0 +1,3 @@
+news:
+- one_page: false
+

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -45,3 +45,17 @@ test_that("correct timeline for first ggplot2 releases", {
 
   expect_equal(timeline, expected)
 })
+
+test_that("multi-page news are rendered", {
+  path <- test_path("assets/news-multi-page")
+  pkg <- as_pkgdown(path)
+  expect_output(build_news(pkg))
+
+  # test that index links are correct
+  lines <- read_lines(path(path, "docs", "news", "index.html"))
+  expect_true(any(grepl("<a href=\"news-2.0.html\">Version 2.0</a>", lines)))
+
+  # test single page structure
+  lines <- read_lines(path(path, "docs", "news", "news-1.0.html"))
+  expect_true(any(grepl("<h1>Changelog <small>1.0</small></h1>", lines)))
+})


### PR DESCRIPTION
Multi-page news rendering was broken; setting `news: one_page: false` was having no effect. 

Not sure what you want the index to look like, this just makes it a simple list with links:

<h1>Release notes</h1>
<ul>
<li> Version 2.0
<li> Version 1.0
</ul>