### PR TITLE
Improve active nav algorithm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown 1.0.0.9000
 
+* Highlighting of active nav bar now uses a superior approach (suggested by 
+  @jcheng5). This should mean that the active page is now correctly highlighted
+  in all scenarios (#660).
+
 * Multi-page Changelogs (generated from `NEWS.md` by setting `news: one_page:
   false` in _pkgdown.yml) are now rendered correctly.
 

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -19,20 +19,27 @@
     $('[data-toggle="tooltip"]').tooltip();
 
     var cur_path = paths(location.pathname);
-    $("#navbar ul li a").each(function(index, value) {
-      if (value.text == "Home")
-        return;
-      if (value.getAttribute("href") === "#")
-        return;
+    var links = $("#navbar ul li a");
+    var max_length = 0;
+    var pos = -1;
+    for (var i = 0; i < links.length; i++) {
+      if (links[i].getAttribute("href") === "#")
+        continue;
+      var path = paths(links[i].pathname);
 
-      var path = paths(value.pathname);
-      if (is_prefix(cur_path, path)) {
-        // Add class to parent <li>, and enclosing <li> if in dropdown
-        var menu_anchor = $(value);
-        menu_anchor.parent().addClass("active");
-        menu_anchor.closest("li.dropdown").addClass("active");
+      var length = prefix_length(cur_path, path);
+      if (length > max_length) {
+        max_length = length;
+        pos = i;
       }
-    });
+    }
+
+    // Add class to parent <li>, and enclosing <li> if in dropdown
+    if (pos >= 0) {
+      var menu_anchor = $(links[pos]);
+      menu_anchor.parent().addClass("active");
+      menu_anchor.closest("li.dropdown").addClass("active");
+    }
   });
 
   function paths(pathname) {
@@ -45,21 +52,21 @@
     return(pieces);
   }
 
-  function is_prefix(needle, haystack) {
-    if (needle.length > haystack.lengh)
-      return(false);
+  function prefix_length(needle, haystack) {
+    if (needle.length > haystack.length)
+      return(0);
 
     // Special case for length-0 haystack, since for loop won't run
     if (haystack.length === 0) {
-      return(needle.length === 0);
+      return(needle.length === 0 ? 1 : 0);
     }
 
     for (var i = 0; i < haystack.length; i++) {
       if (needle[i] != haystack[i])
-        return(false);
+        return(i);
     }
 
-    return(true);
+    return(haystack.length);
   }
 
   /* Clipboard --------------------------*/

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -20,7 +20,7 @@
 
     var cur_path = paths(location.pathname);
     var links = $("#navbar ul li a");
-    var max_length = 0;
+    var max_length = -1;
     var pos = -1;
     for (var i = 0; i < links.length; i++) {
       if (links[i].getAttribute("href") === "#")

--- a/inst/assets/pkgdown.js
+++ b/inst/assets/pkgdown.js
@@ -19,20 +19,27 @@
     $('[data-toggle="tooltip"]').tooltip();
 
     var cur_path = paths(location.pathname);
-    $("#navbar ul li a").each(function(index, value) {
-      if (value.text == "Home")
-        return;
-      if (value.getAttribute("href") === "#")
-        return;
+    var links = $("#navbar ul li a");
+    var max_length = 0;
+    var pos = -1;
+    for (var i = 0; i < links.length; i++) {
+      if (links[i].getAttribute("href") === "#")
+        continue;
+      var path = paths(links[i].pathname);
 
-      var path = paths(value.pathname);
-      if (is_prefix(cur_path, path)) {
-        // Add class to parent <li>, and enclosing <li> if in dropdown
-        var menu_anchor = $(value);
-        menu_anchor.parent().addClass("active");
-        menu_anchor.closest("li.dropdown").addClass("active");
+      var length = prefix_length(cur_path, path);
+      if (length > max_length) {
+        max_length = length;
+        pos = i;
       }
-    });
+    }
+
+    // Add class to parent <li>, and enclosing <li> if in dropdown
+    if (pos >= 0) {
+      var menu_anchor = $(links[pos]);
+      menu_anchor.parent().addClass("active");
+      menu_anchor.closest("li.dropdown").addClass("active");
+    }
   });
 
   function paths(pathname) {
@@ -45,21 +52,21 @@
     return(pieces);
   }
 
-  function is_prefix(needle, haystack) {
-    if (needle.length > haystack.lengh)
-      return(false);
+  function prefix_length(needle, haystack) {
+    if (needle.length > haystack.length)
+      return(0);
 
     // Special case for length-0 haystack, since for loop won't run
     if (haystack.length === 0) {
-      return(needle.length === 0);
+      return(needle.length === 0 ? 1 : 0);
     }
 
     for (var i = 0; i < haystack.length; i++) {
       if (needle[i] != haystack[i])
-        return(false);
+        return(i);
     }
 
-    return(true);
+    return(haystack.length);
   }
 
   /* Clipboard --------------------------*/

--- a/inst/assets/pkgdown.js
+++ b/inst/assets/pkgdown.js
@@ -20,7 +20,7 @@
 
     var cur_path = paths(location.pathname);
     var links = $("#navbar ul li a");
-    var max_length = 0;
+    var max_length = -1;
     var pos = -1;
     for (var i = 0; i < links.length; i++) {
       if (links[i].getAttribute("href") === "#")


### PR DESCRIPTION
Mark a single tab as active, by looking for the longest match to the path components. If there are multiple matches with equal length, the left-most will be highlighted.

Fixes #660