### PR TITLE
Build-ignore pkgdown infra during init

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Imports:
     rstudioapi,
     tibble,
     tools,
+    usethis,
     whisker,
     xml2 (>= 1.1.1),
     yaml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("RStudio", role = c("cph", "fnd"))
     )
 Description: Generate an attractive and useful website from a source package.
-    'pkgdown' convert your documentation, vignettes, 'README' and more to 
+    'pkgdown' converts your documentation, vignettes, 'README', and more to 
     'HTML' making it easy to share information about your package online.
 License: MIT + file LICENSE
 URL: http://pkgdown.r-lib.org, https://github.com/r-lib/pkgdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown 1.1.0.9000
 
+* `init_site()`: now calls `usethis::use_pkgdown()` to build-ignore `_pkgdown.yml`
+  and `docs/`, preventing a NOTE during R CMD CHECK (#710).
+
 # pkgdown 1.1.0
 
 ## New features

--- a/R/init.R
+++ b/R/init.R
@@ -11,6 +11,8 @@
 #' an unexpected file during `R CMD CHECK` is an indication you have not correctly
 #' ignored these files.
 #'
+#' @seealso [http://usethis.r-lib.org/reference/use_pkgdown.html]
+#'
 #' @section Custom CSS/JS:
 #' If you want to do minor customisation of your pkgdown site, the easiest
 #' way is to add `pkgdown/extra.css` and `pkgdown/extra.js`. These

--- a/R/init.R
+++ b/R/init.R
@@ -4,6 +4,13 @@
 #' logo, creates a machine readable description of the site, and sets up
 #' assets and extra files.
 #'
+#' @section Build-ignored files:
+#' pkgdown uses `usethis::use_pkgdown()` to build-ignore `docs/` and
+#' `_pkgdown.yml`. If you use an alternative location for your config file,
+#' update `_pkgdown.yml` in `.Rbuildignore` with its location. A `NOTE` about
+#' an unexpected file during `R CMD CHECK` is an indication you have not correctly
+#' ignored these files.
+#'
 #' @section Custom CSS/JS:
 #' If you want to do minor customisation of your pkgdown site, the easiest
 #' way is to add `pkgdown/extra.css` and `pkgdown/extra.js`. These
@@ -28,6 +35,8 @@ init_site <- function(pkg = ".") {
   build_sitemap(pkg)
   build_docsearch_json(pkg)
   build_logo(pkg)
+
+  usethis::use_pkgdown()
 
   invisible()
 }

--- a/R/init.R
+++ b/R/init.R
@@ -11,8 +11,6 @@
 #' an unexpected file during `R CMD CHECK` is an indication you have not correctly
 #' ignored these files.
 #'
-#' @seealso [http://usethis.r-lib.org/reference/use_pkgdown.html]
-#'
 #' @section Custom CSS/JS:
 #' If you want to do minor customisation of your pkgdown site, the easiest
 #' way is to add `pkgdown/extra.css` and `pkgdown/extra.js`. These

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -38,3 +38,6 @@ If you include you package logo in the standard location of
 you.
 }
 
+\seealso{
+\link{http://usethis.r-lib.org/reference/use_pkgdown.html}
+}

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -38,6 +38,3 @@ If you include you package logo in the standard location of
 you.
 }
 
-\seealso{
-\link{http://usethis.r-lib.org/reference/use_pkgdown.html}
-}

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -14,6 +14,15 @@ This creates the output directory, creates \code{favicon.ico} from package
 logo, creates a machine readable description of the site, and sets up
 assets and extra files.
 }
+\section{Build-ignored files}{
+
+pkgdown uses \code{usethis::use_pkgdown()} to build-ignore \code{docs/} and
+\code{_pkgdown.yml}. If you use an alternative location for your config file,
+update \code{_pkgdown.yml} in \code{.Rbuildignore} with its location. A \code{NOTE} about
+an unexpected file during \code{R CMD CHECK} is an indication you have not correctly
+ignored these files.
+}
+
 \section{Custom CSS/JS}{
 
 If you want to do minor customisation of your pkgdown site, the easiest

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -166,6 +166,7 @@ test_that("build_home fails with empty readme.md", {
 # .github files -----------------------------------------------------------
 
 test_that(".github files are copied and linked", {
+  skip_if_no_pandoc()
   # .github in this test is build-ignored to prevent a NOTE about an unexpected
   # hidden directory. Skip on CMD CHECK if the .github directory is not present.
   pkg <- test_path("assets/site-dot-github")


### PR DESCRIPTION
pkgdown does not currently build-ignore the files it creates, causing a NOTE during R CMD CHECK.

`init_site()` now calls `usethis::use_pkgdown()` to add `docs/` and `_pkgdown.yml` to `.Rbuildignore`.

Need to add news bullet once 1.1.0 is released.

Part of #709