### PR TITLE
fix urls in build_site docs

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -26,7 +26,7 @@
 #'
 #' `url` optionally specifies the url where the site will be published.
 #' If you supply this, other pkgdown sites will link to your site when needed,
-#' rather than using generic links to \url{rdocumentation.org}.
+#' rather than using generic links to \url{https://rdocumentation.org}.
 #'
 #' `title` overrides the default site title, which is the package name.
 #' It's used in the page title and default navbar.
@@ -151,7 +151,7 @@
 #'
 #' Components can contain sub-`menu`s with headings (indicated by missing
 #' `href`) and separators (indiciated by a bunch of `-`). You can use `icon`s
-#' from fontawesome: see a full list <http://fontawesome.io/icons/>.
+#' from fontawesome: see a full list <https://fontawesome.io/icons/>.
 #'
 #' This yaml would override the default "articles" component, eliminate
 #' the "home" component, and add a new "twitter" component. Unless you

--- a/docs/reference/build_site.html
+++ b/docs/reference/build_site.html
@@ -249,7 +249,7 @@ in the current process affects the build process.</p></td>
 paths will be taken relative to the package root.</p>
 <p><code>url</code> optionally specifies the url where the site will be published.
 If you supply this, other pkgdown sites will link to your site when needed,
-rather than using generic links to <a href='rdocumentation.org'>rdocumentation.org</a>.</p>
+rather than using generic links to <a href='https://rdocumentation.org'>https://rdocumentation.org</a>.</p>
 <p><code>title</code> overrides the default site title, which is the package name.
 It's used in the page title and default navbar.</p>
 <p>You can also provided information to override the default display of
@@ -347,7 +347,7 @@ The following YAML snippet illustrates some of the most important features.</p><
 </pre>
     <p>Components can contain sub-<code>menu</code>s with headings (indicated by missing
 <code>href</code>) and separators (indiciated by a bunch of <code>-</code>). You can use <code>icon</code>s
-from fontawesome: see a full list <a href='http://fontawesome.io/icons/'>http://fontawesome.io/icons/</a>.</p>
+from fontawesome: see a full list <a href='https://fontawesome.io/icons/'>https://fontawesome.io/icons/</a>.</p>
 <p>This yaml would override the default "articles" component, eliminate
 the "home" component, and add a new "twitter" component. Unless you
 explicitly mention new components in the <code>structure</code> they'll be added

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -64,7 +64,7 @@ paths will be taken relative to the package root.
 
 \code{url} optionally specifies the url where the site will be published.
 If you supply this, other pkgdown sites will link to your site when needed,
-rather than using generic links to \url{rdocumentation.org}.
+rather than using generic links to \url{https://rdocumentation.org}.
 
 \code{title} overrides the default site title, which is the package name.
 It's used in the page title and default navbar.
@@ -176,7 +176,7 @@ The following YAML snippet illustrates some of the most important features.\pref
 
 Components can contain sub-\code{menu}s with headings (indicated by missing
 \code{href}) and separators (indiciated by a bunch of \code{-}). You can use \code{icon}s
-from fontawesome: see a full list \url{http://fontawesome.io/icons/}.
+from fontawesome: see a full list \url{https://fontawesome.io/icons/}.
 
 This yaml would override the default "articles" component, eliminate
 the "home" component, and add a new "twitter" component. Unless you


### PR DESCRIPTION
Hi!

This PR contains a quick commit that adds the missing https header of some urls in build_site documentation.

That `\url{rdocumentation.org}` took me to <http://pkgdown.r-lib.org/reference/rdocumentation.org> instead of <https://rdocumentation.org>.  This PR would fix it.  Thanks.