### PR TITLE
Process multiple args in \Sexpr{}

### DIFF
--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -525,7 +525,8 @@ parse_opts <- function(string) {
   names(args) <- args
   arg_env <- child_env(baseenv(), !!!args)
 
-  args <- strsplit(string, ",")[[1]]
+  # replace commas with semicolons so that parse_exprs can process multiple args
+  args <- gsub(",", ";", string)
   exprs <- parse_exprs(args)
 
   env <- child_env(arg_env)

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -525,9 +525,9 @@ parse_opts <- function(string) {
   names(args) <- args
   arg_env <- child_env(baseenv(), !!!args)
 
-  # replace commas with semicolons so that parse_exprs can process multiple args
-  args <- gsub(",", ";", string)
-  exprs <- parse_exprs(args)
+
+  args <- strsplit(string, ",")[[1]]
+  exprs <- purrr::map(args, parse_expr)
 
   env <- child_env(arg_env)
   purrr::walk(exprs, eval_bare, env = env)

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -107,6 +107,19 @@ test_that("Sexprs run from package root", {
   )
 })
 
+test_that("DOIs are linked", {
+  # Because paths are different during R CMD check
+  skip_if_not(file_exists("../../DESCRIPTION"))
+
+  scoped_package_context("pkgdown", src_path = "../..")
+  scoped_file_context()
+
+  expect_equal(
+    rd2html("\\doi{10.1177/0163278703255230}"),
+    "doi: <a href='http://doi.org/10.1177/0163278703255230'>10.1177/0163278703255230</a>"
+  )
+})
+
 # links -------------------------------------------------------------------
 
 test_that("href orders arguments correctly", {

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -107,6 +107,13 @@ test_that("Sexprs run from package root", {
   )
 })
 
+test_that("Sexprs with multiple args are parsed", {
+  scoped_package_context("pkgdown")
+  scoped_file_context()
+
+  expect_equal(rd2html("\\Sexpr[results=hide,stage=build]{1}"), character())
+})
+
 test_that("DOIs are linked", {
   # Because paths are different during R CMD check
   skip_if_not(file_exists("../../DESCRIPTION"))


### PR DESCRIPTION
Sexpr with multiple args like `\Sexpr[results=rd,stage=build]` were not parsed correctly. Changing commas to semicolons (i.e., `results=rd;stage=build`) enables `rlang::parse_exprs()` to parse multiple args.

Closes #720