### PR TITLE
Doc fixes

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -54,7 +54,7 @@
 #' common prefix or suffix, you can use `starts_with("prefix")` and
 #' `ends_with("suffix")` to select them all. If you don't care about
 #' position within the string, use `contains("word")`. For more complex
-#' naming schemes you can use an aribrary regular expression with
+#' naming schemes you can use an arbitrary regular expression with
 #' `matches("regexp")`.
 #'
 #' pkgdown will check that all vignettes are included in the index
@@ -86,7 +86,7 @@
 #'
 #' @inheritSection build_reference Figures
 #'
-#' @section Supressing vignettes:
+#' @section Suppressing vignettes:
 #' If you want articles that are not vignettes, either put them in
 #' subdirectories or list in `.Rbuildignore`. An articles link will be
 #' automatically added to the default navbar if the vignettes directory is

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -28,7 +28,7 @@
 #' # pkgdown <img src="man/figures/logo.png" align="right" />
 #' ```
 #'
-#' [init_site()] will also automaticlly create a favicon.ico from your package
+#' [init_site()] will also automatically create a favicon.ico from your package
 #' logo.
 #'
 #' @section YAML config - home:

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -27,7 +27,7 @@
 #' Note that `contents` can contain either a list of function names, or if the
 #' functions in a section share a common prefix or suffix, you can use
 #' `starts_with("prefix")` and `ends_with("suffix")` to select them all. For
-#' more complex naming schemes you can use an aribrary regular expression with
+#' more complex naming schemes you can use an arbitrary regular expression with
 #' `matches("regexp")`. You can also use a leading `-` to exclude matches from a
 #' section. By default, these functions that match multiple topics will exclude
 #' topics with the Rd keyword "internal". To include these, use
@@ -59,7 +59,7 @@
 #'
 #' @section Figures:
 #'
-#' You can control the default rendering of figues by specifying the `figures`
+#' You can control the default rendering of figures by specifying the `figures`
 #' field in `_pkgdown.yml`. The default settings are equivalent to:
 #'
 #' ```
@@ -83,7 +83,7 @@
 #' @inheritParams build_articles
 #' @param lazy If `TRUE`, only rebuild pages where the `.Rd`
 #'   is more recent than the `.html`. This makes it much easier to
-#'   rapidly protoype. It is set to `FALSE` by [build_site()].
+#'   rapidly prototype. It is set to `FALSE` by [build_site()].
 #' @param document If `TRUE`, will run [devtools::document()] before
 #'   updating the site.
 #' @param run_dont_run Run examples that are surrounded in \\dontrun?

--- a/R/build.r
+++ b/R/build.r
@@ -150,7 +150,7 @@
 #' ```
 #'
 #' Components can contain sub-`menu`s with headings (indicated by missing
-#' `href`) and separators (indiciated by a bunch of `-`). You can use `icon`s
+#' `href`) and separators (indicated by a bunch of `-`). You can use `icon`s
 #' from fontawesome: see a full list <https://fontawesome.io/icons/>.
 #'
 #' This yaml would override the default "articles" component, eliminate

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -7,7 +7,7 @@ NULL
 
 #' Determine if code is executed by pkgdown
 #'
-#' This is occassionally useful when you need different behaviour by
+#' This is occasionally useful when you need different behaviour by
 #' pkgdown and regular documentation.
 #'
 #' @export

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ pkgdown::build_site()
 
 This will generate a `docs/` directory. The home page will be generated from your package's `README.md`, and a function reference will be generated from the documentation in the `man/` directory. If you are using GitHub, the easiest way to make this your package website is to check into git, then go to settings for your repo and make sure that the __GitHub pages__ source is set to "master branch /docs folder". Be sure to update the URL on your github repository homepage so others can easily navigate to your new site.
 
-To customise your site, create `_pkgdown.yml` and modify it [as described in the documentation](articles/pkgdown.html). You can also use `pkgdown/_pkgdown.yml` if you need other files to customise your site.
+To customise your site, create `_pkgdown.yml` and modify it [as described in the documentation](http://pkgdown.r-lib.org/articles/pkgdown.html). You can also use `pkgdown/_pkgdown.yml` if you need other files to customise your site.
 
 The package includes an RStudio add-in that you can bind to a keyboard shortcut. I recommend `Cmd` + `Shift` + `W`: it uses `Cmd` + `Shift`, like all other package development worksheets, it replaces a rarely used command (close all tabs), and the `W` is a mnemonic for website.
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ This will generate a `docs/` directory. The home page will be generated
 from your package’s `README.md`, and a function reference will be
 generated from the documentation in the `man/` directory. If you are
 using GitHub, the easiest way to make this your package website is to
-check into git, then go settings for your repo and make sure that the
+check into git, then go to settings for your repo and make sure that the
 **GitHub pages** source is set to “master branch /docs folder”. Be sure
 to update the URL on your github repository homepage so others can
 easily navigate to your new site.
 
 To customise your site, create `_pkgdown.yml` and modify it [as
-described in the documentation](articles/pkgdown.html). You can also use
-`pkgdown/_pkgdown.yml` if you need other files to customise your site.
+described in the
+documentation](http://pkgdown.r-lib.org/articles/pkgdown.html). You can
+also use `pkgdown/_pkgdown.yml` if you need other files to customise
+your site.
 
 The package includes an RStudio add-in that you can bind to a keyboard
 shortcut. I recommend `Cmd` + `Shift` + `W`: it uses `Cmd` + `Shift`,

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -87,7 +87,7 @@ output: github_document
 
 * Citation information from a `inst/CITATION` file is linked in the side bar to the [authors page](http://testthat.r-lib.org/authors.html).
 
-* Author ORCID identification numbers in the `DESRIPTION` are linked under "Developers" using the ORCID logo (![ORCID iD](https://orcid.org/sites/default/files/images/orcid_16x16.png)).
+* Author ORCID identification numbers in the `DESCRIPTION` are linked under "Developers" using the ORCID logo (![ORCID iD](https://orcid.org/sites/default/files/images/orcid_16x16.png)).
 
 ```
 Authors@R: c(


### PR DESCRIPTION
* The link to the get started article doesn't work when clicking from the README on GitHub, so I added the website URL before the relative link.

* I saw a couple typos. I didn't `document`/`build_website` because I wasn't sure what's the preferred workflow for that in this repo.