### PR TITLE
let users explicitly disable Internet

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -117,5 +117,6 @@ skip_if_no_pandoc <- function() {
 
 # from testthat::skip_if_offline()
 has_internet <- function(host = "r-project.org") {
+  if(identical(getOption('pkgdown.internet'), FALSE)) return(FALSE)
   !is.null(curl::nslookup(host, error = FALSE))
 }


### PR DESCRIPTION
users can declare that they don't want to access the Internet.

A curve way to address #762, based on #767