### PR TITLE
Better error messages for tag parsing failures

### DIFF
--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -230,19 +230,10 @@ data_reference_topic <- function(topic,
   out$keywords <- purrr::map_chr(tags$tag_keyword %||% list(), flatten_text)
 
   # Sections that contain arbitrary text and need cross-referencing
-  out$description <- as_data(
-    x = tags$tag_description[[1]],
-    file_name = out$filename # file_name sometimes passed to as_html() for debug
-  )
+  out$description <- as_data(tags$tag_description[[1]])
   out$opengraph <- list(description = strip_html_tags(out$description$contents))
-  out$usage <- as_data(
-    tags$tag_usage[[1]],
-    file_name = out$filename # file_name sometimes passed to as_html() for debug
-  )
-  out$arguments <- as_data(
-    tags$tag_arguments[[1]],
-    file_name = out$filename # file_name sometimes passed to as_html() for debug
-  )
+  out$usage <- as_data(tags$tag_usage[[1]])
+  out$arguments <- as_data(tags$tag_arguments[[1]])
   if (length(out$arguments)) {
     out$has_args <- TRUE # Work around mustache deficiency
   }
@@ -252,8 +243,7 @@ data_reference_topic <- function(topic,
     env = new.env(parent = globalenv()),
     topic = tools::file_path_sans_ext(topic$file_in),
     examples = examples,
-    run_dont_run = run_dont_run,
-    file_name = out$filename # file_name sometimes passed to as_html() for debug
+    run_dont_run = run_dont_run
   )
 
   # Everything else stays in original order, and becomes a list of sections.
@@ -263,7 +253,7 @@ data_reference_topic <- function(topic,
   )
   sections <- topic$rd[tag_names %in% section_tags]
   out$sections <- sections %>%
-    purrr::map(as_data, file_name = out$filename) %>%
+    purrr::map(as_data) %>%
     purrr::map(add_slug)
 
   out

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -230,10 +230,19 @@ data_reference_topic <- function(topic,
   out$keywords <- purrr::map_chr(tags$tag_keyword %||% list(), flatten_text)
 
   # Sections that contain arbitrary text and need cross-referencing
-  out$description <- as_data(tags$tag_description[[1]])
+  out$description <- as_data(
+    x = tags$tag_description[[1]],
+    file_name = out$filename # file_name sometimes passed to as_html() for debug
+  )
   out$opengraph <- list(description = strip_html_tags(out$description$contents))
-  out$usage <- as_data(tags$tag_usage[[1]])
-  out$arguments <- as_data(tags$tag_arguments[[1]])
+  out$usage <- as_data(
+    tags$tag_usage[[1]],
+    file_name = out$filename # file_name sometimes passed to as_html() for debug
+  )
+  out$arguments <- as_data(
+    tags$tag_arguments[[1]],
+    file_name = out$filename # file_name sometimes passed to as_html() for debug
+  )
   if (length(out$arguments)) {
     out$has_args <- TRUE # Work around mustache deficiency
   }
@@ -243,7 +252,8 @@ data_reference_topic <- function(topic,
     env = new.env(parent = globalenv()),
     topic = tools::file_path_sans_ext(topic$file_in),
     examples = examples,
-    run_dont_run = run_dont_run
+    run_dont_run = run_dont_run,
+    file_name = out$filename # file_name sometimes passed to as_html() for debug
   )
 
   # Everything else stays in original order, and becomes a list of sections.
@@ -253,7 +263,7 @@ data_reference_topic <- function(topic,
   )
   sections <- topic$rd[tag_names %in% section_tags]
   out$sections <- sections %>%
-    purrr::map(as_data) %>%
+    purrr::map(as_data, file_name = out$filename) %>%
     purrr::map(add_slug)
 
   out

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -28,16 +28,7 @@ flatten_para <- function(x, ...) {
   after_break <- c(FALSE, before_break[-length(x)])
   groups <- cumsum(before_break | after_break)
 
-  # Wrangling useful debugging information for some as_html() calls
-  section_tagname <- class(x)[1]
-  section_name <- paste(
-    toupper(substr(section_tagname, 5, 5)),
-    substr(section_tagname, 6, nchar(section_tagname)),
-    sep = ""
-  )
-
-  # Calling as_html() on `x` with section_name passed through dots
-  html <- purrr::map_chr(x, as_html, section_name = section_name, ...)
+  html <- purrr::map_chr(x, as_html, ...)
   blocks <- html %>%
     split(groups) %>%
     purrr::map_chr(paste, collapse = "")
@@ -111,11 +102,10 @@ as_html.tag_subsection <- function(x, ...) {
 as_html.tag_eqn <- function(x, ..., mathjax = TRUE) {
   if ( length(x) > 2 ) {
     dots <- list(...)
-    section_name <- dots$section_name
     file_name <- dots$file_name
     message1 <- paste(
       "An \\eqn{} Rd tag contains a bad equation in the",
-      section_name, "section of the", file_name, "file."
+      file_name, "file."
     )
     stop(message1)
   }
@@ -133,11 +123,10 @@ as_html.tag_eqn <- function(x, ..., mathjax = TRUE) {
 as_html.tag_deqn <- function(x, ..., mathjax = TRUE) {
   if ( length(x) > 2 ) {
     dots <- list(...)
-    section_name <- dots$section_name
     file_name <- dots$file_name
     message1 <- paste(
       "A \\deqn{} Rd tag contains a bad equation in the",
-      section_name, "section of the", file_name, "file."
+      file_name, "file."
     )
     stop(message1)
   }
@@ -156,11 +145,10 @@ as_html.tag_deqn <- function(x, ..., mathjax = TRUE) {
 as_html.tag_url <- function(x, ...) {
   if ( length(x) != 1 ) {
     dots <- list(...)
-    section_name <- dots$section_name
     file_name <- dots$file_name
     message1 <- paste(
       "A \\url Rd tag contains a bad URL in the",
-      section_name, "section of the", file_name, "file."
+      file_name, "file."
     )
     if ( length(x) == 0 ) {
       message2 <- paste(
@@ -183,11 +171,10 @@ as_html.tag_url <- function(x, ...) {
 as_html.tag_href <- function(x, ...) {
   if ( length(x) != 2 ) {
     dots <- list(...)
-    section_name <- dots$section_name
     file_name <- dots$file_name
     message1 <- paste(
       "A \\href Rd tag contains a bad label or destination in the",
-      section_name, "section of the", file_name, "file."
+      file_name, "file."
     )
     stop(message1)
   }
@@ -198,11 +185,10 @@ as_html.tag_href <- function(x, ...) {
 as_html.tag_email <- function(x, ...) {
   if ( !(length(x) %in% c(1L, 2L))) {
     dots <- list(...)
-    section_name <- dots$section_name
     file_name <- dots$file_name
     message1 <- paste(
       "An \\email Rd tag contains a bad label or email in the",
-      section_name, "section of the", file_name, "file."
+      file_name, "file."
     )
     stop(message1)
   }
@@ -255,11 +241,10 @@ as_html.tag_link <- function(x, ...) {
 as_html.tag_linkS4class <- function(x, ...) {
   if ( length(x) != 1 ) {
     dots <- list(...)
-    section_name <- dots$section_name
     file_name <- dots$file_name
     message1 <- paste(
       "A \\linkS4class{} Rd tag contains bad link in the",
-      section_name, "section of the", file_name, "file."
+      file_name, "file."
     )
     stop(message1)
   }

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -101,13 +101,7 @@ as_html.tag_subsection <- function(x, ...) {
 #' @export
 as_html.tag_eqn <- function(x, ..., mathjax = TRUE) {
   if ( length(x) > 2 ) {
-    dots <- list(...)
-    file_name <- dots$file_name
-    message1 <- paste(
-      "An \\eqn{} Rd tag contains a bad equation in the",
-      file_name, "file."
-    )
-    stop(message1)
+    stop_on_bad_html_tag(tag_type = "\\eqn{}", tag_log = "equation")
   }
 
   if (isTRUE(mathjax)){
@@ -122,13 +116,7 @@ as_html.tag_eqn <- function(x, ..., mathjax = TRUE) {
 #' @export
 as_html.tag_deqn <- function(x, ..., mathjax = TRUE) {
   if ( length(x) > 2 ) {
-    dots <- list(...)
-    file_name <- dots$file_name
-    message1 <- paste(
-      "A \\deqn{} Rd tag contains a bad equation in the",
-      file_name, "file."
-    )
-    stop(message1)
+    stop_on_bad_html_tag(tag_type = "\\deqn{}", tag_log = "equation")
   }
 
   if (isTRUE(mathjax)) {
@@ -144,24 +132,16 @@ as_html.tag_deqn <- function(x, ..., mathjax = TRUE) {
 #' @export
 as_html.tag_url <- function(x, ...) {
   if ( length(x) != 1 ) {
-    dots <- list(...)
-    file_name <- dots$file_name
-    message1 <- paste(
-      "A \\url Rd tag contains a bad URL in the",
-      file_name, "file."
-    )
     if ( length(x) == 0 ) {
-      message2 <- paste(
-        message1, "Check for empty \\url{} tags."
-      )
-      stop(message2)
+      debug_mess <- "Check for empty \\url{} tags."
     } else {
-      message2 <- paste(
-        message1,
-        "This could be caused by a \\url tag that spans a line break."
-      )
-      stop(message2)
+      debug_mess <- "This may be caused by a \\url tag that spans a line break."
     }
+    stop_on_bad_html_tag(
+      tag_type = "\\url",
+      tag_log = "URL",
+      debug_message = debug_mess
+    )
   }
 
   text <- flatten_text(x[[1]])
@@ -170,13 +150,7 @@ as_html.tag_url <- function(x, ...) {
 #' @export
 as_html.tag_href <- function(x, ...) {
   if ( length(x) != 2 ) {
-    dots <- list(...)
-    file_name <- dots$file_name
-    message1 <- paste(
-      "A \\href Rd tag contains a bad label or destination in the",
-      file_name, "file."
-    )
-    stop(message1)
+    stop_on_bad_html_tag(tag_type = "\\href", tag_log = "label or destination")
   }
 
   a(flatten_text(x[[2]]), href = flatten_text(x[[1]]))
@@ -184,13 +158,7 @@ as_html.tag_href <- function(x, ...) {
 #' @export
 as_html.tag_email <- function(x, ...) {
   if ( !(length(x) %in% c(1L, 2L))) {
-    dots <- list(...)
-    file_name <- dots$file_name
-    message1 <- paste(
-      "An \\email Rd tag contains a bad label or email in the",
-      file_name, "file."
-    )
-    stop(message1)
+    stop_on_bad_html_tag(tag_type = "\\email", tag_log = "label or email")
   }
 
   paste0("<a href='mailto:", x[[1]], "'>", x[[length(x)]], "</a>")
@@ -240,13 +208,7 @@ as_html.tag_link <- function(x, ...) {
 #' @export
 as_html.tag_linkS4class <- function(x, ...) {
   if ( length(x) != 1 ) {
-    dots <- list(...)
-    file_name <- dots$file_name
-    message1 <- paste(
-      "A \\linkS4class{} Rd tag contains bad link in the",
-      file_name, "file."
-    )
-    stop(message1)
+    stop_on_bad_html_tag(tag_type = "\\linkS4class{}", tag_log = "link")
   }
 
   text <- flatten_text(x[[1]])
@@ -576,6 +538,20 @@ trim_ws_nodes <- function(x, side = c("both", "left", "right")) {
 }
 
 
+# Helper for debugging bad Rd tags in as_html() ----------------------------
+
+stop_on_bad_html_tag <- function(tag_type, tag_log, debug_message = NULL) {
+
+  file_name <- context_get("rdname")
+  error_message <- paste(
+    "A", tag_type, "Rd tag",
+    "contains a bad", tag_log,
+    "in the", file_name, "file.",
+    debug_message
+  )
+  stop(error_message)
+}
+
 # Helpers -----------------------------------------------------------------
 
 parse_opts <- function(string) {
@@ -596,4 +572,5 @@ parse_opts <- function(string) {
 
   as.list(env)
 }
+
 

--- a/tests/testthat/test-link-href.R
+++ b/tests/testthat/test-link-href.R
@@ -36,7 +36,7 @@ test_that("links to home of re-exported functions", {
   expect_equal(href_expr_(addterm()), href_topic_remote("addterm", "MASS"))
 })
 
-test_that("fails gracely if can't find re-exported function", {
+test_that("fails gracefully if can't find re-exported function", {
   skip_if_not(getRversion() >= "3.2.0")
 
   scoped_package_context("pkgdown", c(foo = "reexports"))

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -352,27 +352,22 @@ test_that("titles don't get autolinked code", {
 
 test_that("URLs handled well", {
 
-  rd_file_name <- "test.Rd"
-  # section_name <- "Details"
+  ## Binding the rdname to the context environment allows
+  # stop_on_bad_html_tag() to grab the filename via rlang
+  rlang::env_bind(.env = context, rdname = "test-rd-html.R")
+  ## Without this, the error message in this test file is:
+  # Error: Context `rdname` has not been initialised
 
+  ## Good URLs do not throw erros and complete as desired
   expect_equal(
-    html <- rd2html(
-      x = "\\url{http://google.com}",
-      file_name = rd_file_name
-    ),
+    rd2html(x = "\\url{http://google.com}"),
     a("http://google.com", href = "http://google.com")
   )
-  expect_error(
-    html <- rd2html(
-      x = "\\url{}",
-      file_name = rd_file_name
-    )
-  )
-  expect_error(
-    rd2html(
-      x = "\\url{http://go \n ogle.com}",
-      file_name = rd_file_name
-    )
-  )
+
+  ## Empty URLs throw errors
+  expect_error( rd2html(x = "\\url{}") )
+
+  ## Bad URLs throw errors
+  expect_error( rd2html(x = "\\url{http://go \n ogle.com}") )
 
 })

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -346,3 +346,36 @@ test_that("titles don't get autolinked code", {
   rd <- rd_text("\\title{\\code{foo()}}", fragment = FALSE)
   expect_equal(extract_title(rd), "<code>foo()</code>")
 })
+
+# Handling URL failures verbosely -----------------------------------------
+
+
+test_that("URLs handled well", {
+
+  rd_file_name <- "test.Rd"
+  section_name <- "Details"
+
+  expect_equal(
+    html <- rd2html(
+      x = "\\url{http://google.com}",
+      file_name = rd_file_name,
+      section_name = section_name
+    ),
+    a("http://google.com", href = "http://google.com")
+  )
+  expect_error(
+    html <- rd2html(
+      x = "\\url{}",
+      file_name = rd_file_name,
+      section_name = section_name
+    )
+  )
+  expect_error(
+    rd2html(
+      x = "\\url{http://go \n ogle.com}",
+      file_name = rd_file_name,
+      section_name = section_name
+    )
+  )
+
+})

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -353,28 +353,25 @@ test_that("titles don't get autolinked code", {
 test_that("URLs handled well", {
 
   rd_file_name <- "test.Rd"
-  section_name <- "Details"
+  # section_name <- "Details"
 
   expect_equal(
     html <- rd2html(
       x = "\\url{http://google.com}",
-      file_name = rd_file_name,
-      section_name = section_name
+      file_name = rd_file_name
     ),
     a("http://google.com", href = "http://google.com")
   )
   expect_error(
     html <- rd2html(
       x = "\\url{}",
-      file_name = rd_file_name,
-      section_name = section_name
+      file_name = rd_file_name
     )
   )
   expect_error(
     rd2html(
       x = "\\url{http://go \n ogle.com}",
-      file_name = rd_file_name,
-      section_name = section_name
+      file_name = rd_file_name
     )
   )
 


### PR DESCRIPTION
This attempts to fix #770 

Please take a look at the way I am wrangling and passing `file_name` and `section_name` through. 

This did not break any existing tests, but I think it's perhaps a little more fragile than I'd like. I'd be happy for suggestions - maybe it's a good idea to create a `wrangleSectionName()` function and add some tests to make sure the `class(x)[1]` works as intended?