### PR TITLE
Correct message

### DIFF
--- a/R/build-logo.R
+++ b/R/build-logo.R
@@ -7,7 +7,7 @@ build_logo <- function(pkg = ".") {
 
   file_copy_to(pkg, logo_path, from_dir = path_dir(logo_path))
   if (!requireNamespace("magick", quietly = TRUE)) {
-    message("Magick not avaliable, not creating favicon.ico")
+    message("magick not available, not creating favicon.ico")
     return()
   }
 


### PR DESCRIPTION
Was looking at this because it's awesome (especially with `usethis::use_logo`!).

Typo + I find "Magick" misleading. I was wondering whether it should actually be "The magick package" to make it clearer?