### PR TITLE
Add a CNAME file if the site has a url entry in the metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown 1.1.0.9000
 
+* `init_site()` now creates a CNAME file if one doesn't already exist and the
+  site's metadata includes a `url` field.
+
 * Users with limited internet connectivity can explicitly disable pkgdown CRAN checks
   by setting `options(pkgdown.internet = FALSE)` prior to running `build_site()` (#774).
   

--- a/R/build-cname.R
+++ b/R/build-cname.R
@@ -1,0 +1,13 @@
+build_cname <- function(pkg = ".") {
+  pkg <- as_pkgdown(pkg)
+
+  if (!is.null(pkg$meta$url)) {
+    # CNAME files don't have protocols
+    cname <- sub("^https?://", "", pkg$meta$url)
+    cname_path <- path(pkg$dst_path, "CNAME")
+
+    write_if_different(pkg, cname, cname_path)
+  }
+
+  invisible()
+}

--- a/R/init.R
+++ b/R/init.R
@@ -35,6 +35,7 @@ init_site <- function(pkg = ".") {
   build_sitemap(pkg)
   build_docsearch_json(pkg)
   build_logo(pkg)
+  build_cname(pkg)
 
   usethis::use_pkgdown()
 

--- a/tests/testthat/assets/cname/DESCRIPTION
+++ b/tests/testthat/assets/cname/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A longer statement about the package.
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = c("cph", "fnd"))
+    )
+RoxygenNote: 6.0.1

--- a/tests/testthat/assets/cname/_pkgdown.yml
+++ b/tests/testthat/assets/cname/_pkgdown.yml
@@ -1,0 +1,1 @@
+url: https://testpackage.r-lib.org

--- a/tests/testthat/test-build-cname.R
+++ b/tests/testthat/test-build-cname.R
@@ -1,0 +1,14 @@
+context("build_cname")
+
+test_that("a CNAME record is built if a url exists in metadata", {
+  cname <- test_path("assets/cname")
+  dir_create(path(cname, "docs"))
+
+  on.exit({
+    clean_site(cname)
+    file_delete(path(cname, "docs", "CNAME"))
+  })
+
+  expect_output(build_cname(cname))
+  expect_equal(read_lines(path(cname, "docs", "CNAME")), "testpackage.r-lib.org")
+})


### PR DESCRIPTION
This will automatically create a CNAME file if there is a url entry in the metadata.

This is useful in conjunction with #792, as in that scenario there is no existing CNAME file that can be re-used.

It also avoids needing to create this by hand, which is something I tend to forget to do.