### PR TITLE
Fix build_cname() to no longer check for a pkgdown comment

### DIFF
--- a/R/build-cname.R
+++ b/R/build-cname.R
@@ -8,7 +8,7 @@ build_cname <- function(pkg = ".") {
     cname <- sub("//$", "", cname)
     cname_path <- path(pkg$dst_path, "CNAME")
 
-    write_if_different(pkg, cname, cname_path)
+    write_if_different(pkg, cname, cname_path, check = FALSE)
   }
 
   invisible()


### PR DESCRIPTION
CNAME files cannot have comments, so we need to disable the check for a
pkgdown generated file.

Fixes #799