### PR TITLE
Retain colored output even when executing in a new process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown 1.1.0.9000
 
+* `build_site()` now uses colors even if `new_process = TRUE` (@jimhester).
+
 * `init_site()` now creates a CNAME file if one doesn't already exist and the
   site's metadata includes a `url` field.
 

--- a/R/build.r
+++ b/R/build.r
@@ -311,12 +311,17 @@ build_site_external <- function(pkg = ".",
     lazy = lazy,
     override = override,
     preview = FALSE,
-    new_process = FALSE
+    new_process = FALSE,
+    crayon_enabled = crayon::has_color(),
+    crayon_colors = crayon::num_colors()
   )
   callr::r(
-    function(...) pkgdown::build_site(...),
+    function(..., crayon_enabled, crayon_colors) {
+      options(crayon.enabled = crayon_enabled, crayon.colors = crayon_colors)
+      pkgdown::build_site(...)
+    },
     args = args,
-    show = TRUE
+    show = TRUE,
   )
 
   preview_site(pkg, preview = preview)


### PR DESCRIPTION
The colored diagnostic messages are lost when running in a separate
child process unless you tell the child process that it can display
color. We do that by passing the color settings of the parent process
down to the child.