### PR TITLE
Add skip_cleanup to deploy_site_github() docs

### DIFF
--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -14,6 +14,7 @@
 #' deploy:
 #'   provider: script
 #'   script: Rscript -e 'pkgdown::deploy_site_github()'
+#'   skip_cleanup: true
 #' ```
 #'
 #' Then you will need to setup your deployment keys. The easiest way is to call

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -41,6 +41,7 @@ Add the following to your \code{.travis.yml} file.\preformatted{before_deploy: R
 deploy:
   provider: script
   script: Rscript -e 'pkgdown::deploy_site_github()'
+  skip_cleanup: true
 }
 
 Then you will need to setup your deployment keys. The easiest way is to call


### PR DESCRIPTION
After seeing how `vctrs` auto deploys `pkgdown` with travis, and after playing around with it myself, I think `skip_cleanup: true` needs to be added to the `.travis.yml` to keep the built R package around.

Otherwise you get:
https://travis-ci.org/tidymodels/yardstick/builds/433582268#L1306

I think this is because travis has cleaned up the directory after the build.