### PR TITLE
Table of Contents depth; option in _pkgdown.yml

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -212,10 +212,15 @@ build_rmarkdown_format <- function(pkg,
                                    toc = TRUE) {
 
   template <- rmarkdown_template(pkg, depth = depth, data = data)
+  if(!is.null(pkg$meta$toc_depth)){
+    toc_depth = pkg$meta$toc_depth
+  }else{
+    toc_depth = 2
+  }
 
   out <- rmarkdown::html_document(
     toc = toc,
-    toc_depth = 2,
+    toc_depth = toc_depth,
     self_contained = FALSE,
     theme = NULL,
     template = template$path


### PR DESCRIPTION
I would really like something like this, to control how many levels to be used in the table of contents. See also #741 #732 

Even better improvement would be to change the visual style of the button in the ToC, depending on which level the heading is.

Best,
Bjørn
