### PR TITLE
Use higher availability CDN for Mathjax

### DIFF
--- a/inst/templates/head.html
+++ b/inst/templates/head.html
@@ -57,7 +57,7 @@
 {{#development}}{{#in_dev}}<meta name="robots" content="noindex">{{/in_dev}}{{/development}}
 
 <!-- mathjax -->
-<script src='https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>


### PR DESCRIPTION
The R Studio mirror is reported to have only intermittent connectivity in China.

Part of #785