### PR TITLE
Don't call use_pkgdown in init_site()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,6 @@ Imports:
     rstudioapi,
     tibble,
     tools,
-    usethis,
     whisker,
     xml2 (>= 1.1.1),
     yaml

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,9 +26,6 @@
 * Support of multiple arguments in `\Sexpr{}` was fixed, eliminating `x must be a
   string or a R connection` errors when using `\doi` Rd tags (#738).
 
-* `init_site()`: now calls `usethis::use_pkgdown()` to build-ignore `_pkgdown.yml`
-  and `docs/`, preventing a NOTE during R CMD CHECK (#710).
-
 * `build_home()`: a link to the source `inst/CITATION` was added to the authors page (#714).
 
 # pkgdown 1.1.0

--- a/R/init.R
+++ b/R/init.R
@@ -5,11 +5,11 @@
 #' assets and extra files.
 #'
 #' @section Build-ignored files:
-#' pkgdown uses `usethis::use_pkgdown()` to build-ignore `docs/` and
-#' `_pkgdown.yml`. If you use an alternative location for your config file,
-#' update `_pkgdown.yml` in `.Rbuildignore` with its location. A `NOTE` about
-#' an unexpected file during `R CMD CHECK` is an indication you have not correctly
-#' ignored these files.
+#' We recommend using `usethis::use_pkgdown()` to build-ignore `docs/` and
+#' `_pkgdown.yml`. If use another directory, or create the site manually,
+#' you'll need to add them to `.Rbuildignore` yourself. A `NOTE` about
+#' an unexpected file during `R CMD CHECK` is an indication you have not
+#' correctly ignored these files.
 #'
 #' @section Custom CSS/JS:
 #' If you want to do minor customisation of your pkgdown site, the easiest
@@ -40,8 +40,6 @@ init_site <- function(pkg = ".") {
   build_docsearch_json(pkg)
   build_logo(pkg)
   build_cname(pkg)
-
-  usethis::use_pkgdown()
 
   invisible()
 }

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -16,11 +16,11 @@ assets and extra files.
 }
 \section{Build-ignored files}{
 
-pkgdown uses \code{usethis::use_pkgdown()} to build-ignore \code{docs/} and
-\code{_pkgdown.yml}. If you use an alternative location for your config file,
-update \code{_pkgdown.yml} in \code{.Rbuildignore} with its location. A \code{NOTE} about
-an unexpected file during \code{R CMD CHECK} is an indication you have not correctly
-ignored these files.
+We recommend using \code{usethis::use_pkgdown()} to build-ignore \code{docs/} and
+\code{_pkgdown.yml}. If use another directory, or create the site manually,
+you'll need to add them to \code{.Rbuildignore} yourself. A \code{NOTE} about
+an unexpected file during \code{R CMD CHECK} is an indication you have not
+correctly ignored these files.
 }
 
 \section{Custom CSS/JS}{


### PR DESCRIPTION
Instead document what you need to do if you don't use it.

Reverts #710. Fixes #862. Closes #812.