### PR TITLE
omit link (to NA) if there is no BugReports field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown 1.1.0.9000
 
+* `build_home()` no longer includes an NA link for bug reports in the
+  sidebar if the `DESCRIPTION` has no "BugReports" field (#855).
+
 * Support of qualified functions in `@usage` statments was fixed, eliminating `Error in fun_info(x) : Unknown call: ::` errors (#795).
 
 * A default favicon is now used if no logo is provided (#827).

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -79,7 +79,8 @@ data_home_sidebar_links <- function(pkg = ".") {
   links <- c(
     link_url(paste0("Download from ", repo$repo), repo$url),
     link_url("Browse source code", pkg$github_url),
-    link_url("Report a bug", pkg$desc$get("BugReports")[[1]]),
+    if (pkg$desc$has_fields("BugReports"))
+      link_url("Report a bug", pkg$desc$get("BugReports")[[1]]),
     purrr::map_chr(meta, ~ link_url(.$text, .$href))
   )
 


### PR DESCRIPTION
Fixes #855.

This implements the defensive approach of not including any link for bug reports in the sidebar if the DESCRIPTION does not have a BugReports field.