### PR TITLE
Edit rstudio-logo location to bypass HTTP 301

### DIFF
--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -39,7 +39,7 @@ data_author_info <- function(pkg = ".") {
     ),
     "RStudio" = list(
       href = "https://www.rstudio.com",
-      html = "<img src='https://tidyverse.org/rstudio-logo.svg' alt='RStudio' height='24' />"
+      html = "<img src='https://www.tidyverse.org/rstudio-logo.svg' alt='RStudio' height='24' />"
     ),
     "R Consortium" = list(
       href = "https://www.r-consortium.org"

--- a/R/build.r
+++ b/R/build.r
@@ -42,7 +42,7 @@
 #'     href: http://hadley.nz
 #'   RStudio:
 #'     href: https://www.rstudio.com
-#'     html: <img src="https://tidyverse.org/rstudio-logo.svg" height="24" />
+#'     html: <img src="https://www.tidyverse.org/rstudio-logo.svg" height="24" />
 #' ```
 #'
 #' @section Development mode:


### PR DESCRIPTION
https://tidyverse.org/rstudio-logo.svg returns `HTTP 301` and redirects to https://www.tidyverse.org/rstudio-logo.svg

The page loading time is affected by this because the DNS resolution and the TLS handshake now need to be performed twice (first for `tidyverse.org` and then for `www.tidyverse.org`).

This PR updates the path of `rstudio-logo.svg` to bypass the `HTTP 301` response.