### PR TITLE
pass pkgdown.internet option in build_site_external

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
   site's metadata includes a `url` field.
 
 * Users with limited internet connectivity can explicitly disable pkgdown CRAN checks
-  by setting `options(pkgdown.internet = FALSE)` prior to running `build_site()` (#774).
+  by setting `options(pkgdown.internet = FALSE)` prior to running `build_site()` (#774, #877).
   
 * `build_reference_index()`: Selectors that do not match topics now generate a warning.
   If none of the specified selectors have a match, no topics are selected (#728).

--- a/R/build.r
+++ b/R/build.r
@@ -313,9 +313,11 @@ build_site_external <- function(pkg = ".",
   )
   callr::r(
     function(..., crayon_enabled, crayon_colors, pkgdown_internet) {
-      options(crayon.enabled = crayon_enabled,
-              crayon.colors = crayon_colors,
-              pkgdown.internet = pkgdown_internet)
+      options(
+        crayon.enabled = crayon_enabled,
+        crayon.colors = crayon_colors,
+        pkgdown.internet = pkgdown_internet
+      )
       pkgdown::build_site(...)
     },
     args = args,

--- a/R/build.r
+++ b/R/build.r
@@ -308,11 +308,14 @@ build_site_external <- function(pkg = ".",
     preview = FALSE,
     new_process = FALSE,
     crayon_enabled = crayon::has_color(),
-    crayon_colors = crayon::num_colors()
+    crayon_colors = crayon::num_colors(),
+    pkgdown_internet = has_internet()
   )
   callr::r(
-    function(..., crayon_enabled, crayon_colors) {
-      options(crayon.enabled = crayon_enabled, crayon.colors = crayon_colors)
+    function(..., crayon_enabled, crayon_colors, pkgdown_internet) {
+      options(crayon.enabled = crayon_enabled,
+              crayon.colors = crayon_colors,
+              pkgdown.internet = pkgdown_internet)
       pkgdown::build_site(...)
     },
     args = args,


### PR DESCRIPTION
This fixes #861 by passing the option `pkgdown.internet` that could be set by the user to `build_site_external` call to `callr::r()`. It completes #774.

This now works:

```r
options(pkgdown.internet = FALSE)
pkgdown::build_site()
```

I did not look yet if I should add a test for `build_site_external`. 