### PR TITLE
move and complete help section about disable internet connection feature

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -81,10 +81,6 @@
 #' This section is automatically populated if the first paragraph of the
 #' homepage consists solely of status badges as linked images.
 #'
-#' @section Internet:
-#' Users with limited internet connectivity can disable CRAN checks by setting
-#' `options(pkgdown.internet = FALSE)`.
-#'
 #' @inheritParams build_articles
 #' @export
 build_home <- function(pkg = ".",

--- a/R/build.r
+++ b/R/build.r
@@ -240,6 +240,13 @@
 #' is little documentation, and you'll need to read the existing source
 #' for pkgdown templates to ensure that you use the correct components.
 #'
+#' @section Internet:
+#' Users with limited internet connectivity can disable CRAN checks by setting
+#' `options(pkgdown.internet = FALSE)`. This will also disable some features
+#' from pkgdown that requires an internet connectivity. However, if it is used
+#' to build docs for a package that requires internet connectivity in examples
+#' or vignettes, this connection is required as this option won't apply on them.
+#'
 #' @inheritParams build_articles
 #' @inheritParams build_reference
 #' @param lazy If `TRUE`, will only rebuild articles and reference pages

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -98,9 +98,3 @@ This section is automatically populated if the first paragraph of the
 homepage consists solely of status badges as linked images.
 }
 
-\section{Internet}{
-
-Users with limited internet connectivity can disable CRAN checks by setting
-\code{options(pkgdown.internet = FALSE)}.
-}
-

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -249,6 +249,15 @@ is little documentation, and you'll need to read the existing source
 for pkgdown templates to ensure that you use the correct components.
 }
 
+\section{Internet}{
+
+Users with limited internet connectivity can disable CRAN checks by setting
+\code{options(pkgdown.internet = FALSE)}. This will disable some features from
+pkgdown that requires an internet connectivity. However, if it is used to
+build docs for a package that needs internet connectivity in examples or
+vignettes, this connection is required as this options won't apply on them.
+}
+
 \examples{
 \dontrun{
 build_site()


### PR DESCRIPTION
This follows #877 and complete #774 

* Section moved to `build_site` help page
* add some warning about the option `pkdown.internet = FALSE` not being useful if the 📦 for which pkgdown is used for requires internet in examples and vignette.



