### PR TITLE
Default to HTTPS

### DIFF
--- a/R/build-news.R
+++ b/R/build-news.R
@@ -213,7 +213,7 @@ pkg_timeline <- function(package) {
     return(NULL)
   }
 
-  url <- paste0("http://crandb.r-pkg.org/", package, "/all")
+  url <- paste0("https://crandb.r-pkg.org/", package, "/all")
 
   resp <- httr::GET(url)
   if (httr::http_error(resp)) {

--- a/R/github.R
+++ b/R/github.R
@@ -70,7 +70,7 @@ github_source_links <- function(base, paths) {
 }
 
 add_github_links <- function(x, pkg) {
-  user_link <- paste0("<a href='http://github.com/\\1'>@\\1</a>")
+  user_link <- paste0("<a href='https://github.com/\\1'>@\\1</a>")
   x <- gsub("@([-\\w]+)", user_link, x, perl = TRUE)
 
   github_url <- pkg$github_url

--- a/R/link-href.R
+++ b/R/link-href.R
@@ -125,7 +125,7 @@ href_topic_remote <- function(topic, package) {
     paste0(reference_url, paste0("/", rdname, ".html"))
   } else {
     # Fall back to rdocumentation.org which almost certainly works
-    paste0("http://www.rdocumentation.org/packages/", package, "/topics/", rdname)
+    paste0("https://www.rdocumentation.org/packages/", package, "/topics/", rdname)
   }
 }
 

--- a/inst/templates/footer.html
+++ b/inst/templates/footer.html
@@ -3,6 +3,6 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 


### PR DESCRIPTION
Default to HTTPS for:
- rdocumentation.org (301 redirects to HTTPS)
- pkgdown.r-lib.org (301 redirects to HTTPS)
- github.org (301 redirects to HTTPS)
- crandb.r-pkg.org (supports HTTPS but no redirect)