### PR TITLE
Install package to temporary libpath

### DIFF
--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -87,6 +87,9 @@
 #'   updating the site.
 #' @param run_dont_run Run examples that are surrounded in \\dontrun?
 #' @param examples Run examples?
+#' @param load_all If `TRUE`, will load development version of package using
+#'   [pkgload::load_all()]; if `FALSE`, will load installed version of
+#'   package using [library()].
 #' @param seed Seed used to initialize so that random examples are
 #'   reproducible.
 #' @export
@@ -94,6 +97,7 @@ build_reference <- function(pkg = ".",
                             lazy = TRUE,
                             document = FALSE,
                             examples = TRUE,
+                            load_all = TRUE,
                             run_dont_run = FALSE,
                             seed = 1014,
                             override = list(),
@@ -116,9 +120,7 @@ build_reference <- function(pkg = ".",
   }
 
   if (examples) {
-    # Re-loading pkgdown while it's running causes weird behaviour with
-    # the context cache
-    if (!(pkg$package %in% c("pkgdown", "rprojroot"))) {
+    if (load_all && !(pkg$package %in% c("pkgdown", "rprojroot"))) {
       pkgload::load_all(pkg$src_path, export_all = FALSE, helpers = FALSE)
     } else {
       library(pkg$package, character.only = TRUE)

--- a/R/build.r
+++ b/R/build.r
@@ -263,6 +263,7 @@
 #' }
 build_site <- function(pkg = ".",
                        examples = TRUE,
+                       load_all = !new_process,
                        document = TRUE,
                        run_dont_run = FALSE,
                        seed = 1014,
@@ -275,6 +276,7 @@ build_site <- function(pkg = ".",
     build_site_external(
       pkg = pkg,
       examples = examples,
+      load_all = load_all,
       document = document,
       run_dont_run = run_dont_run,
       seed = seed,
@@ -286,6 +288,7 @@ build_site <- function(pkg = ".",
     build_site_local(
       pkg = pkg,
       examples = examples,
+      load_all = load_all,
       document = document,
       run_dont_run = run_dont_run,
       seed = seed,
@@ -298,12 +301,27 @@ build_site <- function(pkg = ".",
 
 build_site_external <- function(pkg = ".",
                                 examples = TRUE,
+                                load_all = load_all,
                                 document = TRUE,
                                 run_dont_run = FALSE,
                                 seed = 1014,
                                 lazy = FALSE,
                                 override = list(),
                                 preview = NA) {
+
+  pkg <- as_pkgdown(pkg)
+
+  rule(paste0("Installing ", pkg$package, " (to temporary library)"))
+  lib_dir <- fs::dir_create(fs::file_temp("library"))
+  on.exit(fs::dir_delete(lib_dir), add = TRUE)
+  install.packages(
+    pkg$src_path,
+    lib = lib_dir,
+    repo = NULL,
+    type = "source",
+    quiet = TRUE
+  )
+
   args <- list(
     pkg = pkg,
     examples = examples,
@@ -312,6 +330,7 @@ build_site_external <- function(pkg = ".",
     seed = seed,
     lazy = lazy,
     override = override,
+    load_all = FALSE,
     preview = FALSE,
     new_process = FALSE,
     crayon_enabled = crayon::has_color(),
@@ -327,6 +346,7 @@ build_site_external <- function(pkg = ".",
       )
       pkgdown::build_site(...)
     },
+    libpath = c(lib_dir, .libPaths()),
     args = args,
     show = TRUE,
   )
@@ -337,6 +357,7 @@ build_site_external <- function(pkg = ".",
 
 build_site_local <- function(pkg = ".",
                        examples = TRUE,
+                       load_all = TRUE,
                        document = TRUE,
                        run_dont_run = FALSE,
                        seed = 1014,
@@ -358,6 +379,7 @@ build_site_local <- function(pkg = ".",
     lazy = lazy,
     document = document,
     examples = examples,
+    load_all = load_all,
     run_dont_run = run_dont_run,
     seed = seed,
     override = override,

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -90,7 +90,8 @@ deploy_local <- function(
   build_site(".",
     override = list(destination = dest_dir),
     document = FALSE,
-    preview = FALSE
+    preview = FALSE,
+    new_process = FALSE
   )
   github_push(dest_dir, commit_message)
 

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -6,8 +6,8 @@
 \title{Build reference section}
 \usage{
 build_reference(pkg = ".", lazy = TRUE, document = FALSE,
-  examples = TRUE, run_dont_run = FALSE, seed = 1014,
-  override = list(), preview = NA)
+  examples = TRUE, load_all = TRUE, run_dont_run = FALSE,
+  seed = 1014, override = list(), preview = NA)
 
 build_reference_index(pkg = ".")
 }
@@ -22,6 +22,10 @@ rapidly prototype. It is set to \code{FALSE} by \code{\link[=build_site]{build_s
 updating the site.}
 
 \item{examples}{Run examples?}
+
+\item{load_all}{If \code{TRUE}, will load development version of package using
+\code{\link[pkgload:load_all]{pkgload::load_all()}}; if \code{FALSE}, will load installed version of
+package using \code{\link[=library]{library()}}.}
 
 \item{run_dont_run}{Run examples that are surrounded in \\dontrun?}
 

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -4,14 +4,18 @@
 \alias{build_site}
 \title{Build a complete pkgdown website}
 \usage{
-build_site(pkg = ".", examples = TRUE, document = TRUE,
-  run_dont_run = FALSE, seed = 1014, lazy = FALSE,
+build_site(pkg = ".", examples = TRUE, load_all = !new_process,
+  document = TRUE, run_dont_run = FALSE, seed = 1014, lazy = FALSE,
   override = list(), preview = NA, new_process = TRUE)
 }
 \arguments{
 \item{pkg}{Path to package.}
 
 \item{examples}{Run examples?}
+
+\item{load_all}{If \code{TRUE}, will load development version of package using
+\code{\link[pkgload:load_all]{pkgload::load_all()}}; if \code{FALSE}, will load installed version of
+package using \code{\link[=library]{library()}}.}
 
 \item{document}{If \code{TRUE}, will run \code{\link[devtools:document]{devtools::document()}} before
 updating the site.}


### PR DESCRIPTION
This works, but I'm not sure about the interface — currently I'm installing only when you `build_site()` in a new process (otherwise there's no easy way to ensure you're using the new version of the package). This means that when called by itself, `build_articles()` will continue to use a previously installed version of the package. 

Maybe I should refactor to `build_reference()` to also work in a new process, and then `build_site()`, `build_reference()` and `build_articles()` would get an `install` argument? But that makes for an inconvenient interactive interface for `build_reference()` since a full install takes much longer than a `load_all()` (the current approach).

Fixes #749 
