### PR TITLE
Hide sidebar on mobile home pages.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown 1.2.0.9000
 
+* Fix sidebar hiding on mobile home pages (#913).
+
 * Restore accidentally removed `docsearch.css` file.
 
 # pkgdown 1.2.0

--- a/inst/templates/content-home.html
+++ b/inst/templates/content-home.html
@@ -3,7 +3,7 @@
 {{{index}}}
   </div>
 
-  <div class="col-md-3" id="sidebar">
+  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     {{#sidebar}}
     {{{.}}}
     {{/sidebar}}


### PR DESCRIPTION
Fixes #913