### PR TITLE
replace 'longer'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,7 +59,7 @@
 * Can now build sites for older packages that don't have a `Authors@R` field 
   (#727).
 
-* Remote urls ending in `.md` are no tweaked to end in `.html` (#763).
+* Remote urls ending in `.md` are no longer tweaked to end in `.html` (#763).
 
 * Bug report link is only shown if there's a "BugReports" field (#855).
 


### PR DESCRIPTION
'longer' was originally there: https://github.com/r-lib/pkgdown/commit/18e30a57aa7781808cb2cc18c6bae855201de9bb#diff-8312ad0561ef661716b48d09478362f3R3

but was then removed: https://github.com/r-lib/pkgdown/commit/169cb82716652f95b26660e505362e486d8dbebc#diff-8312ad0561ef661716b48d09478362f3R54