### PR TITLE
Pass params from deploy_site_github to build_site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Restore accidentally removed `docsearch.css` file.
 
+* `deploy_site_github()` now passes parameters to `build_site()` (@noamross, #922)
+
 # pkgdown 1.2.0
 
 ## New features

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -88,7 +88,7 @@ deploy_site_github <- function(
   cat_line("Setting private key permissions to 0600")
   fs::file_chmod(ssh_id_file, "0600")
 
-  deploy_local(pkg, repo_slug = repo_slug, commit_message = commit_message)
+  deploy_local(pkg, repo_slug = repo_slug, commit_message = commit_message, ...)
 
   rule("Deploy completed", line = 2)
 }
@@ -96,7 +96,8 @@ deploy_site_github <- function(
 deploy_local <- function(
                          pkg = ".",
                          repo_slug = NULL,
-                         commit_message = construct_commit_message(pkg)
+                         commit_message = construct_commit_message(pkg),
+                         ...
                          ) {
 
   dest_dir <- fs::dir_create(fs::file_temp())
@@ -112,7 +113,8 @@ deploy_local <- function(
   build_site(".",
     override = list(destination = dest_dir),
     document = FALSE,
-    preview = FALSE
+    preview = FALSE,
+    ...
   )
   github_push(dest_dir, commit_message)
 


### PR DESCRIPTION
This PR allows parameters to be passed from `deploy_site_github()` to `build_site()`, which is the documented behavior but is not implemented.