### PR TITLE
Use and fix replay_html.value, introduce repr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     processx,
     R6,
     rematch2,
+    repr,
     rlang (>= 0.2.0),
     rmarkdown (>= 1.1.9007),
     roxygen2,

--- a/R/rd-data.R
+++ b/R/rd-data.R
@@ -172,12 +172,16 @@ format_example_chunk <- function(code, run, show,
     return(highlight_text(code))
   }
 
+  # the default is to print values
+  oh <- evaluate::new_output_handler(value = function(x, visible) {
+    structure(list(value = x, visible = visible), class = 'value')
+  })
   withr::with_options(
     list(
       crayon.enabled = getOption("crayon.enabled", crayon::has_color()),
       crayon.colors = getOption("crayon.colors", crayon::num_colors())
     ),
-    expr <- evaluate::evaluate(code, env, new_device = TRUE)
+    expr <- evaluate::evaluate(code, env, output_handler = oh, new_device = TRUE)
   )
 
   if (show) {

--- a/R/replay-html.r
+++ b/R/replay-html.r
@@ -9,13 +9,17 @@ label_lines <- function(x, class = NULL, prompt = "#> ") {
   paste0(escape_html(prompt), lines)
 }
 
-label_output <- function(x, class = NULL, prompt = "#> ") {
-  lines <- label_lines(x, class = class, prompt = prompt)
+wrap_output <- function(lines) {
   paste0(
     "<div class='output co'>",
     paste0(lines, collapse = "\n"),
     "</div>"
   )
+}
+
+label_output <- function(x, class = NULL, prompt = "#> ") {
+  lines <- label_lines(x, class = class, prompt = prompt)
+  wrap_output(lines)
 }
 
 # Replay a list of evaluated results, just like you'd run them in a R
@@ -62,10 +66,15 @@ replay_html.character <- function(x, ...) {
 
 #' @export
 replay_html.value <- function(x, ...) {
-  if (!x$visible) return()
+  if (!x$visible) return("")
 
-  printed <- paste0(utils::capture.output(print(x$value)), collapse = "\n")
-  label_output(printed)
+  html <- repr::repr_html(x$value)
+  if (!is.null(html)) {
+    wrap_output(html)
+  } else {
+    text <- repr::repr_text(x$value)
+    label_output(if (is.null(text)) "" else text)
+  }
 }
 
 #' @export


### PR DESCRIPTION
We should add some CSS to style the `div.output.co` created in the examples.

`replay_html.value` was completely broken (but unused) since evaluate by default captures the textual output already.

Fixes #959