### PR TITLE
Reorder publication targets

### DIFF
--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -24,11 +24,11 @@ You can configure several aspects of your site. Once your finalized site is buil
 
 1. The `URL` field of your package `DESCRIPTION`, alongside a link to its source:
 
-1. [Twitter](https://twitter.com/dataandme/status/1004008257264988160), including the `#rstats` hash tag.
+    ```
+    URL: https://pkgdown.r-lib.org, https://github.com/r-lib/pkgdown
+    ```
 
-```
-URL: https://pkgdown.r-lib.org, https://github.com/r-lib/pkgdown
-```
+1. [Twitter](https://twitter.com/dataandme/status/1004008257264988160), including the `#rstats` hash tag.
 
 ## Configuration
 


### PR DESCRIPTION
`URL` belongs to the second enum item.