### PR TITLE
fix usage example development -> devel

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -79,7 +79,7 @@
 #'
 #' ```
 #' development:
-#'   mode: development
+#'   mode: devel
 #' ```
 #'
 #' You can also have pkgdown automatically detect the mode with:


### PR DESCRIPTION
this is just what appears to be a small typo in the usage example.

Using 

```
development:
  mode: development
```

as documented yields:

```
Error: development$mode` in `_pkgdown.yml must be one of auto, release, devel, or unreleaed
```

So it's gotta be `"devel"`.