### PR TITLE
Fixed malformed tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Optionally, opt of out of installation in `deploy_site_github()`
 
+* `\tabular{}` conversion better handles code (@mitchelloharawild, #978).
+
 # pkgdown 1.3.0
 
 * Restore accidentally deleted `build_logo()` function so that logos

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -273,13 +273,12 @@ as_html.tag_tabular <- function(x, ...) {
   col_sep <- class == "tag_tab"
   sep <- col_sep | row_sep
 
-  # Look for separators that have no text in front of them
-  no_text <- c(TRUE, class[-length(class)] != "TEXT")
-  keep <- !(sep & !no_text)
-  # data.frame(class, sep, no_text, keep)
-
-  cell_grp <- cumsum(keep)
-  cells <- unname(split(contents[keep], cell_grp[keep]))
+  # Identify groups in reverse order (preserve empty cells)
+  # Negative maintains correct ordering once reversed
+  cell_grp <- rev(cumsum(-rev(sep)))
+  cells <- unname(split(contents, cell_grp))
+  # Remove tailing content (that does not match the dimensions of the table)
+  cells <- cells[seq_len(length(cells) - length(cells)%%length(align))]
   cell_contents <- purrr::map_chr(cells, flatten_text, ...)
   cell_contents <- paste0("<td>", str_trim(cell_contents), "</td>")
   cell_contents <- matrix(cell_contents, ncol = length(align), byrow = TRUE)

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -86,6 +86,25 @@ test_that("can skip trailing \\cr", {
   )
 })
 
+test_that("code blocks in tables render (#978)", {
+  expect_equal(
+    rd2html('\\tabular{ll}{a \\tab \\code{b} \\cr foo \\tab bar}')[[2]],
+    "<tr><td>a</td><td><code>b</code></td></tr>"
+  )
+})
+
+test_that("tables with tailing \n (#978)", {
+  expect_equal(
+    rd2html('
+      \\tabular{ll}{
+        a   \\tab     \\cr
+        foo \\tab bar
+      }
+    ')[[2]],
+    "<tr><td>a</td><td></td></tr>"
+  )
+})
+
 # sexpr  ------------------------------------------------------------------
 
 test_that("code inside Sexpr is evaluated", {


### PR DESCRIPTION
- Tables with tailing TEXT (such as \n) now do not contain extra last rows
- Empty separator detection is row robust to other separators (such as \code{})

Resolves #928