### PR TITLE
Add matomo (piwik) tracking option

### DIFF
--- a/inst/templates/head.html
+++ b/inst/templates/head.html
@@ -84,3 +84,25 @@
   gtag('config', '{{.}}');
 </script>
 {{/ganalytics}}{{/yaml}}
+
+<!-- Matomo / Piwik -->
+{{#yaml}}{{#matomo}}
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//analytics.tadaa-data.de/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '{{.}}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="//analytics.tadaa-data.de/matomo.php?idsite={{.}}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code -->
+{{/matomo}}{{/yaml}}

--- a/inst/templates/head.html
+++ b/inst/templates/head.html
@@ -86,7 +86,7 @@
 {{/ganalytics}}{{/yaml}}
 
 <!-- Matomo / Piwik -->
-{{#yaml}}{{#matomo}}
+{{#yaml}}{{#matomo_siteid}}
 <!-- Matomo -->
 <script type="text/javascript">
   var _paq = window._paq || [];
@@ -96,13 +96,13 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//analytics.tadaa-data.de/";
+    var u="{{matomo_site}}/";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '{{.}}']);
+    _paq.push(['setSiteId', '{{matomo_siteid}}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src="//analytics.tadaa-data.de/matomo.php?idsite={{.}}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="{{matomo_site}}/matomo.php?idsite={{matomo_siteid}}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 <!-- End Matomo Code -->
-{{/matomo}}{{/yaml}}
+{{/matomo_siteid}}{{/yaml}}


### PR DESCRIPTION
Matomo tracking code is enabled via example `yaml`:

```yaml
template:
  params:
    matomo_siteid: 20
    matomo_site: "https://analytics.tadaa-data.de"
```

It would probably be preferrable if the `yaml` looked like this:

```yaml
template:
  params:
    matomo:
       siteid: 20
       site: "https://analytics.tadaa-data.de"
```

…or something to that effect, but this was my first time using whisker, and I already forgot most of what I knew about hugo templates, so I'm keeping this as it is for now and wait to see if this is a change someone is interested in.

On a side note: The site url seems to need to be specified with explicit protocol instead of the `//example.com` syntax. This is due to some other part in the rendering process seems to want to make relative URLs out of `//` prefixes – I haven't yet figured out how to fix that – but then again, defaulting to `https` isn't really a downside.