### PR TITLE
fix conflict in YAML param name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Badges can be extracted from the README paragraph coming after the comment `<!-- badges: start -->`, to build the "dev status" section of the sidebar (#670, @gaborcsardi, @maelle)
 
-* One can override the title of the homepage via a `title` field in the config (#957, @maelle).
+* One can override the title of the homepage via a `pagetitle` field in the config (#957 #1004, @maelle).
 
 * Links to external documentation now point to [rdrr.io](https://rdrr.io) (#998).
 

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -54,7 +54,7 @@ data_home <- function(pkg = ".") {
   pkg <- as_pkgdown(pkg)
 
   print_yaml(list(
-    pagetitle = pkg$meta[["title"]] %||% pkg$desc$get("Title")[[1]],
+    pagetitle = pkg$meta[["pagetitle"]] %||% pkg$desc$get("Title")[[1]],
     sidebar = data_home_sidebar(pkg),
     opengraph = list(description = pkg$desc$get("Description")[[1]])
   ))

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -57,11 +57,11 @@
 #'
 #' The homepage title that will be displayed in the browser tab,
 #' and in Twitter metadata, is by default the package title from
-#' `DESCRIPTION`. You can override it by adding a field called `title`
+#' `DESCRIPTION`. You can override it by adding a field called `pagetitle`
 #' to the `pkgdown` config:
 #'
 #' ```
-#' title: "Such a cool package"
+#' pagetitle: "Such a cool package"
 #' ```
 #'
 #' @section YAML config - authors:

--- a/R/build.r
+++ b/R/build.r
@@ -17,8 +17,8 @@
 #' [clean_site] first to clean up orphan files.
 #'
 #' @section YAML config:
-#' There are four top-level YAML settings that affect the entire site:
-#' `destination`, `url`, `title`, `template`, and `navbar`.
+#' There are five top-level YAML settings that affect the entire site:
+#' `destination`, `url`, `title`, `pagetitle`, `template`, and `navbar`.
 #'
 #' `destination` controls where the site will be generated. It defaults to
 #' `docs/` (for GitHub pages), but you can override if desired. Relative
@@ -38,6 +38,11 @@
 #'
 #' `title` overrides the default site title, which is the package name.
 #' It's used in the page title and default navbar.
+#'
+#' `pagetitle` overrides
+#' * the part the default homepage title before `title`, by default the
+#' package title from `DESCRIPTION`;
+#' * the title of the Twitter cards.
 #'
 #' You can also provided information to override the default display of
 #' the authors. Provided a list named with the name of each author,

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -75,8 +75,8 @@ You can remove the first heading with:\preformatted{home:
 
 The homepage title that will be displayed in the browser tab,
 and in Twitter metadata, is by default the package title from
-\code{DESCRIPTION}. You can override it by adding a field called \code{title}
-to the \code{pkgdown} config:\preformatted{title: "Such a cool package"
+\code{DESCRIPTION}. You can override it by adding a field called \code{pagetitle}
+to the \code{pkgdown} config:\preformatted{pagetitle: "Such a cool package"
 }
 }
 

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -53,8 +53,8 @@ Note if names of generated files were changed, you will need to use
 }
 \section{YAML config}{
 
-There are four top-level YAML settings that affect the entire site:
-\code{destination}, \code{url}, \code{title}, \code{template}, and \code{navbar}.
+There are five top-level YAML settings that affect the entire site:
+\code{destination}, \code{url}, \code{title}, \code{pagetitle}, \code{template}, and \code{navbar}.
 
 \code{destination} controls where the site will be generated. It defaults to
 \code{docs/} (for GitHub pages), but you can override if desired. Relative
@@ -73,6 +73,13 @@ rather than using generic links to \url{https://rdrr.io}.
 
 \code{title} overrides the default site title, which is the package name.
 It's used in the page title and default navbar.
+
+\code{pagetitle} overrides
+\itemize{
+\item the part the default homepage title before \code{title}, by default the
+package title from \code{DESCRIPTION};
+\item the title of the Twitter cards.
+}
 
 You can also provided information to override the default display of
 the authors. Provided a list named with the name of each author,

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -36,7 +36,7 @@ test_that("page title defaults to package title", {
 test_that("page title can be overridden", {
   pkg <- test_path("assets/home-index-rmd")
   pkg <- as_pkgdown(pkg)
-  pkg$meta <- list(title = "Such a cool package")
+  pkg$meta <- list(pagetitle = "Such a cool package")
 
   expect_equal(
     as.character(data_home(pkg))[[1]],


### PR DESCRIPTION
cf #1004 

My PR #997  was based on adding a YAML param called "title" which was a bad decision because there was already a documented role for a param called "title". I've renamed the parameter "pagetitle" which isn't necessarily a good choice either, what would be a clear name?

* "title" controls the title in the navbar and the part after "·" in each page title.
* "pagetitle"/bettername controls the title of Twitter cards, and the part before "·" in the homepage.

Sorry for breaking stuff in the first place. :wink: