### PR TITLE
Update dir_ls recursive arg to recurse

### DIFF
--- a/R/build-tutorials.R
+++ b/R/build-tutorials.R
@@ -95,7 +95,7 @@ find_tutorials <- function(path = ".") {
     stop("rsconnect package must be installed to scan for tutorials", call. = FALSE)
   }
 
-  rmds <- unname(dir_ls(path, recursive = TRUE, regexp = "\\.[Rr]md$"))
+  rmds <- unname(dir_ls(path, recurse = TRUE, regexp = "\\.[Rr]md$"))
   info <- purrr::map(rmds, tutorial_info, base_path = path)
   purrr::compact(info)
 }

--- a/R/link-article-index.R
+++ b/R/link-article-index.R
@@ -19,7 +19,7 @@ article_index_local <- function(package, path = find.package(package)) {
     return(character())
   }
 
-  vig_path <- dir_ls(src, regexp = "\\.[rR]md$", recursive = TRUE, type = "file")
+  vig_path <- dir_ls(src, regexp = "\\.[rR]md$", recurse = TRUE, type = "file")
 
   out_path <- gsub("\\.[rR]md$", ".html", path_rel(vig_path, start = path_real(src)))
   vig_name <- gsub("\\.[rR]md$", "", path_file(vig_path))

--- a/R/package.r
+++ b/R/package.r
@@ -191,7 +191,7 @@ package_vignettes <- function(path = ".") {
   if (!dir_exists(base)) {
     vig_path <- character()
   } else {
-    vig_path <- dir_ls(base, regexp = "\\.[rR]md$", recursive = TRUE)
+    vig_path <- dir_ls(base, regexp = "\\.[rR]md$", recurse = TRUE)
   }
   vig_path <- path_rel(vig_path, base)
   vig_path <- vig_path[!grepl("^_", path_file(vig_path))]

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -4,7 +4,7 @@ dir_copy_to <- function(pkg, from, to, overwrite = TRUE) {
     path_abs(path_rel(path, start = from), start = to)
   }
 
-  contents <- dir_ls(from, recursive = TRUE)
+  contents <- dir_ls(from, recurse = TRUE)
   is_dir <- fs::is_dir(contents)
 
   # First create directories

--- a/tests/testthat/test-build_article.R
+++ b/tests/testthat/test-build_article.R
@@ -12,7 +12,7 @@ test_that("render_rmarkdown copies image files in subdirectories", {
     )
   )
   expect_equal(
-    path_rel(dir_ls(tmp, type = "file", recursive = TRUE), tmp),
+    path_rel(dir_ls(tmp, type = "file", recurse = TRUE), tmp),
     c(
       "assets/articles/open-graph/logo.png",
       "assets/articles/vignette-with-img.html"

--- a/tests/testthat/test-figure.R
+++ b/tests/testthat/test-figure.R
@@ -11,6 +11,6 @@ test_that("can override defaults in _pkgdown.yml", {
   expect_setequal(img, c("figure-1.jpg", "figure-2.jpg"))
 
   expect_output(build_articles(figure))
-  img <- path_file(dir_ls(path(figure, "docs", "articles"), glob = "*.jpg", recursive = TRUE))
+  img <- path_file(dir_ls(path(figure, "docs", "articles"), glob = "*.jpg", recurse = TRUE))
   expect_equal(img, "unnamed-chunk-1-1.jpg")
 })


### PR DESCRIPTION
Breaking change in fs 1.3.0, see https://fs.r-lib.org/news/index.html

This change will be invisible to end users, should I add a bullet point to the changelog nonetheless?