### PR TITLE
improve deploy doc

### DIFF
--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -7,42 +7,45 @@
 #' details on setting up your repository to use this.
 #'
 #' @section Setup:
-#' Add the following to your `.travis.yml` file.
+#' For a quick setup, you can use [usethis::use_pkgdown_travis()]. It  will help you
+#' with the following detailed steps.
 #'
-#' ```
-#' before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
-#' deploy:
-#'   provider: script
-#'   script: Rscript -e 'pkgdown::deploy_site_github()'
-#'   skip_cleanup: true
-#' ```
+#' * Add the following to your `.travis.yml` file.
 #'
-#' Then you will need to setup your deployment keys. The easiest way is to call
+#'     ```
+#'     before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
+#'     deploy:
+#'       provider: script
+#'       script: Rscript -e 'pkgdown::deploy_site_github()'
+#'       skip_cleanup: true
+#'     ```
+#'
+#' * Then you will need to setup your deployment keys. The easiest way is to call
 #' `travis::use_travis_deploy()`. This will generate and push the necessary
 #' keys to your GitHub and Travis accounts. See the [travis package
 #' website](https://ropenscilabs.github.io/travis/) for more details.
 #'
-#' Next, make sure that a gh-pages branch exists. The simplest way to do
+#' * Next, make sure that a gh-pages branch exists. The simplest way to do
 #' so is to run the following git commands locally:
 #'
-#' ```
-#' git checkout --orphan gh-pages
-#' git rm -rf .
-#' git commit --allow-empty -m 'Initial gh-pages commit'
-#' git push origin gh-pages
-#' git checkout master
-#' ```
+#'     ```
+#'     git checkout --orphan gh-pages
+#'     git rm -rf .
+#'     git commit --allow-empty -m 'Initial gh-pages commit'
+#'     git push origin gh-pages
+#'     git checkout master
+#'     ```
 #'
-#' We recommend doing this outside of RStudio (with the project closed) as
-#' from RStudio's perspective you end up deleting all the files and then
-#' re-creating them.
+#'     We recommend doing this outside of RStudio (with the project closed) as
+#'     from RStudio's perspective you end up deleting all the files and then
+#'     re-creating them.
 #'
-#' If you're using a custom CNAME, make sure you have set the `url` in
+#' *  If you're using a custom CNAME, make sure you have set the `url` in
 #' `_pkgdown.yaml`:
 #'
-#' ```yaml
-#' url: http://pkgdown.r-lib.org
-#' ```
+#'    ```yaml
+#'    url: http://pkgdown.r-lib.org
+#'    ```
 #'
 #' @inheritParams build_site
 #' @param install Optionally, opt-out of automatic installation. This is

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -10,7 +10,7 @@
 #' Add the following to your `.travis.yml` file.
 #'
 #' ```
-#' before_deploy: Rscript -e 'remotes::install_cran("pkgdown")'
+#' before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
 #' deploy:
 #'   provider: script
 #'   script: Rscript -e 'pkgdown::deploy_site_github()'

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -41,18 +41,19 @@ details on setting up your repository to use this.
 }
 \section{Setup}{
 
-Add the following to your \code{.travis.yml} file.\preformatted{before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
+For a quick setup, you can use \code{\link[usethis:use_pkgdown_travis]{usethis::use_pkgdown_travis()}}. It  will help you
+with the following detailed steps.
+\itemize{
+\item Add the following to your \code{.travis.yml} file.\preformatted{before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
 deploy:
   provider: script
   script: Rscript -e 'pkgdown::deploy_site_github()'
   skip_cleanup: true
 }
-
-Then you will need to setup your deployment keys. The easiest way is to call
+\item Then you will need to setup your deployment keys. The easiest way is to call
 \code{travis::use_travis_deploy()}. This will generate and push the necessary
 keys to your GitHub and Travis accounts. See the \href{https://ropenscilabs.github.io/travis/}{travis package website} for more details.
-
-Next, make sure that a gh-pages branch exists. The simplest way to do
+\item Next, make sure that a gh-pages branch exists. The simplest way to do
 so is to run the following git commands locally:\preformatted{git checkout --orphan gh-pages
 git rm -rf .
 git commit --allow-empty -m 'Initial gh-pages commit'
@@ -63,9 +64,9 @@ git checkout master
 We recommend doing this outside of RStudio (with the project closed) as
 from RStudio's perspective you end up deleting all the files and then
 re-creating them.
-
-If you're using a custom CNAME, make sure you have set the \code{url} in
+\item If you're using a custom CNAME, make sure you have set the \code{url} in
 \code{_pkgdown.yaml}:\preformatted{url: http://pkgdown.r-lib.org
+}
 }
 }
 

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -41,7 +41,7 @@ details on setting up your repository to use this.
 }
 \section{Setup}{
 
-Add the following to your \code{.travis.yml} file.\preformatted{before_deploy: Rscript -e 'remotes::install_cran("pkgdown")'
+Add the following to your \code{.travis.yml} file.\preformatted{before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
 deploy:
   provider: script
   script: Rscript -e 'pkgdown::deploy_site_github()'


### PR DESCRIPTION
This closes #1021 and possibly #994 

Two improvements suggested, easily reversible

* use `before_cache` instead of `before_deploy` as [adviced](https://github.com/r-lib/usethis/issues/747#issuecomment-489772348)

* Suggest to use `usethis::use_pkgdown_travis()` for a quick setup to help with the step describe

Another choice could be to rewrite this doc to guide as first choice to `usethis::use_pkgdown_travis()` for setup and detail the step to configure here or there.