### PR TITLE
Add 'devel' parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgdown
 Title: Make Static HTML Documentation for a Package
-Version: 1.3.0.9000
+Version: 1.3.0.9100
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre"), 
       comment = c(ORCID = "0000-0003-4757-117X")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pkgdown 1.3.0.9000 (development version)
 
-* `build_site()`, `build_reference()` and `build_home()` gains a parameter `devel` which can be set to `FALSE` to disable redocumenting and reloading the package, and knitting of home `Rmd` file. This generalises and replaces (with deprecation) the existing `document` argument.
+* `build_site()`, `build_reference()` and `build_home()` gain a parameter `devel` which can be set to `FALSE` to disable redocumenting and reloading the package, and knitting of home `Rmd` file. This generalises and replaces (with deprecation) the existing `document` argument.
 
 * The sticky behavior of the navbar is now implemented in pure CSS instead of relying on the 3rd party javascript library (#1016, @bisaloo)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 # pkgdown 1.3.0.9000 (development version)
 
+* `build_site()` gains a parameter `devel` which can be set to `FALSE` to disable redocumenting and reloading the package, and knitting of home `Rmd` file.
+
 * The sticky behavior of the navbar is now implemented in pure CSS instead of relying on the 3rd party javascript library (#1016, @bisaloo)
 
 * Allow setting hard timeout for build_site(new_process = TRUE) via options('pkgdown.timeout'). 
   Thereby stalled builds in a cron job can get killed automatically, preventing the
   process from hanging indefinitely.
-
-* Function `build_site()` now defaults to `document = FALSE`
 
 * Badges can be extracted from the README paragraph coming after the comment `<!-- badges: start -->`, to build the "dev status" section of the sidebar (#670, @gaborcsardi, @maelle)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pkgdown 1.3.0.9000 (development version)
 
-* `build_site()` gains a parameter `devel` which can be set to `FALSE` to disable redocumenting and reloading the package, and knitting of home `Rmd` file.
+* `build_site()`, `build_reference()` and `build_home()` gains a parameter `devel` which can be set to `FALSE` to disable redocumenting and reloading the package, and knitting of home `Rmd` file. This generalises and replaces (with deprecation) the existing `document` argument.
 
 * The sticky behavior of the navbar is now implemented in pure CSS instead of relying on the 3rd party javascript library (#1016, @bisaloo)
 

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -1,12 +1,17 @@
-build_home_index <- function(pkg = ".", quiet = TRUE) {
+build_home_index <- function(pkg = ".", quiet = TRUE, knit = TRUE) {
   pkg <- as_pkgdown(pkg)
 
   scoped_package_context(pkg$package, pkg$topic_index, pkg$article_index)
   scoped_file_context(depth = 0L)
 
+  # When knit = FALSE, prefer pre-rendered md file if exists
   src_path <- path_first_existing(
     pkg$src_path,
-    c("index.Rmd", "README.Rmd", "index.md", "README.md")
+    if(knit){
+      c("index.Rmd", "README.Rmd", "index.md", "README.md")
+    } else {
+      c("index.md", "README.md","index.Rmd", "README.Rmd")
+    }
   )
   dst_path <- path(pkg$dst_path, "index.html")
   data <- data_home(pkg)
@@ -17,7 +22,7 @@ build_home_index <- function(pkg = ".", quiet = TRUE) {
   } else {
     file_ext <- path_ext(src_path)
 
-    if (file_ext == "md") {
+    if (file_ext == "md" || (!knit && file_ext == "Rmd")) {
       data$index <- markdown(src_path)
       render_page(pkg, "home", data, "index.html")
     } else if (file_ext == "Rmd") {

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -7,7 +7,7 @@ build_home_index <- function(pkg = ".", quiet = TRUE, knit = TRUE) {
   # When knit = FALSE, prefer pre-rendered md file if exists
   src_path <- path_first_existing(
     pkg$src_path,
-    if(knit){
+    if (knit){
       c("index.Rmd", "README.Rmd", "index.md", "README.md")
     } else {
       c("index.md", "README.md","index.Rmd", "README.Rmd")

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -88,13 +88,16 @@
 #'   only contains images.
 #'
 #' @inheritParams build_articles
-#' @param knit if FALSE, do not knit `Rmd` files but render as plain markdown.
+#' @param devel If `TRUE`, assumes you are doing active development, and
+#'   re-knits all `.Rmd` files. If `FALSE`, assumes Rmarkdown files have
+#'   already rendered to `.md`, falling back to rendering as plain markdown
+#'   if they have not.
 #' @export
 build_home <- function(pkg = ".",
                        override = list(),
                        preview = NA,
                        quiet = TRUE,
-                       knit = TRUE) {
+                       devel = TRUE) {
 
   pkg <- section_init(pkg, depth = 0L, override = override)
   rule("Building home")
@@ -107,7 +110,7 @@ build_home <- function(pkg = ".",
   }
   build_home_md(pkg)
   build_home_license(pkg)
-  build_home_index(pkg, quiet = quiet, knit = knit)
+  build_home_index(pkg, quiet = quiet, knit = devel)
 
   preview_site(pkg, "/", preview = preview)
 }

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -88,11 +88,13 @@
 #'   only contains images.
 #'
 #' @inheritParams build_articles
+#' @param knit if FALSE, do not knit `Rmd` files but render as plain markdown.
 #' @export
 build_home <- function(pkg = ".",
                        override = list(),
                        preview = NA,
-                       quiet = TRUE) {
+                       quiet = TRUE,
+                       knit = TRUE) {
 
   pkg <- section_init(pkg, depth = 0L, override = override)
   rule("Building home")
@@ -105,7 +107,7 @@ build_home <- function(pkg = ".",
   }
   build_home_md(pkg)
   build_home_license(pkg)
-  build_home_index(pkg, quiet = quiet)
+  build_home_index(pkg, quiet = quiet, knit = knit)
 
   preview_site(pkg, "/", preview = preview)
 }

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -83,29 +83,35 @@
 #' @param lazy If `TRUE`, only rebuild pages where the `.Rd`
 #'   is more recent than the `.html`. This makes it much easier to
 #'   rapidly prototype. It is set to `FALSE` by [build_site()].
-#' @param document If `TRUE`, will run [devtools::document()] before
-#'   updating the site.
 #' @param run_dont_run Run examples that are surrounded in \\dontrun?
 #' @param examples Run examples?
 #' @param seed Seed used to initialize so that random examples are
 #'   reproducible.
-#' @param devel if `FALSE`, uses the installed package version and does not re-
-#'   generate documentation and  `README.md` from `README.Rmd`.
+#' @param devel If `TRUE` (the default), assumes you are in a live development
+#'   environment, so automatically runs [devtools::document()] and loads
+#'   package with [devtools::load_all()]. If `FALSE`, does not re-document,
+#'   and uses the installed version of the package for examples.
+#' @param document **Deprecated** Use `devel` instead.
 #' @export
 build_reference <- function(pkg = ".",
                             lazy = TRUE,
-                            document = FALSE,
                             examples = TRUE,
                             run_dont_run = FALSE,
                             seed = 1014,
                             override = list(),
                             preview = NA,
-                            devel = TRUE
+                            devel = TRUE,
+                            document = "DEPRECATED"
                             ) {
   pkg <- section_init(pkg, depth = 1L, override = override)
 
+  if (!missing(document)) {
+    warning("`document` is deprecated. Please use `devel` instead.", call. = FALSE)
+    devel <- !document
+  }
+
   rule("Building function reference")
-  if (document && (pkg$package != "pkgdown") && is_installed("devtools")) {
+  if (devel && (pkg$package != "pkgdown") && is_installed("devtools")) {
     devtools::document(pkg$src_path)
   }
 

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -89,6 +89,8 @@
 #' @param examples Run examples?
 #' @param seed Seed used to initialize so that random examples are
 #'   reproducible.
+#' @param devel if `FALSE`, uses the installed package version and does not re-
+#'   generate documentation and  `README.md` from `README.Rmd`.
 #' @export
 build_reference <- function(pkg = ".",
                             lazy = TRUE,
@@ -97,7 +99,8 @@ build_reference <- function(pkg = ".",
                             run_dont_run = FALSE,
                             seed = 1014,
                             override = list(),
-                            preview = NA
+                            preview = NA,
+                            devel = TRUE
                             ) {
   pkg <- section_init(pkg, depth = 1L, override = override)
 
@@ -118,7 +121,7 @@ build_reference <- function(pkg = ".",
   if (examples) {
     # Re-loading pkgdown while it's running causes weird behaviour with
     # the context cache
-    if (!(pkg$package %in% c("pkgdown", "rprojroot"))) {
+    if (isTRUE(devel) && !(pkg$package %in% c("pkgdown", "rprojroot"))) {
       pkgload::load_all(pkg$src_path, export_all = FALSE, helpers = FALSE)
     } else {
       library(pkg$package, character.only = TRUE)

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -107,7 +107,7 @@ build_reference <- function(pkg = ".",
 
   if (!missing(document)) {
     warning("`document` is deprecated. Please use `devel` instead.", call. = FALSE)
-    devel <- !document
+    devel <- document
   }
 
   rule("Building function reference")

--- a/R/build.r
+++ b/R/build.r
@@ -264,13 +264,14 @@
 #' }
 build_site <- function(pkg = ".",
                        examples = TRUE,
-                       document = FALSE,
+                       document = devel,
                        run_dont_run = FALSE,
                        seed = 1014,
                        lazy = FALSE,
                        override = list(),
                        preview = NA,
-                       new_process = TRUE) {
+                       new_process = TRUE,
+                       devel = TRUE) {
 
   if (new_process) {
     build_site_external(
@@ -281,7 +282,8 @@ build_site <- function(pkg = ".",
       seed = seed,
       lazy = lazy,
       override = override,
-      preview = preview
+      preview = preview,
+      devel = devel
     )
   } else {
     build_site_local(
@@ -292,7 +294,8 @@ build_site <- function(pkg = ".",
       seed = seed,
       lazy = lazy,
       override = override,
-      preview = preview
+      preview = preview,
+      devel = devel
     )
   }
 }
@@ -304,7 +307,8 @@ build_site_external <- function(pkg = ".",
                                 seed = 1014,
                                 lazy = FALSE,
                                 override = list(),
-                                preview = NA) {
+                                preview = NA,
+                                devel = TRUE) {
   args <- list(
     pkg = pkg,
     examples = examples,
@@ -315,6 +319,7 @@ build_site_external <- function(pkg = ".",
     override = override,
     preview = FALSE,
     new_process = FALSE,
+    devel = devel,
     crayon_enabled = crayon::has_color(),
     crayon_colors = crayon::num_colors(),
     pkgdown_internet = has_internet()
@@ -344,7 +349,8 @@ build_site_local <- function(pkg = ".",
                        seed = 1014,
                        lazy = FALSE,
                        override = list(),
-                       preview = NA
+                       preview = NA,
+                       devel = TRUE
                        ) {
 
   pkg <- section_init(pkg, depth = 0, override = override)
@@ -355,7 +361,7 @@ build_site_local <- function(pkg = ".",
 
   init_site(pkg)
 
-  build_home(pkg, override = override, preview = FALSE)
+  build_home(pkg, override = override, preview = FALSE, knit = devel)
   build_reference(pkg,
     lazy = lazy,
     document = document,
@@ -363,7 +369,8 @@ build_site_local <- function(pkg = ".",
     run_dont_run = run_dont_run,
     seed = seed,
     override = override,
-    preview = FALSE
+    preview = FALSE,
+    devel = devel
   )
   build_articles(pkg, lazy = lazy, override = override, preview = FALSE)
   build_tutorials(pkg, override = override, preview = FALSE)

--- a/R/build.r
+++ b/R/build.r
@@ -264,20 +264,24 @@
 #' }
 build_site <- function(pkg = ".",
                        examples = TRUE,
-                       document = devel,
                        run_dont_run = FALSE,
                        seed = 1014,
                        lazy = FALSE,
                        override = list(),
                        preview = NA,
                        new_process = TRUE,
-                       devel = TRUE) {
+                       devel = TRUE,
+                       document = "DEPRECATED") {
+
+  if (!missing(document)) {
+    warning("`document` is deprecated. Please use `devel` instead.", call. = FALSE)
+    devel <- !document
+  }
 
   if (new_process) {
     build_site_external(
       pkg = pkg,
       examples = examples,
-      document = document,
       run_dont_run = run_dont_run,
       seed = seed,
       lazy = lazy,
@@ -289,7 +293,6 @@ build_site <- function(pkg = ".",
     build_site_local(
       pkg = pkg,
       examples = examples,
-      document = document,
       run_dont_run = run_dont_run,
       seed = seed,
       lazy = lazy,
@@ -302,7 +305,6 @@ build_site <- function(pkg = ".",
 
 build_site_external <- function(pkg = ".",
                                 examples = TRUE,
-                                document = FALSE,
                                 run_dont_run = FALSE,
                                 seed = 1014,
                                 lazy = FALSE,
@@ -312,7 +314,6 @@ build_site_external <- function(pkg = ".",
   args <- list(
     pkg = pkg,
     examples = examples,
-    document = document,
     run_dont_run = run_dont_run,
     seed = seed,
     lazy = lazy,
@@ -344,7 +345,6 @@ build_site_external <- function(pkg = ".",
 
 build_site_local <- function(pkg = ".",
                        examples = TRUE,
-                       document = FALSE,
                        run_dont_run = FALSE,
                        seed = 1014,
                        lazy = FALSE,
@@ -361,10 +361,9 @@ build_site_local <- function(pkg = ".",
 
   init_site(pkg)
 
-  build_home(pkg, override = override, preview = FALSE, knit = devel)
+  build_home(pkg, override = override, preview = FALSE, devel = devel)
   build_reference(pkg,
     lazy = lazy,
-    document = document,
     examples = examples,
     run_dont_run = run_dont_run,
     seed = seed,

--- a/R/build.r
+++ b/R/build.r
@@ -275,7 +275,7 @@ build_site <- function(pkg = ".",
 
   if (!missing(document)) {
     warning("`document` is deprecated. Please use `devel` instead.", call. = FALSE)
-    devel <- !document
+    devel <- document
   }
 
   if (new_process) {

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -120,7 +120,7 @@ deploy_local <- function(
   github_clone(dest_dir, repo_slug)
   build_site(".",
     override = list(destination = dest_dir),
-    document = FALSE,
+    devel = FALSE,
     preview = FALSE,
     ...
   )

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -5,7 +5,7 @@
 \title{Build home section}
 \usage{
 build_home(pkg = ".", override = list(), preview = NA,
-  quiet = TRUE, knit = TRUE)
+  quiet = TRUE, devel = TRUE)
 }
 \arguments{
 \item{pkg}{Path to package.}
@@ -19,7 +19,10 @@ freshly generated section in browser.}
 \item{quiet}{Set to \code{FALSE} to display output of knitr and
 pandoc. This is useful when debugging.}
 
-\item{knit}{if FALSE, do not knit \code{Rmd} files but render as plain markdown.}
+\item{devel}{If \code{TRUE}, assumes you are doing active development, and
+re-knits all \code{.Rmd} files. If \code{FALSE}, assumes Rmarkdown files have
+already rendered to \code{.md}, falling back to rendering as plain markdown
+if they have not.}
 }
 \description{
 This function is responsible for building \code{.md} (or \code{.Rmd}) files typically

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -5,7 +5,7 @@
 \title{Build home section}
 \usage{
 build_home(pkg = ".", override = list(), preview = NA,
-  quiet = TRUE)
+  quiet = TRUE, knit = TRUE)
 }
 \arguments{
 \item{pkg}{Path to package.}
@@ -18,6 +18,8 @@ freshly generated section in browser.}
 
 \item{quiet}{Set to \code{FALSE} to display output of knitr and
 pandoc. This is useful when debugging.}
+
+\item{knit}{if FALSE, do not knit \code{Rmd} files but render as plain markdown.}
 }
 \description{
 This function is responsible for building \code{.md} (or \code{.Rmd}) files typically

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -7,7 +7,7 @@
 \usage{
 build_reference(pkg = ".", lazy = TRUE, document = FALSE,
   examples = TRUE, run_dont_run = FALSE, seed = 1014,
-  override = list(), preview = NA)
+  override = list(), preview = NA, devel = TRUE)
 
 build_reference_index(pkg = ".")
 }
@@ -33,6 +33,9 @@ values in \code{_pkgdown.yml}}
 
 \item{preview}{If \code{TRUE}, or \code{is.na(preview) && interactive()}, will preview
 freshly generated section in browser.}
+
+\item{devel}{if \code{FALSE}, uses the installed package version and does not re-
+generate documentation and  \code{README.md} from \code{README.Rmd}.}
 }
 \description{
 By default, pkgdown will generate an index that lists all functions in

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -5,9 +5,9 @@
 \alias{build_reference_index}
 \title{Build reference section}
 \usage{
-build_reference(pkg = ".", lazy = TRUE, document = FALSE,
-  examples = TRUE, run_dont_run = FALSE, seed = 1014,
-  override = list(), preview = NA, devel = TRUE)
+build_reference(pkg = ".", lazy = TRUE, examples = TRUE,
+  run_dont_run = FALSE, seed = 1014, override = list(),
+  preview = NA, devel = TRUE, document = "DEPRECATED")
 
 build_reference_index(pkg = ".")
 }
@@ -17,9 +17,6 @@ build_reference_index(pkg = ".")
 \item{lazy}{If \code{TRUE}, only rebuild pages where the \code{.Rd}
 is more recent than the \code{.html}. This makes it much easier to
 rapidly prototype. It is set to \code{FALSE} by \code{\link[=build_site]{build_site()}}.}
-
-\item{document}{If \code{TRUE}, will run \code{\link[devtools:document]{devtools::document()}} before
-updating the site.}
 
 \item{examples}{Run examples?}
 
@@ -34,8 +31,12 @@ values in \code{_pkgdown.yml}}
 \item{preview}{If \code{TRUE}, or \code{is.na(preview) && interactive()}, will preview
 freshly generated section in browser.}
 
-\item{devel}{if \code{FALSE}, uses the installed package version and does not re-
-generate documentation and  \code{README.md} from \code{README.Rmd}.}
+\item{devel}{If \code{TRUE} (the default), assumes you are in a live development
+environment, so automatically runs \code{\link[devtools:document]{devtools::document()}} and loads
+package with \code{\link[devtools:load_all]{devtools::load_all()}}. If \code{FALSE}, does not re-document,
+and uses the installed version of the package for examples.}
+
+\item{document}{\strong{Deprecated} Use \code{devel} instead.}
 }
 \description{
 By default, pkgdown will generate an index that lists all functions in

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -4,18 +4,14 @@
 \alias{build_site}
 \title{Build a complete pkgdown website}
 \usage{
-build_site(pkg = ".", examples = TRUE, document = devel,
-  run_dont_run = FALSE, seed = 1014, lazy = FALSE,
-  override = list(), preview = NA, new_process = TRUE,
-  devel = TRUE)
+build_site(pkg = ".", examples = TRUE, run_dont_run = FALSE,
+  seed = 1014, lazy = FALSE, override = list(), preview = NA,
+  new_process = TRUE, devel = TRUE, document = "DEPRECATED")
 }
 \arguments{
 \item{pkg}{Path to package.}
 
 \item{examples}{Run examples?}
-
-\item{document}{If \code{TRUE}, will run \code{\link[devtools:document]{devtools::document()}} before
-updating the site.}
 
 \item{run_dont_run}{Run examples that are surrounded in \\dontrun?}
 
@@ -35,8 +31,12 @@ freshly generated section in browser.}
 This enhances reproducibility by ensuring nothing that you have loaded
 in the current process affects the build process.}
 
-\item{devel}{if \code{FALSE}, uses the installed package version and does not re-
-generate documentation and  \code{README.md} from \code{README.Rmd}.}
+\item{devel}{If \code{TRUE} (the default), assumes you are in a live development
+environment, so automatically runs \code{\link[devtools:document]{devtools::document()}} and loads
+package with \code{\link[devtools:load_all]{devtools::load_all()}}. If \code{FALSE}, does not re-document,
+and uses the installed version of the package for examples.}
+
+\item{document}{\strong{Deprecated} Use \code{devel} instead.}
 }
 \description{
 \code{build_site()} is a convenient wrapper around six functions:

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -4,9 +4,10 @@
 \alias{build_site}
 \title{Build a complete pkgdown website}
 \usage{
-build_site(pkg = ".", examples = TRUE, document = FALSE,
+build_site(pkg = ".", examples = TRUE, document = devel,
   run_dont_run = FALSE, seed = 1014, lazy = FALSE,
-  override = list(), preview = NA, new_process = TRUE)
+  override = list(), preview = NA, new_process = TRUE,
+  devel = TRUE)
 }
 \arguments{
 \item{pkg}{Path to package.}
@@ -33,6 +34,9 @@ freshly generated section in browser.}
 \item{new_process}{If \code{TRUE}, will run \code{build_site()} in a separate process.
 This enhances reproducibility by ensuring nothing that you have loaded
 in the current process affects the build process.}
+
+\item{devel}{if \code{FALSE}, uses the installed package version and does not re-
+generate documentation and  \code{README.md} from \code{README.Rmd}.}
 }
 \description{
 \code{build_site()} is a convenient wrapper around six functions:

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -9,19 +9,19 @@ test_that("intermediate files cleaned up automatically", {
   expect_output(build_home(pkg))
   on.exit(clean_site(pkg))
 
-  expect_equal(sort(dir(pkg)), sort(c("docs", "DESCRIPTION", "index.Rmd")))
+  expect_setequal(dir(pkg), c("docs", "DESCRIPTION", "index.Rmd"))
 })
 
 test_that("intermediate files cleaned up automatically", {
   skip_if_no_pandoc()
 
   pkg <- test_path("assets/home-readme-rmd")
-  expect_output(build_site(pkg, document = TRUE))
+  expect_output(build_home(pkg))
   on.exit(clean_site(pkg))
 
   expect_setequal(
     dir(pkg),
-    c("docs", "man", "NAMESPACE", "DESCRIPTION", "README.md", "README.Rmd")
+    c("docs", "NAMESPACE", "DESCRIPTION", "README.md", "README.Rmd")
   )
 })
 

--- a/tests/testthat/test-figure.R
+++ b/tests/testthat/test-figure.R
@@ -6,7 +6,9 @@ test_that("can override defaults in _pkgdown.yml", {
   figure <- test_path("assets/figure")
   on.exit(clean_site(figure))
 
-  expect_output(build_reference(figure))
+  callr::rcmd("INSTALL", figure, show = FALSE, fail_on_status = TRUE)
+
+  expect_output(build_reference(figure, devel = FALSE))
   img <- path_file(dir_ls(path(figure, "docs", "reference"), glob = "*.jpg"))
   expect_setequal(img, c("figure-1.jpg", "figure-2.jpg"))
 


### PR DESCRIPTION
Rework as [discussed in #1020](https://github.com/r-lib/pkgdown/pull/1020#issuecomment-492212317). 

Hadley said: I think this should optional, and controlled by an argument that also controls whether or not document() is run — i.e. we need something like development = FALSE which would:

 - in build_site(), error if the package is not installed
 - in build_reference(), skip document() and use library() instead of pkgload
 - in build_home(), never rebuild README.md from README.Rmd