### PR TITLE
Increase flexibility of news title matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown 1.3.0.9000 (development version)
 
+* News page recognises more version specfications (including the 
+  "(development version)" now used by usethis) (#980).
+
 * `build_home()` now looks for license files spelled either as LICENSE or 
   LICENCE (#972).
 

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -94,12 +94,12 @@ build_news_single <- function(pkg) {
 
 build_news_multi <- function(pkg) {
   news <- data_news(pkg)
-  major <- factor(news$major_dev, levels = unique(news$major_dev))
+  page <- factor(news$page, levels = unique(news$page))
 
   news_paged <- tibble::tibble(
-    version = levels(major),
+    version = levels(page),
     file_out = paste0("news-", version, ".html"),
-    contents = news[c("html", "version", "anchor")] %>% split(major)
+    contents = news[c("html", "version", "anchor")] %>% split(page)
   )
 
   render_news <- function(version, file_out, contents) {
@@ -138,43 +138,64 @@ data_news <- function(pkg = ".") {
   titles <- sections %>%
     xml2::xml_find_first(".//h1|h2") %>%
     xml2::xml_text(trim = TRUE)
+  anchors <- sections %>% xml2::xml_attr("id")
 
   if (any(is.na(titles))) {
     stop("Invalid NEWS.md: bad nesting of titles", call. = FALSE)
   }
 
-  anchors <- sections %>%
-    xml2::xml_attr("id")
-
-  re <- regexec("^([[:alnum:],\\.]+)\\s+((\\d+[.-]\\d+)(?:[.-]\\d+)*)", titles)
-  pieces <- regmatches(titles, re)
-
-  # Only keep sections with unambiguous version
-  is_version <- purrr::map_int(pieces, length) == 4
-  pieces <- pieces[is_version]
-  sections <- sections[is_version]
-  anchors <- anchors[is_version]
-
-  major <- purrr::map_chr(pieces, 4)
-  version <- purrr::map_chr(pieces, 3)
+  versions <- news_version(titles)
+  sections <- sections[!is.na(versions)]
+  anchors <- anchors[!is.na(versions)]
+  versions <- versions[!is.na(versions)]
 
   timeline <- pkg_timeline(pkg$package)
   html <- sections %>%
     purrr::walk(tweak_code) %>%
-    purrr::walk2(version, tweak_news_heading, timeline = timeline) %>%
+    purrr::walk2(versions, tweak_news_heading, timeline = timeline) %>%
     purrr::map_chr(as.character) %>%
     purrr::map_chr(add_github_links, pkg = pkg)
 
   news <- tibble::tibble(
-    version = version,
-    is_dev = is_dev(version),
-    major = major,
-    major_dev = ifelse(is_dev, "unreleased", major),
+    version = versions,
+    page = purrr::map_chr(versions, version_page),
     anchor = anchors,
     html = html
   )
 
   news
+}
+
+news_version <- function(x) {
+  pattern <- "(?x)
+    ^([[:alnum:],\\.]+)\\s+             # alpha-numeric package name
+    (
+      (?:                               # version specification
+        v?                              # optional v
+        (?:\\d+[.-]\\d+)(?:[.-]\\d+)*   # followed by digits, dots and dashes
+      )|                                # OR
+      (?:\\(development\\ version\\))   # literal used by usethis
+    )
+  "
+  re <- regexec(pattern, x, perl = TRUE)
+  pieces <- regmatches(x, re)
+
+  versions <- purrr::map_chr(pieces, 3, .default = NA)
+  gsub("^[v(]|[)]$", "", versions)
+}
+
+version_page <- function(x) {
+  if (x == "development version") {
+    return("dev")
+  }
+
+  ver <- unclass(package_version(x))[[1]]
+
+  if (length(ver) == 4 && ver[[4]] > 0) {
+    "dev"
+  } else {
+    paste0(ver[[1]], ".", ver[[2]])
+  }
 }
 
 navbar_news <- function(pkg) {
@@ -197,15 +218,6 @@ navbar_news <- function(pkg) {
 
 has_news <- function(path = ".") {
   file_exists(path(path, "NEWS.md"))
-}
-
-is_dev <- function(version) {
-  dev_v <- version %>%
-    package_version() %>%
-    purrr::map(unclass) %>%
-    purrr::map_dbl(c(1, 4), .null = 0)
-
-  dev_v > 0
 }
 
 pkg_timeline <- function(package) {

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -168,20 +168,16 @@ data_news <- function(pkg = ".") {
 
 news_version <- function(x) {
   pattern <- "(?x)
-    ^([[:alnum:],\\.]+)\\s+             # alpha-numeric package name
-    (
-      (?:                               # version specification
-        v?                              # optional v
-        (?:\\d+[.-]\\d+)(?:[.-]\\d+)*   # followed by digits, dots and dashes
-      )|                                # OR
-      (?:\\(development\\ version\\))   # literal used by usethis
+    ^(?<package>[[:alnum:],\\.]+)\\s+ # alpha-numeric package name
+    (?<version>
+      v?                              # optional v
+      (\\d+[.-]\\d+)(?:[.-]\\d+)*     # followed by digits, dots and dashes
+      |                               # OR
+      (\\(development\\ version\\))   # literal used by usethis
     )
   "
-  re <- regexec(pattern, x, perl = TRUE)
-  pieces <- regmatches(x, re)
-
-  versions <- purrr::map_chr(pieces, 3, .default = NA)
-  gsub("^[v(]|[)]$", "", versions)
+  pieces <- rematch2::re_match(x, pattern)
+  gsub("^[v(]|[)]$", "", pieces$version)
 }
 
 version_page <- function(x) {

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -68,3 +68,21 @@ test_that("multi-page news are rendered", {
   lines <- read_lines(path(path, "docs", "news", "news-1.0.html"))
   expect_true(any(grepl("<h1>Changelog <small>1.0</small></h1>", lines)))
 })
+
+
+# news_title and version_page -----------------------------------------------
+
+test_that("can recognise common forms of title", {
+  version <- news_version(c(
+    "pkgdown 1.3.0",
+    "pkgdown v1.3.0",
+    "pkgdown (development version)"
+  ))
+  expect_equal(version, c("1.3.0", "1.3.0", "development version"))
+})
+
+test_that("correctly collapses version to page for common cases", {
+  versions <- c("1.0.0", "1.0.0.0", "1.0.0.9000", "development version")
+  pages <- purrr::map_chr(versions, version_page)
+  expect_equal(pages, c("1.0", "1.0", "dev", "dev"))
+})


### PR DESCRIPTION
Included a decent amount of refactoring, first to make the regular expression more readable, and then to make news_version return something that was easier to test.

Fixes #980