### PR TITLE
Adjust padding-top based on navbar height

### DIFF
--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -21,8 +21,6 @@ body > .container {
   display: flex;
   height: 100%;
   flex-direction: column;
-
-  padding-top: 60px;
 }
 
 body > .container .row {

--- a/inst/assets/pkgdown.js
+++ b/inst/assets/pkgdown.js
@@ -39,6 +39,13 @@
     }
   });
 
+  $(function() {
+      $(document.body).css('padding-top', $('#topnavbar').height() + 10);
+      $(window).resize(function(){
+          $(document.body).css('padding-top', $('#topnavbar').height() + 10);
+      });
+  });
+
   function paths(pathname) {
     var pieces = pathname.split("/");
     pieces.shift(); // always starts with /

--- a/inst/assets/pkgdown.js
+++ b/inst/assets/pkgdown.js
@@ -4,6 +4,11 @@
 
     $('.navbar-fixed-top').headroom();
 
+    $('body').css('padding-top', $('.navbar').height() + 10);
+    $(window).resize(function(){
+      $('body').css('padding-top', $('.navbar').height() + 10);
+    });
+
     $('body').scrollspy({
       target: '#sidebar',
       offset: 60
@@ -37,13 +42,6 @@
       menu_anchor.parent().addClass("active");
       menu_anchor.closest("li.dropdown").addClass("active");
     }
-  });
-
-  $(function() {
-      $(document.body).css('padding-top', $('#topnavbar').height() + 10);
-      $(window).resize(function(){
-          $(document.body).css('padding-top', $('#topnavbar').height() + 10);
-      });
   });
 
   function paths(pathname) {

--- a/inst/templates/navbar.html
+++ b/inst/templates/navbar.html
@@ -1,5 +1,5 @@
 {{#navbar}}
-<div class="navbar navbar-{{{type}}} navbar-fixed-top" role="navigation">
+<div class="navbar navbar-{{{type}}} navbar-fixed-top" role="navigation" id="topnavbar">
   <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">

--- a/inst/templates/navbar.html
+++ b/inst/templates/navbar.html
@@ -1,5 +1,5 @@
 {{#navbar}}
-<div class="navbar navbar-{{{type}}} navbar-fixed-top" role="navigation" id="topnavbar">
+<div class="navbar navbar-{{{type}}} navbar-fixed-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">


### PR DESCRIPTION
For both the tidytemplate and the rotemplate packages there are issues where the navbar overlaps the page body on small screens (https://github.com/tidyverse/tidytemplate/issues/42, https://github.com/ropensci/rotemplate/issues/15). 

In principle, this problem also exists with the default pkgdown theme, though not as often, because of the smaller navbar font size. Here are two examples [in the wild](https://radiant-rstats.github.io/radiant.multivariate/):

![radiant_ipad](https://user-images.githubusercontent.com/1423562/58308664-7a653c00-7e02-11e9-9617-352e1974301f.png)

![radiant_300](https://user-images.githubusercontent.com/1423562/58308668-7df8c300-7e02-11e9-94ab-9db797244eb9.png)

This can be fixed if the top-padding of the body is set relative to the navbar, see [this answer on SO](https://stackoverflow.com/a/20197508/2114932), which this PR draws upon.

My knowledge of Javascript and CSS is extremely limited, so it's quite likely that this PR can be improved upon, hence my labelling it as proof-of-concept. 

With this PR applied, pkgdown shows the whole headline of the page body (using a dummy package here, since I do not have all radiant.multivariate dependencies installed).

![pkg_long_name](https://user-images.githubusercontent.com/1423562/58372739-4d0faf80-7f22-11e9-9f9a-807444f41856.png)
