### PR TITLE
Updated build docs with caution on Google Analytics

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -204,6 +204,11 @@
 #' correspond to your
 #' [tracking id](https://support.google.com/analytics/answer/1032385).
 #'
+#' When enabling Google Analytics, be aware of the type and amount of
+#' user information that you are collecting. You may wish to limit the
+#' extent of data collection or to add a privacy disclosure to your
+#' site, in keeping with current laws and regulations.
+#'
 #' ```
 #' template:
 #'   params:

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -226,7 +226,12 @@ See a complete list of themes and preview how they look at
 Optionally provide the \code{ganalytics} template parameter to enable
 \href{https://www.google.com/analytics/}{Google Analytics}. It should
 correspond to your
-\href{https://support.google.com/analytics/answer/1032385}{tracking id}.\preformatted{template:
+\href{https://support.google.com/analytics/answer/1032385}{tracking id}.
+
+When enabling Google Analytics, be aware of the type and amount of
+user information that you are collecting. You may wish to limit the
+extent of data collection or to add a privacy disclosure to your
+site, in keeping with current laws and regulations.\preformatted{template:
   params:
     ganalytics: UA-000000-01
 }


### PR DESCRIPTION
This PR adds two sentences to the section of the `build_site()` documentation to suggest developers be cognizant of their responsibilities for collection and disclosure when using Google Analytics.

The wording is intentionally high-level to stay succinct and avoid going stale. Hopefully, it is not too vague to be useful.

Closes #1009. 