### PR TITLE
fix typos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,3 +63,4 @@ SystemRequirements: pandoc
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
+Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,4 +63,3 @@ SystemRequirements: pandoc
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
-Language: en-GB

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 * `build_site()`, `build_reference()` and `build_home()` gain a parameter `devel` which can be set to `FALSE` to disable redocumenting and reloading the package, and knitting of home `Rmd` file. This generalises and replaces (with deprecation) the existing `document` argument.
 
-* The sticky behavior of the navbar is now implemented in pure CSS instead of relying on the 3rd party javascript library (#1016, @bisaloo)
+* The sticky behaviour of the navbar is now implemented in pure CSS instead of relying on the 3rd party javascript library (#1016, @bisaloo)
 
 * A timeout for `build_site(new_process = TRUE)` can be set with `options(pkgdown.timeout = Inf)` to prevent stalled builds from hanging cron jobs. 
 
@@ -49,7 +49,7 @@
 
 ## New features
 
-* `deploy_site_github()` can be used from continuous intergration systems
+* `deploy_site_github()` can be used from continuous integration systems
   (like travis) to automatically deploy your package website to GitHub Pages.
   See documentation for how to set up details (@jimhester).
 
@@ -136,7 +136,7 @@
 * `build_site()` loses vestigal `mathjax` parameter. This didn't appear to do 
   anything and  no one could remember why it existed (#785).
 
-* `build_site()` now uses colors even if `new_process = TRUE` (@jimhester).
+* `build_site()` now uses colours even if `new_process = TRUE` (@jimhester).
 
 # pkgdown 1.1.0
 

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -7,7 +7,7 @@
 #' also builds any files found in `.github/`.
 #'
 #' @section Images and figures:
-#' If you want to include images in your `README.md`, they must be stored in
+#' If you want to include images in your `README.md`, they must be stored
 #' somewhere in the package so that they can be displayed on the CRAN website.
 #' The best place to put them is `man/figures`. If you are generating figures
 #' with R Markdown, make sure you set up `fig.path` as followed:

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -33,7 +33,7 @@
 #' topics with the Rd keyword "internal". To include these, use
 #' `starts_with("build_", internal = TRUE)`.
 #'
-#' You can alo select topics that contain specified Rd concepts with
+#' You can also select topics that contain specified Rd concepts with
 #' `has_concept("blah")`.
 #'
 #' You can provide long descriptions for groups of functions using the YAML `>`

--- a/R/build.r
+++ b/R/build.r
@@ -14,7 +14,7 @@
 #' that aspect of the site.
 #'
 #' Note if names of generated files were changed, you will need to use
-#' [clean_site] first to clean up orphan files.
+#' [clean_site()] first to clean up orphan files.
 #'
 #' @section YAML config:
 #' There are four top-level YAML settings that affect the entire site:

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -33,7 +33,7 @@ also builds any files found in \code{.github/}.
 }
 \section{Images and figures}{
 
-If you want to include images in your \code{README.md}, they must be stored in
+If you want to include images in your \code{README.md}, they must be stored
 somewhere in the package so that they can be displayed on the CRAN website.
 The best place to put them is \code{man/figures}. If you are generating figures
 with R Markdown, make sure you set up \code{fig.path} as followed:

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -70,7 +70,7 @@ section. By default, these functions that match multiple topics will exclude
 topics with the Rd keyword "internal". To include these, use
 \code{starts_with("build_", internal = TRUE)}.
 
-You can alo select topics that contain specified Rd concepts with
+You can also select topics that contain specified Rd concepts with
 \code{has_concept("blah")}.
 
 You can provide long descriptions for groups of functions using the YAML \code{>}

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -53,7 +53,7 @@ See the documentation for the each function to learn how to control
 that aspect of the site.
 
 Note if names of generated files were changed, you will need to use
-\link{clean_site} first to clean up orphan files.
+\code{\link[=clean_site]{clean_site()}} first to clean up orphan files.
 }
 \section{YAML config}{
 

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -179,7 +179,7 @@ See complete details in `build_articles()`.
 
 ### Embedding a Shiny app
 
-If you would like to embed a Shiny app into an article, the app will have to be hosted indpendently, somewhere like [shinyapps.io](https://www.shinyapps.io). Then, you can embed the app into your article using an `iframe`. To customise its appearance, you may wish to [include some css code](../reference/build_site.html#yaml-config-template); you can use [this css code](https://github.com/r-lib/pkgdown/issues/838#issuecomment-430473856) as a starting point.\
+If you would like to embed a Shiny app into an article, the app will have to be hosted independently, somewhere like [shinyapps.io](https://www.shinyapps.io). Then, you can embed the app into your article using an `iframe`. To customise its appearance, you may wish to [include some css code](../reference/build_site.html#yaml-config-template); you can use [this css code](https://github.com/r-lib/pkgdown/issues/838#issuecomment-430473856) as a starting point.\
 
 To embed the `iframe`, you can use functions from the [htmltools](https://CRAN.R-project.org/package=htmltools) package:
 


### PR DESCRIPTION
This fixes some typos, mostly found with `spelling::spell_check_package()`. 
It also adds the `Language` field to DESCRIPTION and sets it to the de-facto `en-GB`. 