### PR TITLE
Clarify boundary between unreleased and release in tests

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -91,7 +91,7 @@
 #'
 #' The mode will be automatically determined based on the version number:
 #'
-#' * `0.0.0.9000`: unreleased
+#' * `0.0.0.9000` (`0.0.0.*`): unreleased
 #' * four version components: development
 #' * everything else -> release
 #'

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -123,7 +123,7 @@ You can also have pkgdown automatically detect the mode with:\preformatted{devel
 
 The mode will be automatically determined based on the version number:
 \itemize{
-\item \code{0.0.0.9000}: unreleased
+\item \code{0.0.0.9000} (\code{0.0.0.*}): unreleased
 \item four version components: development
 \item everything else -> release
 }

--- a/tests/testthat/test-development.R
+++ b/tests/testthat/test-development.R
@@ -21,6 +21,8 @@ test_that("mode = auto uses version", {
 test_that("dev_mode recognises basic version structure", {
   expect_equal(dev_mode(package_version("0.0.0.9000")), "unreleased")
   expect_equal(dev_mode(package_version("0.0.0.9001")), "unreleased")
+  expect_equal(dev_mode(package_version("0.0.0.9999")), "unreleased")
+  expect_equal(dev_mode(package_version("0.0.1")), "release")
   expect_equal(dev_mode(package_version("0.1.0")), "release")
   expect_equal(dev_mode(package_version("1.0.0.9000")), "devel")
 })


### PR DESCRIPTION
and in documentation.