### PR TITLE
Add support for \Sexpr[results=verbatim] in manual pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown 1.3.0.9000 (development version)
 
+* Add support for \Sexpr[results=verbatim] in manual pages
+
 * Function names can now be included in headers without spurious auto-linking (#948).
 
 * The title and description of the homepage now corresponds by default to an unquoted version of the DESCRIPTION Title and Description. Furthermore, one can override the title and description of the homepage via the `title` and `description` fields in the home section of config (#957, @maelle).

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -231,13 +231,19 @@ as_html.tag_Sexpr <- function(x, ...) {
   on.exit(setwd(old_wd), add = TRUE)
 
   # Environment shared across a file
-  res <- eval(parse(text = code), context_get("sexpr_env"))
+  std_out <- capture.output({
+    out <- withVisible(eval(parse(text = code), context_get("sexpr_env")))
+    res <- out$value
+    if(out$visible)
+      print(res)
+  })
 
   results <- options$results %||% "rd"
   switch(results,
     text = as.character(res),
     rd = flatten_text(rd_text(as.character(res))),
     hide = "",
+    verbatim = paste0("<pre>", escape_html(paste(std_out, collapse = "\n")), "</pre>"),
     stop("\\Sexpr{result=", results, "} not yet supported", call. = FALSE)
   )
 }

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -120,6 +120,8 @@ test_that("can control \\Sexpr output", {
 
   expect_equal(rd2html("\\Sexpr[results=hide]{1}"), character())
   expect_equal(rd2html("\\Sexpr[results=text]{1}"), "1")
+  expect_equal(rd2html("\\Sexpr[results=verbatim]{1 + 2}"), "<pre>[1] 3</pre>")
+  expect_equal(rd2html("\\Sexpr[results=verbatim]{cat(1)}"), "<pre>1</pre>")
   expect_equal(rd2html("\\Sexpr[results=rd]{\"\\\\\\emph{x}\"}"), "<em>x</em>")
 })
 


### PR DESCRIPTION
This mimics what R does when inserting a verbatim Sexpr in a manual page.