### PR TITLE
Document exclusion of `vignettes/tutorials/` when building articles

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -7,7 +7,8 @@
 #'
 #' A vignette with the same name as the package (e.g., `vignettes/pkgdown.Rmd`)
 #' gets special treatment. It is rendered and linked to in the navbar under
-#' "Get started".
+#' "Get started". Rmarkdown files in `vignettes/tutorials/` are ignored,
+#' because these are assumed to contain tutorials, see `build_tutorials()`.
 #'
 #' @section External files:
 #' pkgdown differs from base R in its handling of external files. When building

--- a/man/build_articles.Rd
+++ b/man/build_articles.Rd
@@ -40,7 +40,8 @@ template.
 \details{
 A vignette with the same name as the package (e.g., \code{vignettes/pkgdown.Rmd})
 gets special treatment. It is rendered and linked to in the navbar under
-"Get started".
+"Get started". Rmarkdown files in \code{vignettes/tutorials/} are ignored,
+because these are assumed to contain tutorials, see \code{build_tutorials()}.
 }
 \section{External files}{
 

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -162,7 +162,7 @@ See complete details in `build_reference()`.
 
 ## Articles
 
-pkgdown will automatically build all `.Rmd` vignettes, including those in subdirectories. The only exception are `.Rmd` vignettes that start with `_` (i.e., `_index.Rmd`), enabling the use of child documents in [bookdown](https://bookdown.org/yihui/bookdown/). Vignette outputs are rendered to `articles/`. pkgdown will ignore the output format defined in the yaml header, and always use `html_fragment(toc = TRUE, toc_float = TRUE)`. 
+pkgdown will automatically build all `.Rmd` vignettes, including those in subdirectories. The only exception are `.Rmd` vignettes that start with `_` (i.e., `_index.Rmd`), enabling the use of child documents in [bookdown](https://bookdown.org/yihui/bookdown/), and vignettes in a `tutorials` subdirectory, which is reserved for tutorials built with `build_tutorials()`. Vignette outputs are rendered to `articles/`. pkgdown will ignore the output format defined in the yaml header, and always use `html_fragment(toc = TRUE, toc_float = TRUE)`. 
 
 If you want to include an article on the website but not in the package (e.g., because it's large), you can either place it in a subdirectory of `vignettes/` or add it to `.Rbuildignore`. In addition, you must ensure that there is no `vignettes:` section in the article's yaml header. In the extreme case where you want to produce only articles but not vignettes, you should add the complete `vignettes/` directory to `.Rbuildignore` and ensure that DESCRIPTION does not have a `VignetteBuilder` field.
 


### PR DESCRIPTION
It took me a while to understand why my Rmarkdown files in `vignettes/tutorials/` were not included by `build_articles()`, because the documentation said: "pkgdown will automatically build all .Rmd vignettes, including those in subdirectories. The only exception are .Rmd vignettes that start with _". This pull request fixes that documentation.