### PR TITLE
Use full URL in 404 sites, fixes #1129

### DIFF
--- a/R/render.r
+++ b/R/render.r
@@ -34,6 +34,12 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   data$has_favicons <- has_favicons(pkg)
   data$opengraph <- utils::modifyList(data_open_graph(pkg), data$opengraph %||% list())
 
+  # The real location of 404.html is dynamic (#1129).
+  # Relative root does not work, use the full URL if available.
+  if(identical(path, "404.html") && length(pkg$meta$url)){
+    data$site$root <- paste0(pkg$meta$url, "/")
+  }
+
   # render template components
   pieces <- c("head", "navbar", "header", "content", "docsearch", "footer")
 


### PR DESCRIPTION
See issue #1129 for details. 

Basically the `{{root}}` variable is always interpolated with a number of `../../../` to get to the root of the site. However the `404.html` is special because it may appear at any level.