### PR TITLE
build_home(): be more explicit that ".Rmd" is not rendered 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,8 +18,8 @@
     library, and runs examples/articles in a new process.
 
 * `build_reference()` no longer runs `devtools::document()` (#1079) and
-  `build_home()` no longer re-builds `README.Rmd`.  This makes the scope 
-  of responsibility of pkgdown more clear: it now only creates/modifies 
+  `build_home()` no longer re-builds `index.Rmd` or `README.Rmd`.  This makes 
+  the scope of responsibility of pkgdown more clear: it now only creates/modifies 
   files in `doc/`.
 
 * `build_home()` now strips quotes from `Title` and `Description` fields 

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -5,7 +5,7 @@ build_home_index <- function(pkg = ".", quiet = TRUE) {
   scoped_file_context(depth = 0L)
 
   src_path <- path_first_existing(pkg$src_path,
-    c("index.md", "README.md", "index.Rmd", "README.Rmd")
+    c("index.md", "README.md")
   )
   dst_path <- path(pkg$dst_path, "index.html")
   data <- data_home(pkg)


### PR DESCRIPTION
by pkgdown v1.4 (https://github.com/r-lib/pkgdown/issues/1136)
