### PR TITLE
allow 'articles::navbar' for ordering vignette entries

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -381,7 +381,7 @@ navbar_articles <- function(pkg = ".") {
 
   # if an explicit navbar is supplied in meta, use that; otherwise
   # use a default-constructed navbar entry
-  meta_navbar <- pkg$meta$articles$navbar
+  meta_navbar <- pkg$meta$vignettes$navbar
   if (is.null(meta_navbar))
     return(menu("Articles", menu_links(vignettes$title, vignettes$file_out)))
 

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -374,3 +374,41 @@ default_articles_index <- function(pkg = ".") {
   ))
 
 }
+
+navbar_articles <- function(pkg = ".") {
+  pkg <- as_pkgdown(pkg)
+  vignettes <- pkg$vignettes
+
+  # if an explicit navbar is supplied in meta, use that; otherwise
+  # use a default-constructed navbar entry
+  meta_navbar <- pkg$meta$articles$navbar
+  if (is.null(meta_navbar))
+    return(menu("Articles", menu_links(vignettes$title, vignettes$file_out)))
+
+  # construct navbar (detect whether user has only provided menu entries,
+  # versus specific text + menu entries)
+  navbar <- meta_navbar
+  if (is.null(names(navbar)))
+    navbar <- list(text = "Articles", menu = navbar)
+
+  # expand some short-form menu items
+  navbar$menu <- lapply(navbar$menu, function(item) {
+
+    # vignette: <name>
+    if (is.character(item$vignette) && item$vignette %in% vignettes$name) {
+      vignette <- vignettes[vignettes$name == item$vignette, ]
+      item <- menu_link(vignette$title, vignette$file_out)
+    }
+
+    # section: <title>
+    if (is.character(item$section)) {
+      item <- list(text = item$section)
+    }
+
+    item
+
+  })
+
+  navbar
+
+}

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -75,7 +75,7 @@ navbar_components <- function(pkg = ".") {
 
     menu$intro <- menu_link("Get started", intro$file_out)
   }
-  menu$articles <-  menu("Articles", menu_links(vignettes$title, vignettes$file_out))
+  menu$articles <-  navbar_articles(pkg)
   menu$news <- navbar_news(pkg)
 
   if (!is.null(pkg$github_url)) {


### PR DESCRIPTION
Closes https://github.com/r-lib/pkgdown/issues/1146. Note that this PR is currently incomplete; some guidance would be helpful in terms of figuring out how to best handle errors / testing.

The intention is to allow users to write e.g.

```
articles:
  navbar:
    vignette: introduction
    vignette: collaborating
```

as a short-form way of declaring vignettes + their intended ordering in the Articles navbar.