### PR TITLE
Use ORCiD logo from FontAwesome 5.11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* pkgdown now uses the ORCiD logo included in Font Awesome 5.11 instead of 
+  querying it from members.orcid.org (@bisaloo, #1153)
+
 # pkgdown 1.4.1
 
 * Don't install test package in user library (fixes CRAN failure).

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -152,8 +152,8 @@ orcid_link <- function(orcid) {
   if (is.null(orcid)) return(NULL)
 
   paste0(
-    "<a href='https://orcid.org/", orcid, "' target='orcid.widget'>",
-    "<span class='fab fa-orcid orcid'></span></a>"
+    "<a href='https://orcid.org/", orcid, "' target='orcid.widget' aria-label='ORCID'>",
+    "<span class='fab fa-orcid orcid' aria-hidden='true'></span></a>"
   )
 }
 

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -153,7 +153,7 @@ orcid_link <- function(orcid) {
 
   paste0(
     "<a href='https://orcid.org/", orcid, "' target='orcid.widget'>",
-    "<img src='https://members.orcid.org/sites/default/files/vector_iD_icon.svg' class='orcid' alt='ORCID'></a>"
+    "<span class='fab fa-orcid orcid'></span></a>"
   )
 }
 

--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -122,7 +122,8 @@ a.anchor {
 }
 
 .orcid {
-  height: 16px;
+  font-size: 16px;
+  color: #A6CE39;
   /* margins are required by official ORCID trademark and display guidelines */
   margin-left:4px;
   margin-right:4px;

--- a/inst/templates/head.html
+++ b/inst/templates/head.html
@@ -25,8 +25,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.7.1/css/all.min.css" integrity="sha256-nAmazAk6vS34Xqo0BSrTb+abbtFlgsFK7NKSi6o7Y78=" crossorigin="anonymous" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.7.1/css/v4-shims.min.css" integrity="sha256-6qHlizsOWFskGlwVOKuns+D1nB6ssZrHQrNj1wGplHc=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.1/css/all.min.css" integrity="sha256-PbSmjxuVAzJ6FPvNYsrXygfGhNJYyZ2GktDbkMBqQZg=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.1/css/v4-shims.min.css" integrity="sha256-A6jcAdwFD48VMjlI3GDxUd+eCQa7/KWy6G9oe/ovaPA=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This prevents a request to a third party, thereby improving privacy, speed and robustness of pkgdown websites.

This is now possible thanks to https://github.com/FortAwesome/Font-Awesome/issues/4401.