### PR TITLE
Copy existing favicons

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -37,7 +37,9 @@ init_site <- function(pkg = ".") {
   dir_create(pkg$dst_path)
   copy_assets(pkg)
 
-  if (has_logo(pkg) && !has_favicons(pkg)) {
+  if (has_favicons(pkgs)) {
+    copy_favicons(pkg)
+  } else if (has_logo(pkg)) {
     build_favicons(pkg)
     copy_favicons(pkg)
   }

--- a/R/init.R
+++ b/R/init.R
@@ -37,7 +37,7 @@ init_site <- function(pkg = ".") {
   dir_create(pkg$dst_path)
   copy_assets(pkg)
 
-  if (has_favicons(pkgs)) {
+  if (has_favicons(pkg)) {
     copy_favicons(pkg)
   } else if (has_logo(pkg)) {
     build_favicons(pkg)


### PR DESCRIPTION
Favicons are currently only copied if they have been just created on the fly. This is a problem for repositories where the gh-pages branch is re-created as new orphan branch on deploy.

This PR solves this by always copying existing favicons.