### PR TITLE
Enable deploy_site_github() to handle GH enterprise instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 # pkgdown 1.4.1
 
 * Don't install test package in user library (fixes CRAN failure).
-* `deploy_site_github()` now accepts a `host` argument enabling users to leverage this for github enterprise - @dimagor
+* `deploy_site_github()` now accepts a `host` argument enabling users to leverage this for github enterprise - (@dimagor)
 
 # pkgdown 1.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 # pkgdown 1.4.1
 
 * Don't install test package in user library (fixes CRAN failure).
+* `deploy_site_github()` now accepts a `host` argument enabling users to leverage this for github enterprise - @dimagor
 
 # pkgdown 1.4.0
 

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -57,6 +57,7 @@
 #'   new keypair specifically for deploying the site. The easiest way is to use
 #'   `travis::use_travis_deploy()`.
 #' @param repo_slug The `user/repo` slug for the repository.
+#' @param host The github host url.
 #' @param commit_message The commit message to be used for the commit.
 #' @param verbose Print verbose output
 #' @param ... Additional arguments passed to [build_site()].
@@ -67,6 +68,7 @@ deploy_site_github <- function(
   tarball = Sys.getenv("PKG_TARBALL", ""),
   ssh_id = Sys.getenv("id_rsa", ""),
   repo_slug = Sys.getenv("TRAVIS_REPO_SLUG", ""),
+  host = "github.com",
   commit_message = construct_commit_message(pkg),
   verbose = FALSE,
   ...) {
@@ -96,17 +98,18 @@ deploy_site_github <- function(
   cat_line("Setting private key permissions to 0600")
   fs::file_chmod(ssh_id_file, "0600")
 
-  deploy_local(pkg, repo_slug = repo_slug, commit_message = commit_message, ...)
+  deploy_local(pkg, repo_slug = repo_slug, host = host, commit_message = commit_message, ...)
 
   rule("Deploy completed", line = 2)
 }
 
 deploy_local <- function(
-                         pkg = ".",
-                         repo_slug = NULL,
-                         commit_message = construct_commit_message(pkg),
-                         ...
-                         ) {
+  pkg = ".",
+  repo_slug = NULL,
+  host,
+  commit_message = construct_commit_message(pkg),
+  ...
+) {
 
   dest_dir <- fs::dir_create(fs::file_temp())
   on.exit(fs::dir_delete(dest_dir))
@@ -117,27 +120,27 @@ deploy_local <- function(
     repo_slug <- paste0(gh$owner, "/", gh$repo)
   }
 
-  github_clone(dest_dir, repo_slug)
+  github_clone(dest_dir, repo_slug, host)
   build_site(".",
-    override = list(destination = dest_dir),
-    devel = FALSE,
-    preview = FALSE,
-    install = FALSE,
-    ...
+             override = list(destination = dest_dir),
+             devel = FALSE,
+             preview = FALSE,
+             install = FALSE,
+             ...
   )
   github_push(dest_dir, commit_message)
 
   invisible()
 }
 
-github_clone <- function(dir, repo_slug) {
-  remote_url <- sprintf("git@github.com:%s.git", repo_slug)
+github_clone <- function(dir, repo_slug, host) {
+  remote_url <- sprintf("git@%s:%s.git", host, repo_slug)
   rule("Cloning existing site", line = 1)
   git("clone",
-    "--single-branch", "-b", "gh-pages",
-    "--depth", "1",
-    remote_url,
-    dir
+      "--single-branch", "-b", "gh-pages",
+      "--depth", "1",
+      remote_url,
+      dir
   )
 }
 

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -108,7 +108,8 @@ deploy_local <- function(
                          repo_slug = NULL,
                          host,
                          commit_message = construct_commit_message(pkg),
-                         ...) {
+                         ...
+                         ) {
   dest_dir <- fs::dir_create(fs::file_temp())
   on.exit(fs::dir_delete(dest_dir))
 
@@ -134,8 +135,7 @@ deploy_local <- function(
 github_clone <- function(dir, repo_slug, host) {
   remote_url <- sprintf("git@%s:%s.git", host, repo_slug)
   rule("Cloning existing site", line = 1)
-  git(
-    "clone",
+  git("clone",
     "--single-branch", "-b", "gh-pages",
     "--depth", "1",
     remote_url,

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -104,13 +104,11 @@ deploy_site_github <- function(
 }
 
 deploy_local <- function(
-  pkg = ".",
-  repo_slug = NULL,
-  host,
-  commit_message = construct_commit_message(pkg),
-  ...
-) {
-
+                         pkg = ".",
+                         repo_slug = NULL,
+                         host,
+                         commit_message = construct_commit_message(pkg),
+                         ...) {
   dest_dir <- fs::dir_create(fs::file_temp())
   on.exit(fs::dir_delete(dest_dir))
 
@@ -122,11 +120,11 @@ deploy_local <- function(
 
   github_clone(dest_dir, repo_slug, host)
   build_site(".",
-             override = list(destination = dest_dir),
-             devel = FALSE,
-             preview = FALSE,
-             install = FALSE,
-             ...
+    override = list(destination = dest_dir),
+    devel = FALSE,
+    preview = FALSE,
+    install = FALSE,
+    ...
   )
   github_push(dest_dir, commit_message)
 
@@ -136,11 +134,12 @@ deploy_local <- function(
 github_clone <- function(dir, repo_slug, host) {
   remote_url <- sprintf("git@%s:%s.git", host, repo_slug)
   rule("Cloning existing site", line = 1)
-  git("clone",
-      "--single-branch", "-b", "gh-pages",
-      "--depth", "1",
-      remote_url,
-      dir
+  git(
+    "clone",
+    "--single-branch", "-b", "gh-pages",
+    "--depth", "1",
+    remote_url,
+    dir
   )
 }
 

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -7,7 +7,7 @@
 deploy_site_github(pkg = ".", install = TRUE,
   tarball = Sys.getenv("PKG_TARBALL", ""),
   ssh_id = Sys.getenv("id_rsa", ""),
-  repo_slug = Sys.getenv("TRAVIS_REPO_SLUG", ""),
+  repo_slug = Sys.getenv("TRAVIS_REPO_SLUG", ""), host = "github.com",
   commit_message = construct_commit_message(pkg), verbose = FALSE, ...)
 }
 \arguments{
@@ -25,6 +25,8 @@ new keypair specifically for deploying the site. The easiest way is to use
 \code{travis::use_travis_deploy()}.}
 
 \item{repo_slug}{The \code{user/repo} slug for the repository.}
+
+\item{host}{The github host url.}
 
 \item{commit_message}{The commit message to be used for the commit.}
 


### PR DESCRIPTION
`deploy_site_github()` does not currently support enterprise github for deployment and defaults to github.com. This is hardcoded in the `github_clone()` function. 

The proposal in this PR is to add a new argument `host` that would allow enterprise users to specify the URL of their github instance when deploying with Travis. I can confirm that this approach works for my org's internal github. 

Happy to provide any additional information.



