### PR TITLE
Remove unused (and typoed) selector from docsearch json template

### DIFF
--- a/inst/templates/config-docsearch.json
+++ b/inst/templates/config-docsearch.json
@@ -74,7 +74,7 @@
         "selector": ".contents h2, .contents h3",
         "default_value": "Context"
       },
-      "text": ".contents p, .contents li, .tempate-article .contents .pre"
+      "text": ".contents p, .contents li"
     }
   },
   "selectors_exclude": [


### PR DESCRIPTION
See https://github.com/algolia/docsearch-scraper/pull/423#discussion_r241115308.