### PR TITLE
Allow more way to specify badges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,10 @@
 
 * A timestamp for the last site build is reported in `pkgdown.yml` (#1122).
 
+* badges are now extracted from everything between `<!--badges: start-->`
+  and `<!--badges: end-->`. They used to be extracted only if they were
+  direct children of the first `<p/>` after `<!--badges: start-->`.
+
 # pkgdown 1.4.1
 
 * Don't install test package in user library (fixes CRAN failure).

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -20,13 +20,15 @@
 #' The sidebar is automatically populated with:
 #'
 #' *   Development status badges found in `README.md`/`index.md`. pkgdown
-#'     identifies badge paragraphs in two ways:
+#'     identifies badges in three ways:
 #'
-#'     * A paragraph starting with `<!-- badges: start -->` and ending with
-#'       `<!-- badges: end -->` as created by `usethis::use_readme_md()`. or
-#'       `usethis::use_readme_rmd()`.
+#'     * Any image-containing links between `<!-- badges: start -->` and
+#'       `<!-- badges: end -->`, as e.g. created by `usethis::use_readme_md()`
+#'       or `usethis::use_readme_rmd()`.
 #'
-#'     * The first paragraph, if it only contains images.
+#'     * Any image-containing links within `<div id="badges"></div>`.
+#'
+#'     * Within the first paragraph, if it only contains image-containing links.
 #'
 #' *   A link for bug reports is added if the `BugReports` field in
 #'     `DESCRIPTION` contains a link. You can use `usethis::use_github_links()`

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -252,12 +252,11 @@ tweak_homepage_html <- function(html, strip_header = FALSE) {
 # Mutates `html`, removing the badge container
 badges_extract <- function(html) {
   # First try specially named element;
-  x <- xml2::xml_find_first(html, "//*[@id='badges']")
-  force <- TRUE
+  x <- xml2::xml_find_first(html, "//div[@id='badges']")
+  strict <- FALSE
 
   # then try usethis-readme-like paragraph;
   if (length(x) == 0) {
-    # Find all elements between the two comments:
     # Find start comment, then all elements after
     # which are followed by the end comment.
     x <- xml2::xml_find_all(html, "
@@ -269,7 +268,7 @@ badges_extract <- function(html) {
   # finally try first paragraph
   if (length(x) == 0) {
     x <- xml2::xml_find_first(html, "//p")
-    force <- FALSE
+    strict <- TRUE
   }
 
   # No paragraph
@@ -279,7 +278,7 @@ badges_extract <- function(html) {
 
   # If we guessed the element,
   # we only proceed if there is no text
-  if (!force && any(xml2::xml_text(x, trim = TRUE) != "")) {
+  if (strict && any(xml2::xml_text(x, trim = TRUE) != "")) {
     return(character())
   }
 

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -262,9 +262,7 @@ badges_extract <- function(html) {
     # which are followed by the end comment.
     x <- xml2::xml_find_all(html, "
       //comment()[contains(., 'badges: start')][1]
-        /following-sibling::*[
-          following-sibling::comment()[contains(., 'badges: end')]
-        ]
+      /following-sibling::*[following-sibling::comment()[contains(., 'badges: end')]]
     ")
   }
 
@@ -309,4 +307,3 @@ update_html <- function(path, tweak, ...) {
   xml2::write_html(html, path, format = FALSE)
   path
 }
-

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -42,12 +42,13 @@ for you because it only touches files in the \verb{doc/} directory.
 The sidebar is automatically populated with:
 \itemize{
 \item Development status badges found in \code{README.md}/\code{index.md}. pkgdown
-identifies badge paragraphs in two ways:
+identifies badges in three ways:
 \itemize{
-\item A paragraph starting with \verb{<!-- badges: start -->} and ending with
-\verb{<!-- badges: end -->} as created by \code{usethis::use_readme_md()}. or
-\code{usethis::use_readme_rmd()}.
-\item The first paragraph, if it only contains images.
+\item Any image-containing links between \verb{<!-- badges: start -->} and
+\verb{<!-- badges: end -->}, as e.g. created by \code{usethis::use_readme_md()}
+or \code{usethis::use_readme_rmd()}.
+\item Any image-containing links within \verb{<div id="badges"></div>}.
+\item Within the first paragraph, if it only contains image-containing links.
 }
 \item A link for bug reports is added if the \code{BugReports} field in
 \code{DESCRIPTION} contains a link. You can use \code{usethis::use_github_links()}

--- a/tests/testthat/test-html-tweak.R
+++ b/tests/testthat/test-html-tweak.R
@@ -155,17 +155,23 @@ test_that("finds single badge", {
   )
 })
 
-test_that("badges can't contain an extra text", {
+test_that("badges aren't extracted from first paragraph if it contains extra text", {
   expect_equal(
     badges_extract_text('<p><a href="url"><img src="img" alt="alt" /></a>Hi!</p>'),
     character()
   )
 })
 
-
-test_that("badges can be in special div", {
+test_that("badges can be in special element", {
   expect_equal(
     badges_extract_text('<p></p><div id="badges"><a href="x"><img src="y"></a></div>'),
+    '<a href="x"><img src="y"></a>'
+  )
+})
+
+test_that("badges in special element can be accompanied by text", {
+  expect_equal(
+    badges_extract_text('<p></p><p><span id="badges"><a href="x"><img src="y"></a>Hi!</span></p>'),
     '<a href="x"><img src="y"></a>'
   )
 })
@@ -176,7 +182,12 @@ test_that("badges-paragraph a la usethis can be found", {
   <p>Connect to thisisatest, from R</p>
   </blockquote>
   <!-- badges: start -->
-  <p><a href="https://travis-ci.org/thisisatest/thisisatest"><img src="https://travis-ci.org/thisisatest/thisisatest.svg?branch=master" alt="Linux Build Status"></a> <!-- badges: end --></p>
+  <p>
+  <a href="https://travis-ci.org/thisisatest/thisisatest">
+    <img src="https://travis-ci.org/thisisatest/thisisatest.svg?branch=master" alt="Linux Build Status">
+  </a>
+  </p>
+  <!-- badges: end -->
   <div id="introduction" class="section level2">
   <h2 class="hasAnchor">
   <a href="#introduction" class="anchor"></a>Introduction</h2>
@@ -185,4 +196,19 @@ test_that("badges-paragraph a la usethis can be found", {
 
   badges_page <- xml2::read_html(string)
   expect_equal(length(badges_extract(badges_page)), 1)
+})
+
+test_that("multiple badges-paragraphs can be found between comments", {
+  string <- '
+  <p></p>
+  <!-- badges: start -->
+  <ul>
+  <li><a href="x"><img src="y"></a></li>
+  <li><a href="z"><img src="f"></a></li>
+  </ul>
+  <!-- badges: end -->
+  <p></p>'
+
+  badges_page <- xml2::read_html(string)
+  expect_equal(length(badges_extract(badges_page)), 2)
 })


### PR DESCRIPTION
If the user puts the badges comments or an element with `id=badges`, I assume they want to extract the badges from there instead of having everything silently ignored.

This changes the detection code so that it extracts all badge-like links

1. between a pair of `badges: start` and `badges: end` comments
2. inside of an element with `id=badges` (not just divs, an ul would work too)
2. in the first paragraph, provided that paragraph only contains badge-like links (old logic)

This allows extraction of badges under more circumstances like e.g. from my package, where two badges look identical and have some explaining text:

> ```markdown
> <!-- badges: start -->
> builds
> ------
> 
> - [![Travis](https://travis...)](https://travis...) – Travis
> - [![Bioconductor stable](https://bioc...)](https://bioc...) – Bioconductor stable
> - [![Bioconductor devel](https://bioc...)](https://bioc...) – Bioconductor devel
> <!-- badges: end -->