### PR TITLE
Support `pkgdown/index.md` and `pkgdown/index.Rmd`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 
 * `deploy_site_github()` now accepts a `host` argument enabling users to leverage this for github enterprise - (@dimagor)
 
+* `build_home()` now looks for `pkgdown/index.md` and `pkgdown/index.Rmd` in
+addition to the top-level `index` or `README` files (@nteetor, #1184)
+
 # pkgdown 1.4.1
 
 * Don't install test package in user library (fixes CRAN failure).

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -4,8 +4,15 @@ build_home_index <- function(pkg = ".", quiet = TRUE) {
   scoped_package_context(pkg$package, pkg$topic_index, pkg$article_index)
   scoped_file_context(depth = 0L)
 
-  src_path <- path_first_existing(pkg$src_path,
-    c("index.md", "README.md", "index.Rmd", "README.Rmd")
+  src_path <- path_first_existing(
+    pkg$src_path,
+    c("pkgdown/index.md",
+      "pkgdown/index.Rmd",
+      "index.md",
+      "README.md",
+      "index.Rmd",
+      "README.Rmd"
+    )
   )
   dst_path <- path(pkg$dst_path, "index.html")
   data <- data_home(pkg)


### PR DESCRIPTION
First brought up in #1031. This pull requests adds support for index files in the `pkgdown/` folder and I did add support for `pkgdown/index.md` for consistency. In the original issue I only mentioned `index.Rmd`.

I elected to put the `pkgdown/` specific files ahead of the other possible index and README files. My assumption: someone who creates `pkgdown/index.[R]?md` wants to use that file over any other. 