### PR TITLE
Add math extensions for markdown parsing

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -3,9 +3,9 @@ markdown <- function(path = NULL, ..., strip_header = FALSE) {
   on.exit(file_delete(tmp), add = TRUE)
 
   if (rmarkdown::pandoc_available("2.0")) {
-    from <- "markdown_github-hard_line_breaks+smart+auto_identifiers"
+    from <- "markdown_github-hard_line_breaks+smart+auto_identifiers+tex_math_dollars+tex_math_single_backslash"
   } else if (rmarkdown::pandoc_available("1.12.3")) {
-    from <- "markdown_github-hard_line_breaks"
+    from <- "markdown_github-hard_line_breaks+tex_math_dollars+tex_math_single_backslash"
   } else {
     stop("Pandoc not available", call. = FALSE)
   }


### PR DESCRIPTION
See https://github.com/r-lib/pkgdown/issues/1150#issuecomment-562948777

This PR adds two pandoc extensions. From [pandoc manual](https://pandoc.org/MANUAL.html#extensions):

- Extension: `tex_math_dollars`. Anything between two `$` characters will be treated as TeX math. The opening `$` must have a non-space character immediately to its right, while the closing `$` must have a non-space character immediately to its left, and must not be followed immediately by a digit. Thus, $20,000 and $30,000 won’t parse as math. If for some reason you need to enclose text in literal `$` characters, backslash-escape them and they won’t be treated as math delimiters.
- Extension: `tex_math_single_backslash`. Causes anything between `\(` and `\)` to be interpreted as inline TeX math, and anything between `\[` and `\]` to be interpreted as display TeX math. Note: a drawback of this extension is that it precludes escaping `(` and `[`.

I added both to be consistent with what LaTeX users would expect but we don't necessarily need both as each one of them is sufficient to generate both inline and display math.

