### PR TITLE
Use the recommended gfm markdown dialect

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* When pandoc 2.0 is available, markdown is now parsed as 'gfm' instead of the legacy
+  'github_markdown' dialect as recommended in the Pandoc manual. This should make the
+  output more consistent with Github and rmarkdown.
+
 * pkgdown now uses the ORCiD logo included in Font Awesome 5.11 instead of 
   querying it from members.orcid.org (@bisaloo, #1153)
 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -3,7 +3,7 @@ markdown <- function(path = NULL, ..., strip_header = FALSE) {
   on.exit(file_delete(tmp), add = TRUE)
 
   if (rmarkdown::pandoc_available("2.0")) {
-    from <- "markdown_github-hard_line_breaks+smart+auto_identifiers"
+    from <- "gfm-hard_line_breaks+smart+auto_identifiers"
   } else if (rmarkdown::pandoc_available("1.12.3")) {
     from <- "markdown_github-hard_line_breaks"
   } else {

--- a/tests/testthat/assets/markdown-dialect/DESCRIPTION
+++ b/tests/testthat/assets/markdown-dialect/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A test package
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = c("cph", "fnd"))
+    )
+RoxygenNote: 6.0.1

--- a/tests/testthat/assets/markdown-dialect/README.md
+++ b/tests/testthat/assets/markdown-dialect/README.md
@@ -1,0 +1,12 @@
+# My package
+
+This only works in GFM:
+
+<details>
+
+## Some header
+
+```r
+foo <- rnorm(123)
+```
+</details>

--- a/tests/testthat/test-amarkdown-dialect.R
+++ b/tests/testthat/test-amarkdown-dialect.R
@@ -1,0 +1,14 @@
+context("test-markdown-dialect.R")
+
+test_that("markdown inside html block gets parsed", {
+  skip_if_not(rmarkdown::pandoc_available('2.0'))
+
+  pkg <- test_path("assets/markdown-dialect")
+  expect_output(build_home(pkg))
+  on.exit(clean_site(pkg))
+
+  lines <- read_lines(path(pkg, "docs", "index.html"))
+  expect_true(any(grepl('<details>', lines, fixed = TRUE)))
+  expect_true(any(grepl('Some header</h2>', lines, fixed = TRUE)))
+  expect_true(any(grepl('<span class="dv">123</span>', lines, fixed = TRUE)))
+})


### PR DESCRIPTION
This is the default (and recommended) markdown dialect as of pandoc 2.0
See https://pandoc.org/MANUAL.html

This fixes some problems we have where the pkgdown markdown is rendered differently from rmarkdown or github.