### PR TITLE
linking to other git than github

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -2,7 +2,8 @@
 github_url_rx <- function() {
   paste0(
     "^",
-    "(?:https?://github.com/)",
+    "(?:https?://)",
+    "(?<git>[^/]+)/",
     "(?<owner>[^/]+)/",
     "(?<repo>[^/#]+)",
     "/?",
@@ -21,7 +22,7 @@ github_url_rx <- function() {
 ## output: "https://github.com/r-lib/gh"
 pkg_github_url <- function(desc) {
   urls <- desc$get_urls()
-  gh_links <- grep("^https?://github.com/", urls, value = TRUE)
+  gh_links <- grep("^https?://git", urls, value = TRUE)
 
   if (length(gh_links) == 0) {
     return()
@@ -33,7 +34,7 @@ pkg_github_url <- function(desc) {
 
 parse_github_link <- function(link) {
   x <- rematch2::re_match(link, github_url_rx())
-  paste0("https://github.com/", x$owner, "/", x$repo)
+  paste0("https://", x$git, "/", x$owner, "/", x$repo)
 }
 
 github_source <- function(base, paths) {

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -79,7 +79,12 @@ navbar_components <- function(pkg = ".") {
   menu$news <- navbar_news(pkg)
 
   if (!is.null(pkg$github_url)) {
-    menu$github <- menu_icon("github", pkg$github_url, style = "fab")
+    if (grepl('github', pkg$github_url, perl = TRUE))
+      menu$github <- menu_icon("github", pkg$github_url, style = "fab")
+    else if (grepl('gitlab', pkg$github_url, perl = TRUE))
+      menu$github <- menu_icon("gitlab", pkg$github_url, style = "fab")
+    else
+      menu$github <- menu_icon("git", pkg$github_url, style = "fab")
   }
 
   print_yaml(menu)


### PR DESCRIPTION
A proposition to link to other git plateforms than github, e.g. gitlab.com or any gitlab server, as asked in issue #1045
I did not change add_github_links accoringly as I do not see clearly how neither what it is for...