### PR TITLE
Fix badges not showing in dev section of sidebar

### DIFF
--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -217,7 +217,7 @@ tweak_homepage_html <- function(html, strip_header = FALSE) {
     list_div <- paste0("<div>", list, "</div>")
     list_html <- list_div %>% xml2::read_html() %>% xml2::xml_find_first(".//div")
 
-    sidebar <- html %>% xml2::xml_find_first(".//div[@id='sidebar']")
+    sidebar <- html %>% xml2::xml_find_first(".//div[@id='pkgdown-sidebar']")
     list_html %>%
       xml2::xml_children() %>%
       purrr::walk(~ xml2::xml_add_child(sidebar, .))


### PR DESCRIPTION
Apparently the div was renamed throughout the package from `sidebar` to `pkgdown-sidebar` at some time.

fixes #1207 