### PR TITLE
Support deploying even if the branch does not exist.

### DIFF
--- a/man/deploy_to_branch.Rd
+++ b/man/deploy_to_branch.Rd
@@ -8,6 +8,7 @@ deploy_to_branch(
   pkg = ".",
   commit_message = construct_commit_message(pkg),
   branch = "gh-pages",
+  remote = "origin",
   ...
 )
 }
@@ -17,6 +18,8 @@ deploy_to_branch(
 \item{commit_message}{The commit message to be used for the commit.}
 
 \item{branch}{The git branch to deploy to}
+
+\item{remote}{The git remote to deploy to}
 
 \item{...}{Additional arguments passed to \code{\link[=build_site]{build_site()}}.}
 }


### PR DESCRIPTION
Previously `deploy_to_branch()` would fail if the branch you were
deploying to did not exist on the remote. This fixes the issue by
creating a new orphan branch and pushing it to the remote if it does not
already exist.

Fixes #1223