### PR TITLE
Support @examplesIf roxygen tag, conditional examples

### DIFF
--- a/R/rd-example.R
+++ b/R/rd-example.R
@@ -61,14 +61,18 @@ process_conditional_examples <- function(rd) {
         if (isTRUE(cond)) {
           remove <- c(remove, idx, idx + 1L)
         } else {
-          if (deparse(cond_expr) != "FALSE") {
+          is_false <- deparse(cond_expr) == "FALSE"
+          if (!is_false) {
+            new_cond <- paste0("if (FALSE) { # ", deparse(cond_expr))
             warning(
               "@examplesIf condition `",
               deparse(cond_expr),
               "` is FALSE"
             )
+          } else {
+            new_cond <- "if (FALSE) {"
           }
-          rd[[idx]] <- structure(list("if (FALSE) {"), class = c("RCODE", "tag"))
+          rd[[idx]] <- structure(list(new_cond), class = c("RCODE", "tag"))
         }
       } else {
         # End of @examplesIf

--- a/R/rd-example.R
+++ b/R/rd-example.R
@@ -1,6 +1,7 @@
 rd2ex <- function(x, ...) {
-  x <- rd_text(paste0("\\examples{", x, "}"), fragment = FALSE)
-  x <- flatten_ex(x[[1]], ...)
+  x <- rd_text(paste0("\\examples{", x, "}"), fragment = FALSE)[[1]]
+  x <- process_conditional_examples(x)
+  x <- flatten_ex(x, ...)
 
   if (grepl("\n", x)) {
     strsplit(x, "\n")[[1]]

--- a/R/test.R
+++ b/R/test.R
@@ -113,6 +113,19 @@ NULL
 #' answer <- 42
 #' }
 #' answer # should be 42
+#'
+#' # To hide the \dontshow part, for conditional examples
+#' \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+#' answer <- 43
+#' \dontshow{\}) # examplesIf}
+#' answer # should be still 42
+#'
+#' # But this one runs, and the condition is hidden
+#' \dontshow{if (TRUE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+#' answer <- 43
+#' \dontshow{\}) # examplesIf}
+#' answer
+
 NULL
 
 #' Test case: params

--- a/man/test-dont.Rd
+++ b/man/test-dont.Rd
@@ -32,6 +32,18 @@ answer <- 1
 answer <- 42
 }
 answer # should be 42
+
+# To hide the \dontshow part, for conditional examples
+\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+answer <- 43
+\dontshow{\}) # examplesIf}
+answer # should be still 42
+
+# But this one runs, and the condition is hidden
+\dontshow{if (TRUE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+answer <- 43
+\dontshow{\}) # examplesIf}
+answer
 }
 \seealso{
 Other tests: 

--- a/tests/testthat/test-rd-example.R
+++ b/tests/testthat/test-rd-example.R
@@ -53,7 +53,7 @@ test_that("extracts conditions from if", {
 
 test_that("@examplesIf", {
   rd <- paste0(
-    "\\dontshow{if (FALSE) (if (getRversion() >= \"3.4\") withAutoprint else force)(\\{ # examplesIf}\n",
+    "\\dontshow{if (1 == 0) (if (getRversion() >= \"3.4\") withAutoprint else force)(\\{ # examplesIf}\n",
     "answer <- 43\n",
     "\\dontshow{\\}) # examplesIf}"
   )
@@ -62,7 +62,10 @@ test_that("@examplesIf", {
     "answer <- 43",
     "}"
   )
-  expect_equal(rd2ex(rd), exp)
+  expect_warning(
+    expect_equal(rd2ex(rd), exp),
+    "@examplesIf condition"
+  )
 
   rd2 <- paste0(
     "\\dontshow{if (TRUE) (if (getRversion() >= \"3.4\") withAutoprint else force)(\\{ # examplesIf}\n",

--- a/tests/testthat/test-rd-example.R
+++ b/tests/testthat/test-rd-example.R
@@ -50,3 +50,28 @@ test_that("extracts conditions from if", {
   expect_equal(rd2ex("\\ifelse{html}{1 + 2}{3 + 4}"), "1 + 2")
   expect_equal(rd2ex("\\ifelse{latex}{1 + 2}{3 + 4}"), "3 + 4")
 })
+
+test_that("@examplesIf", {
+  rd <- paste0(
+    "\\dontshow{if (FALSE) (if (getRversion() >= \"3.4\") withAutoprint else force)(\\{ # examplesIf}\n",
+    "answer <- 43\n",
+    "\\dontshow{\\}) # examplesIf}"
+  )
+  exp <- c(
+    "if (FALSE) {",
+    "answer <- 43",
+    "}"
+  )
+  expect_equal(rd2ex(rd), exp)
+
+  rd2 <- paste0(
+    "\\dontshow{if (TRUE) (if (getRversion() >= \"3.4\") withAutoprint else force)(\\{ # examplesIf}\n",
+    "answer <- 43\n",
+    "\\dontshow{\\}) # examplesIf}"
+  )
+  exp2 <- c(
+    "answer <- 43"
+  )
+  expect_equal(rd2ex(rd2), exp2)
+
+})

--- a/tests/testthat/test-rd-example.R
+++ b/tests/testthat/test-rd-example.R
@@ -58,7 +58,7 @@ test_that("@examplesIf", {
     "\\dontshow{\\}) # examplesIf}"
   )
   exp <- c(
-    "if (FALSE) {",
+    "if (FALSE) { # 1 == 0",
     "answer <- 43",
     "}"
   )


### PR DESCRIPTION
Unfortunately we need to parse and transform the Rd, so it is not completely trivial. This seems unavoidable.

If the condition is met, then the condition is not shown at all, and the code runs. 

If the condition is not met, then it is replaced by `if (FALSE)`, so the example code does not run. We can probably improve this.