### PR TITLE
Alert user that `build_home()` does not update images on home page

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -64,6 +64,11 @@
 #' ```
 #' }
 #'
+#' Note that `build_home()` does not copy the figures from `man/figures` to the
+#' directory where they are needed to be shown on the website. This copying is 
+#' effected by running `build_reference()`. So if you want to update the figures
+#' on the home page, be sure to run `build_reference()` in addition to `build_home()`.
+#'
 #' @section Package logo:
 #' If you have a package logo, you can include it at the top of your README in a
 #' level-one heading:


### PR DESCRIPTION
Currently the user needs to run `build_reference()` in order to update the images on the home page, see #1225. This patch adds an explanation of this to the documentation. An alternative would be to let `build_home()` do the updating of the images itself. A pull request for that was however rejected by Hadley, see #1226