### PR TITLE
Declare encoding of citation as UTF-8

### DIFF
--- a/R/build-home-citation.R
+++ b/R/build-home-citation.R
@@ -3,7 +3,7 @@ has_citation <- function(path = ".") {
   file_exists(path(path, 'inst/CITATION'))
 }
 
-create_meta <- function(path) {
+create_citation_meta <- function(path) {
   path <- path(path, "DESCRIPTION")
 
   dcf <- read.dcf(path)
@@ -11,8 +11,9 @@ create_meta <- function(path) {
 
   if (!is.null(meta$Encoding)) {
     meta <- lapply(meta, iconv, from = meta$Encoding, to = "UTF-8")
+  } else {
+    meta$Encoding <- "UTF-8"
   }
-  meta$Encoding <- "UTF-8"
 
   meta
 }
@@ -21,7 +22,7 @@ read_citation <- function(path = ".") {
   if (!has_citation(path)) {
     return(character())
   }
-  meta <- create_meta(path)
+  meta <- create_citation_meta(path)
   cit_path <- path(path, 'inst/CITATION')
 
   utils::readCitationFile(cit_path, meta = meta)

--- a/R/build-home-citation.R
+++ b/R/build-home-citation.R
@@ -12,6 +12,7 @@ create_meta <- function(path) {
   if (!is.null(meta$Encoding)) {
     meta <- lapply(meta, iconv, from = meta$Encoding, to = "UTF-8")
   }
+  meta$Encoding <- "UTF-8"
 
   meta
 }

--- a/tests/testthat/test-build-citation-authors.R
+++ b/tests/testthat/test-build-citation-authors.R
@@ -22,7 +22,7 @@ test_that("latin1 encoding and `citation(auto = meta) can be read` (#689)", {
 test_that("create_meta can read DESCRIPTION with an Encoding", {
   path <- test_path("assets/site-citation/encoding-UTF-8")
 
-  meta <- create_meta(path)
+  meta <- create_citation_meta(path)
   expect_type(meta, "list")
   expect_equal(meta$`Authors@R`, 'person(\"Florian\", \"Privé\")')
 })


### PR DESCRIPTION
Since the previous line re-encode if already set and UTF-8 is a reasonable default.

Fixes #975