### PR TITLE
Tweak dl styling

### DIFF
--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -329,7 +329,7 @@ as_html.tag_enumerate <- function(x, ...) {
 }
 #' @export
 as_html.tag_describe <- function(x, ...) {
-  paste0("<dl class='dl-horizontal'>\n", parse_descriptions(x[-1], ...), "\n</dl>")
+  paste0("<dl'>\n", parse_descriptions(x[-1], ...), "\n</dl>")
 }
 
 # Effectively does nothing: only used by parse_items() to split up

--- a/R/test.R
+++ b/R/test.R
@@ -25,9 +25,24 @@
 #'
 #' \subsection{Definition list}{
 #' \describe{
-#'   \item{a}{1}
-#'   \item{b}{2}
-#'   \item{This is a very long definition term}{}
+#'   \item{short}{short}
+#'   \item{short}{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+#'   eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+#'   minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+#'   ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+#'   voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+#'   sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+#'   mollit anim id est laborum.}
+#'   \item{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+#'   eiusmod tempor incididunt ut labore et dolore magna aliqua.}{short}
+#'   \item{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+#'   eiusmod tempor incididunt ut labore et dolore magna aliqua.}{Lorem ipsum
+#'   adipiscing elit, sed do  eiusmod tempor incididunt ut labore et dolore ad
+#'   minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+#'   ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+#'   voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+#'   sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+#'   mollit anim id est laborum.}
 #' }
 #' }
 #' @keywords internal

--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -71,6 +71,10 @@ summary {
   margin-top: calc(-60px + 1em);
 }
 
+dd {
+  margin-left: 3em;
+}
+
 /* Section anchors ---------------------------------*/
 
 a.anchor {

--- a/man/test-lists.Rd
+++ b/man/test-lists.Rd
@@ -26,9 +26,24 @@
 
 \subsection{Definition list}{
 \describe{
-  \item{a}{1}
-  \item{b}{2}
-  \item{This is a very long definition term}{}
+  \item{short}{short}
+  \item{short}{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+  eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+  minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+  ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+  voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+  sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+  mollit anim id est laborum.}
+  \item{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+  eiusmod tempor incididunt ut labore et dolore magna aliqua.}{short}
+  \item{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+  eiusmod tempor incididunt ut labore et dolore magna aliqua.}{Lorem ipsum
+  adipiscing elit, sed do  eiusmod tempor incididunt ut labore et dolore ad
+  minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+  ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+  voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+  sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+  mollit anim id est laborum.}
 }
 }
 }

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -317,7 +317,7 @@ test_that("nested item with whitespace parsed correctly", {
       This text is indented in a way pkgdown doesn't like.
   }}")
   expect_equal(out, c(
-    "<dl class='dl-horizontal'>",
+    "<dl'>",
     "<dt>Label</dt><dd><p>This text is indented in a way pkgdown doesn't like.</p></dd>",
     "</dl>"
   ))


### PR DESCRIPTION
Fixes #786

Rendering of `test-lists`:

<img width="885" alt="Screenshot 2020-03-22 at 9 25 27 AM" src="https://user-images.githubusercontent.com/4196/77251905-13c9ce00-6c1f-11ea-918e-ecc75c95ef5c.png">
