### PR TITLE
Explicitly set the remote's branch before fetching

### DIFF
--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -132,6 +132,10 @@ deploy_to_branch <- function(pkg = ".",
 
   }
 
+  # Explicitly set the branches tracked by the origin remote.
+  # Needed if we are using a shallow clone, such as on travis-CI
+  git("remote", "set-branches", remote, branch)
+
   git("fetch", remote, branch)
 
   github_worktree_add(dest_dir, remote, branch)


### PR DESCRIPTION
Travis-CI uses a shallow clone of the repository, which means that the
'origin' remote only tracks the HEAD branch. Even if we later fetch a
different branch the worktree command will still fail, because the
branch is not tracked by the remote. Using `git set-branches` we can
explicitly add the branch we are trying to deploy to be tracked by the
remote, which fixes the issue.

Fixes #1271