### PR TITLE
pass branch arg to deploy_to_branch() in deploy_site_github()

### DIFF
--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -1,11 +1,12 @@
 #' Deploy a pkgdown site on Travis-CI to Github Pages
 #'
 #' `deploy_site_github()` sets up your SSH keys for deployment, builds the
-#' site with [build_site()], commits the site to the `gh-pages` branch and then pushes
-#' the results back to GitHub. `deploy_site_github()` is meant only to be used
-#' by the CI system on Travis, it should not be called locally.
-#' [deploy_to_branch()] can be used to deploy a site directly to GitHub Pages
-#' locally. See 'Setup' for details on setting up your repository to use this.
+#' site with [build_site()], commits the site to the `gh-pages` branch (by
+#' default) and then pushes the results back to GitHub. `deploy_site_github()`
+#' is meant only to be used by the CI system on Travis, it should not be called
+#' locally. [deploy_to_branch()] can be used to deploy a site directly to GitHub
+#' Pages locally. See 'Setup' for details on setting up your repository to use
+#' this.
 #'
 #' @section Setup:
 #' For a quick setup, you can use [usethis::use_pkgdown_travis()]. It  will help you
@@ -26,8 +27,9 @@
 #' keys to your GitHub and Travis accounts. See the [travis package
 #' website](https://docs.ropensci.org/travis/index.html) for more details.
 #'
-#' * Next, make sure that a gh-pages branch exists. The simplest way to do
-#' so is to run the following git commands locally:
+#' * Next, make sure that a gh-pages branch (or some other branch that you'd
+#' like to push to) exists. The simplest way to do so is to run the following
+#' git commands locally:
 #'
 #'     ```
 #'     git checkout --orphan gh-pages
@@ -59,7 +61,8 @@
 #'   `travis::use_travis_deploy()`.
 #' @param commit_message The commit message to be used for the commit.
 #' @param verbose Print verbose output
-#' @param ... Additional arguments passed to [build_site()].
+#' @param ... Additional arguments passed to [build_site()] (or a `branch`
+#' argument to be supplied to [deploy_to_branch()])
 #' @param repo_slug **Deprecated** No longer used.
 #' @export
 deploy_site_github <- function(
@@ -97,7 +100,7 @@ deploy_site_github <- function(
   cat_line("Setting private key permissions to 0600")
   fs::file_chmod(ssh_id_file, "0600")
 
-  deploy_to_branch(pkg, commit_message = commit_message, branch = "gh-pages", ...)
+  deploy_to_branch(pkg, commit_message = commit_message, ...)
 
   rule("Deploy completed", line = 2)
 }

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -33,17 +33,19 @@ new keypair specifically for deploying the site. The easiest way is to use
 
 \item{verbose}{Print verbose output}
 
-\item{...}{Additional arguments passed to \code{\link[=build_site]{build_site()}}.}
+\item{...}{Additional arguments passed to \code{\link[=build_site]{build_site()}} (or a \code{branch}
+argument to be supplied to \code{\link[=deploy_to_branch]{deploy_to_branch()}})}
 
 \item{repo_slug}{\strong{Deprecated} No longer used.}
 }
 \description{
 \code{deploy_site_github()} sets up your SSH keys for deployment, builds the
-site with \code{\link[=build_site]{build_site()}}, commits the site to the \code{gh-pages} branch and then pushes
-the results back to GitHub. \code{deploy_site_github()} is meant only to be used
-by the CI system on Travis, it should not be called locally.
-\code{\link[=deploy_to_branch]{deploy_to_branch()}} can be used to deploy a site directly to GitHub Pages
-locally. See 'Setup' for details on setting up your repository to use this.
+site with \code{\link[=build_site]{build_site()}}, commits the site to the \code{gh-pages} branch (by
+default) and then pushes the results back to GitHub. \code{deploy_site_github()}
+is meant only to be used by the CI system on Travis, it should not be called
+locally. \code{\link[=deploy_to_branch]{deploy_to_branch()}} can be used to deploy a site directly to GitHub
+Pages locally. See 'Setup' for details on setting up your repository to use
+this.
 }
 \section{Setup}{
 
@@ -59,8 +61,9 @@ deploy:
 \item Then you will need to setup your deployment keys. The easiest way is to call
 \code{travis::use_travis_deploy()}. This will generate and push the necessary
 keys to your GitHub and Travis accounts. See the \href{https://docs.ropensci.org/travis/index.html}{travis package website} for more details.
-\item Next, make sure that a gh-pages branch exists. The simplest way to do
-so is to run the following git commands locally:\preformatted{git checkout --orphan gh-pages
+\item Next, make sure that a gh-pages branch (or some other branch that you'd
+like to push to) exists. The simplest way to do so is to run the following
+git commands locally:\preformatted{git checkout --orphan gh-pages
 git rm -rf .
 git commit --allow-empty -m 'Initial gh-pages commit'
 git push origin gh-pages


### PR DESCRIPTION
Something @andrewpbray and I came across while configuring automatic deployment of the `infer` site—it looks like `deploy_site_github()` only allows for pushing to a `gh-pages` branch. We were hoping to automatically deploy docs for the development version of the package to a separate branch that we have a development-version website running off of. 

This PR would allow for the optional specification of a `branch` argument other than `gh-pages` to `deploy_site_github()`, and updates documentation to reflect the change.