### PR TITLE
use RETRY logic for HTTP calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* All HTTP requests are now retried upon failure (@jameslamb, #1305).
+
 * Highlighting of empty expressions was restored (#1310).
 
 * `\preformatted{}` no longer double escapes its contents (#1311).

--- a/R/build-favicons.R
+++ b/R/build-favicons.R
@@ -57,9 +57,11 @@ build_favicons <- function(pkg = ".", overwrite = FALSE) {
     )
   )
 
-  resp <- httr::POST(
+  resp <- httr::RETRY(
+    "POST",
     "https://realfavicongenerator.net/api/favicon",
-    body = json_request, encode = "json",
+    body = json_request,
+    encode = "json"
   )
   if (httr::http_error(resp)) {
     stop("API request failed.", call. = FALSE)
@@ -78,7 +80,7 @@ build_favicons <- function(pkg = ".", overwrite = FALSE) {
 
   tmp <- tempfile()
   on.exit(unlink(tmp))
-  result <- httr::GET(result$favicon$package_url, httr::write_disk(tmp))
+  result <- httr::RETRY("GET", result$favicon$package_url, httr::write_disk(tmp))
 
   tryCatch({
     utils::unzip(tmp, exdir = path(pkg$src_path, "pkgdown", "favicon"))

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -98,7 +98,7 @@ cran_link <- memoise(function(pkg) {
 
   # bioconductor always returns a 200 status, redirecting to /removed-packages/
   bioc_url <- paste0("https://www.bioconductor.org/packages/", pkg)
-  req <- httr::HEAD(bioc_url)
+  req <- httr::RETRY("HEAD", bioc_url)
   if (!httr::http_error(req) && !grepl("removed-packages", req$url)) {
     return(list(repo = "BIOC", url = bioc_url))
   }

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -232,7 +232,7 @@ pkg_timeline <- function(package) {
 
   url <- paste0("https://crandb.r-pkg.org/", package, "/all")
 
-  resp <- httr::GET(url)
+  resp <- httr::RETRY("GET", url)
   if (httr::http_error(resp)) {
     return(NULL)
   }

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -46,7 +46,7 @@ remote_metadata <- memoise(function(package) {
 })
 
 fetch_yaml <- function(url) {
-  resp <- httr::GET(url, httr::timeout(3))
+  resp <- httr::RETRY("GET", url, httr::timeout(3))
   httr::stop_for_status(resp)
 
   text <- httr::content(resp, as = "text", encoding = "UTF-8")


### PR DESCRIPTION
Thanks for for this awesome project!

In this PR, I'd like to propose swapping out calls to `httr::<verb>()` etc. with `httr::RETRY()`. This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on https://github.com/chircollab/chircollab20/issues/1 as part of Chicago R Collab, an R 'unconference' in Chicago.