### PR TITLE
Allow highlighting of empty expressions

### DIFF
--- a/R/highlight.r
+++ b/R/highlight.r
@@ -10,8 +10,8 @@ highlight_text <- function(text) {
     error = function(e) NULL
   )
 
-  # Failed to parse, or yielded empty expression
-  if (length(expr) == 0) {
+  # Failed to parse
+  if (is.null(expr)) {
     return(escape_html(text))
   }
 

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -58,3 +58,10 @@ test_that("unparsed code is still escaped", {
 
   expect_equal(highlight_text("<"), "&lt;")
 })
+
+test_that("code consisting of comments only is not stripped of tags", {
+  scoped_package_context("test")
+
+  expect_equal(highlight_text("#"), "<span class='co'>#</span>")
+})
+


### PR DESCRIPTION
This will prevent highlight markup from being stripped from code that consists entirely
of code comments (only lines beginning with #'s).

A partial fix for https://github.com/r-lib/pkgdown/issues/1296, but would still not syntax highlight code chunks that resulted in syntax
errors (e.g., when chunk options `collapse = TRUE` and `comment = NA`) 