### PR TITLE
Fix typo in <dl> header

### DIFF
--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -329,7 +329,7 @@ as_html.tag_enumerate <- function(x, ...) {
 }
 #' @export
 as_html.tag_describe <- function(x, ...) {
-  paste0("<dl'>\n", parse_descriptions(x[-1], ...), "\n</dl>")
+  paste0("<dl>\n", parse_descriptions(x[-1], ...), "\n</dl>")
 }
 
 # Effectively does nothing: only used by parse_items() to split up

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -317,7 +317,7 @@ test_that("nested item with whitespace parsed correctly", {
       This text is indented in a way pkgdown doesn't like.
   }}")
   expect_equal(out, c(
-    "<dl'>",
+    "<dl>",
     "<dt>Label</dt><dd><p>This text is indented in a way pkgdown doesn't like.</p></dd>",
     "</dl>"
   ))


### PR DESCRIPTION
015f5f56d842a45094beda9bb8d40b2b8f79fc9b introduced a typo into the `<dl>` header, which causes subsequent blocks to be absorbed into the `<dl>` by some rendering engines (e.g. Chrome’s). In most (all?) cases this luckily only causes subtle spacing issues.