### PR TITLE
Allow highlighting of some empty expressions

### DIFF
--- a/R/highlight.r
+++ b/R/highlight.r
@@ -11,7 +11,7 @@ highlight_text <- function(text) {
   )
 
   # Failed to parse or is white-space only/empty
-  if (is.null(expr) || !nchar(trimws(text))) {
+  if (is.null(expr) || trimws(text) == "") {
     return(escape_html(text))
   }
 

--- a/R/highlight.r
+++ b/R/highlight.r
@@ -10,8 +10,8 @@ highlight_text <- function(text) {
     error = function(e) NULL
   )
 
-  # Failed to parse, or yielded empty expression
-  if (length(expr) == 0) {
+  # Failed to parse or is white-space only/empty
+  if (is.null(expr) || !nchar(trimws(text))) {
     return(escape_html(text))
   }
 

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -59,3 +59,20 @@ test_that("unparsed code is still escaped", {
   expect_equal(highlight_text("<"), "&lt;")
 })
 
+test_that("code consisting of comments only is not stripped of tags", {
+  scoped_package_context("test")
+
+  expect_equal(highlight_text("#"), "<span class='co'>#</span>")
+})
+
+test_that("code consisting of an empty string is parsed correctly", {
+  scoped_package_context("test")
+
+  expect_equal(highlight_text(""), "")
+})
+
+test_that("code consisting of white-space only is parsed correctly", {
+  scoped_package_context("test")
+
+  expect_equal(highlight_text("\n\t"), "\n\t")
+})


### PR DESCRIPTION
Improved version of #1307 accounting for problems caused by empty expressions consisting of empty strings or whitespace only.

Prevents highlight markup from being stripped from code that consists entirely of code comments (only lines beginning with #'s).

A partial fix for #1296, but would still not syntax highlight code chunks that resulted in syntax
errors (e.g., when knitr chunk options collapse = TRUE and comment = NA are set)