### PR TITLE
set a min-width of the reference table

### DIFF
--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -244,7 +244,7 @@ nav[data-toggle='toc'] .nav .nav > .active:focus > a {
 
 .ref-index th {font-weight: normal;}
 
-.ref-index td {vertical-align: top;}
+.ref-index td {vertical-align: top; min-width: 100px}
 .ref-index .icon {width: 40px;}
 .ref-index .alias {width: 40%;}
 .ref-index-icons .alias {width: calc(40% - 40px);}


### PR DESCRIPTION
There could be a rendering issue if the first column of the reference page is too narrow. For example,

<img width="743" alt="Screen Shot 2020-04-25 at 6 33 11 PM" src="https://user-images.githubusercontent.com/1690993/80295004-aaf4da80-8723-11ea-95f4-2edec867e2f7.png">


This PR makes sure that each column has at least some minimum width so the table will be rendered nicely.

<img width="680" alt="Screen Shot 2020-04-25 at 6 35 37 PM" src="https://user-images.githubusercontent.com/1690993/80295017-bf38d780-8723-11ea-9092-9162b6f48a6c.png">
