### PR TITLE
Add header_attributes to markdown extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Setting `clean = TRUE` in `deploy_site_github()` removes old files from the deployed site before building a new one (#1297).
 
+* Markdown header attributes are now processed in all markdown files (@jonkeane)
+
 # pkgdown 1.5.1
 
 * Syntax highlighting works on Windows once more (#1282).

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Setting `clean = TRUE` in `deploy_site_github()` removes old files from the deployed site before building a new one (#1297).
 
-* Markdown header attributes are now processed in all markdown files (@jonkeane)
+* Markdown header attributes are now processed in all markdown files (@jonkeane, #1343)
 
 # pkgdown 1.5.1
 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -3,9 +3,9 @@ markdown <- function(path = NULL, ..., strip_header = FALSE) {
   on.exit(file_delete(tmp), add = TRUE)
 
   if (rmarkdown::pandoc_available("2.0")) {
-    from <- "markdown_github-hard_line_breaks+smart+auto_identifiers+tex_math_dollars+tex_math_single_backslash+markdown_in_html_blocks"
+    from <- "markdown_github-hard_line_breaks+smart+auto_identifiers+tex_math_dollars+tex_math_single_backslash+markdown_in_html_blocks+header_attributes"
   } else if (rmarkdown::pandoc_available("1.12.3")) {
-    from <- "markdown_github-hard_line_breaks+tex_math_dollars+tex_math_single_backslash"
+    from <- "markdown_github-hard_line_breaks+tex_math_dollars+tex_math_single_backslash+header_attributes"
   } else {
     stop("Pandoc not available", call. = FALSE)
   }

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -5,7 +5,7 @@ markdown <- function(path = NULL, ..., strip_header = FALSE) {
   if (rmarkdown::pandoc_available("2.0")) {
     from <- "markdown_github-hard_line_breaks+smart+auto_identifiers+tex_math_dollars+tex_math_single_backslash+markdown_in_html_blocks+header_attributes"
   } else if (rmarkdown::pandoc_available("1.12.3")) {
-    from <- "markdown_github-hard_line_breaks+tex_math_dollars+tex_math_single_backslash+header_attributes"
+    from <- "markdown_github-hard_line_breaks+tex_math_dollars+tex_math_single_backslash"
   } else {
     stop("Pandoc not available", call. = FALSE)
   }

--- a/tests/testthat/assets/readme-with-attr.md
+++ b/tests/testthat/assets/readme-with-attr.md
@@ -1,0 +1,4 @@
+
+# Header {.class #id}
+
+Paragraph

--- a/tests/testthat/assets/readme-with-attr.md
+++ b/tests/testthat/assets/readme-with-attr.md
@@ -1,4 +1,0 @@
-
-# Header {.class #id}
-
-Paragraph

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -69,3 +69,9 @@ test_that("homepage description can be overridden", {
 
 })
 
+test_that("header attributes are parsed", {
+  index_xml <- markdown(normalizePath(test_path("assets/readme-with-attr.md")))
+
+  expect_true(grepl("id=\"id\"", index_xml))
+  expect_true(grepl("class=\".*? class\"", index_xml))
+})

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -68,10 +68,3 @@ test_that("homepage description can be overridden", {
   )
 
 })
-
-test_that("header attributes are parsed", {
-  index_xml <- markdown(normalizePath(test_path("assets/readme-with-attr.md")))
-
-  expect_true(grepl("id=\"id\"", index_xml))
-  expect_true(grepl("class=\".*? class\"", index_xml))
-})

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -3,7 +3,7 @@ test_that("empty string works", {
 })
 
 test_that("header attributes are parsed", {
-  index_xml <- markdown_text(read_lines(test_path("assets/readme-with-attr.md")))
+  index_xml <- markdown_text("# Header {.class #id}")
 
   expect_true(grepl("id=\"id\"", index_xml))
   expect_true(grepl("class=\".*? class\"", index_xml))

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -1,3 +1,10 @@
 test_that("empty string works", {
   expect_equal(markdown_text(""), "")
 })
+
+test_that("header attributes are parsed", {
+  index_xml <- markdown(normalizePath(test_path("assets/readme-with-attr.md")))
+
+  expect_true(grepl("id=\"id\"", index_xml))
+  expect_true(grepl("class=\".*? class\"", index_xml))
+})

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -3,7 +3,7 @@ test_that("empty string works", {
 })
 
 test_that("header attributes are parsed", {
-  index_xml <- markdown(normalizePath(test_path("assets/readme-with-attr.md")))
+  index_xml <- markdown_text(read_lines(test_path("assets/readme-with-attr.md")))
 
   expect_true(grepl("id=\"id\"", index_xml))
   expect_true(grepl("class=\".*? class\"", index_xml))


### PR DESCRIPTION
Thanks for all the great work on `pkgdown` it's really fantastic. 

When building a site I noticed that building my index from `readme.md`, `index.md`, etc. wasn't catching and interpreting [header attributes](https://pandoc.org/MANUAL.html#extension-header_attributes) like `rmarkdown` does when rendering vignettes. It looks like this is because the flavor `markdwn_github` doesn't have the extension `header_attributes` on by default (since github doesn't strictly implement that itself). This adds that extension so that pkgdown rendered pages will use so that custom classes, ids, and attributes can be specified in a similar way that they can in vignettes.

This might be better as an optional parameter in case anyone was relying on rendering unescaped curly-brackets in headers. 