### PR TITLE
Add an option to specify which git branch to link to

### DIFF
--- a/R/repo.R
+++ b/R/repo.R
@@ -72,9 +72,10 @@ repo_meta <- function(home = NULL, source = NULL, issue = NULL, user = NULL) {
 
 repo_meta_gh_like <- function(link) {
   gh <- parse_github_like_url(link)
+  default_branch <- getOption("pkgdown.default.branch", "master")
   repo_meta(
     paste0(gh$host, "/", gh$owner, "/", gh$repo, "/"),
-    paste0(gh$host, "/", gh$owner, "/", gh$repo, "/blob/master/"),
+    paste0(gh$host, "/", gh$owner, "/", gh$repo, "/blob/", default_branch, "/"),
     paste0(gh$host, "/", gh$owner, "/", gh$repo, "/issues/"),
     paste0(gh$host, "/")
   )

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -29,6 +29,20 @@ test_that("repo_source() truncates automatically", {
   })
 })
 
+# repo_source with alternate default branch -------------------------------
+
+test_that("repo_source() truncates automatically", {
+  withr::with_options(
+    list("pkgdown.default.branch" = "main"), {
+      pkg <- list(repo = repo_meta_gh_like("https://github.com/r-lib/pkgdown"))
+
+      expect_match(
+        repo_source(pkg, "a"),
+        "https://github.com/r-lib/pkgdown/blob/main/a"
+      )
+    }
+  )
+})
 
 # package_repo ------------------------------------------------------------
 

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -31,7 +31,7 @@ test_that("repo_source() truncates automatically", {
 
 # repo_source with alternate default branch -------------------------------
 
-test_that("repo_source() truncates automatically", {
+test_that("repo_source() uses the default branch option", {
   withr::with_options(
     list("pkgdown.default.branch" = "main"), {
       pkg <- list(repo = repo_meta_gh_like("https://github.com/r-lib/pkgdown"))


### PR DESCRIPTION
Thank you again for all of the hardworking on pkgdown, it's a really great package.

When the option `"pkgdown.default.branch"` is set, that value will be used as the branch name for URLs instead of a hardcoded version. 

I could imagine a few other ways to implement this as well (e.g. using git config options to figure out what the branch name ought to be) but wanted to send this as a lightweight change. I'm happy to explore other options as well. I haven't added to the documentation for this change, but will if this approach is acceptable to the maintainers.