### PR TITLE
Add support to html_vignette with as_is: true in pkgdown (alternative to #1352)

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -264,8 +264,8 @@ build_article <- function(name,
 
       options <- list(
         template = template$path,
-        self_contained = FALSE,
-        theme = NULL
+        self_contained = FALSE
+        # , theme = NULL
       )
     } else {
       options <- list()


### PR DESCRIPTION
This PR is similar to #1352, but instead of adding the YAML option to disable hardcoded `NULL` theme, removes the hardcoding at all.

See #1352 for the discussion.