### PR TITLE
make adding default citation an option

### DIFF
--- a/R/build-home-citation.R
+++ b/R/build-home-citation.R
@@ -67,9 +67,9 @@ data_citations <- function(pkg = ".") {
     return(purrr::transpose(cit))
   }
 
-  autocit <- packageDescription(pkg$package)
+  autocit <- utils::packageDescription(pkg$package)
   autocit$`Date/Publication` <- Sys.time()
-  cit <- citation(auto = autocit)
+  cit <- utils::citation(auto = autocit)
   list(
     html = paste0("<p>", format(cit, style = "textVersion"), "</p>"),
     bibtex = format(cit, style = "bibtex")

--- a/R/build-home-citation.R
+++ b/R/build-home-citation.R
@@ -72,7 +72,7 @@ data_citations <- function(pkg = ".") {
   cit <- citation(auto = autocit)
   list(
     html = paste0("<p>", format(cit, style = "textVersion"), "</p>"),
-    bibtex = format(cit, style = "Bibtex")
+    bibtex = format(cit, style = "bibtex")
     )
 }
 

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -147,6 +147,18 @@
 #'     href: "http://name-website.com"
 #'     html: "<img src='name-picture.png' height=24>"
 #' ```
+#'
+#' @section YAML config - citation:
+#' Even in the absence of `inst/CITATION`, standard information on how to cite
+#' the package will be added to the authors page and linked from the sidebar if
+#'
+#' ```
+#' forcecitation: true
+#' ```
+#'
+#' If you want to encourage users of your package to cite an article or book
+#' instead, add a file `inst/CITATION` with more specific information.
+#'
 #' @inheritParams build_articles
 #' @export
 build_home <- function(pkg = ".",
@@ -158,11 +170,12 @@ build_home <- function(pkg = ".",
   rule("Building home")
   dir_create(pkg$dst_path)
 
-  if (has_citation(pkg$src_path)) {
+  if (need_citation(pkg)) {
     build_citation_authors(pkg)
   } else {
     build_authors(pkg)
   }
+
   build_home_md(pkg)
   build_home_license(pkg)
   build_home_index(pkg, quiet = quiet)

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -153,3 +153,13 @@ sponsor.
 }
 }
 
+\section{YAML config - citation}{
+
+Even in the absence of \code{inst/CITATION}, standard information on how to cite
+the package will be added to the authors page and linked from the sidebar if\preformatted{forcecitation: true
+}
+
+If you want to encourage users of your package to cite an article or book
+instead, add a file \code{inst/CITATION} with more specific information.
+}
+

--- a/tests/testthat/assets/site-citation/default-citation/DESCRIPTION
+++ b/tests/testthat/assets/site-citation/default-citation/DESCRIPTION
@@ -1,0 +1,10 @@
+Package: pkgdown
+Version: 1.0.0
+Title: A test package
+Description: A longer statement about the package.
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = c("cph", "fnd"))
+    )
+RoxygenNote: 6.0.1
+URL: http://github.com/test

--- a/tests/testthat/assets/site-citation/default-citation/_pkgdown.yml
+++ b/tests/testthat/assets/site-citation/default-citation/_pkgdown.yml
@@ -1,0 +1,1 @@
+forcecitation: true

--- a/tests/testthat/test-build-citation-authors.R
+++ b/tests/testthat/test-build-citation-authors.R
@@ -36,3 +36,23 @@ test_that("source link is added to citation page", {
   lines <- read_lines(path(path, "docs", "authors.html"))
   expect_true(any(grepl("<code>inst/CITATION</code></a></small>", lines)))
 })
+
+test_that("default source link is added to citation page", {
+  path <- test_path("assets/site-citation/default-citation")
+
+  expect_output(build_home(path))
+  on.exit(clean_site(path))
+
+  lines <- read_lines(path(path, "docs", "authors.html"))
+  expect_true(any(grepl("<code>DESCRIPTION</code></a></small>", lines)))
+})
+
+test_that("default citation can be created", {
+  path <- test_path("assets/site-citation/default-citation")
+
+  expect_output(build_home(path))
+  on.exit(clean_site(path))
+
+  lines <- read_lines(path(path, "docs", "authors.html"))
+  expect_true(any(grepl("<pre>@Manual\\{", lines)))
+})


### PR DESCRIPTION
This is a feature request. :-) cc @jeroen 

This PR would add a YAML config field `forcecitation`. If it is true, even in the absence of `inst/CITATION`, some basic citation information would be added.

Here's how it would look like for pkgdown: 

![image](https://user-images.githubusercontent.com/8360597/94553297-98457b00-0258-11eb-860f-a695880c3f07.png)
