### PR TITLE
Set html_document(anchor_sections = FALSE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   horizontal space and wasn't very useful since there is already a link to the 
   home page immediately to its left (#1383).
 
+* `build_rmarkdown_format` internally sets `html_document(anchor_sections = FALSE)` so to avoid needless dependencies (@atusy, #1426).
+
 # pkgdown 1.6.1
 
 * The article index (used for autolinking vignettes across packages) 

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -304,7 +304,8 @@ build_rmarkdown_format <- function(pkg,
     toc_depth = pkg$meta$toc$depth %||% 2,
     self_contained = FALSE,
     theme = NULL,
-    template = template$path
+    template = template$path,
+    anchor_sections = FALSE
   )
   out$knitr$opts_chunk <- fig_opts_chunk(pkg$figures, out$knitr$opts_chunk)
 


### PR DESCRIPTION
This PR internally sets `html_document(anchor_sections = FALSE)` to remove needless JS dependency.

Recently, `html_document` gained the `anchor_sections` argument, whose default is `TRUE`.
It adds a JavaScript dependency to anchor sections.
Although it becomes quiet when the document already anchor sections by themselves,
it still adds needless dependencies.
