### PR TITLE
document and test skipping sections from toc

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -172,6 +172,14 @@
 #'   depth: 2
 #' ```
 #'
+#' To omit a section from the TOC write the heading in HTML and pass it a `data-skip-toc` boolean [HTML data attribute](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes):
+#'
+#' ```rmd
+#' <h3 data-toc-skip> Section Not in TOC {data-toc-skip} </h3>
+#' ```
+#'
+#' The [`.unlisted`](https://pandoc.org/MANUAL.html#heading-identifiers) class used by pandoc is not supported by the pkgdown template.
+#'
 #' @inheritParams as_pkgdown
 #' @param quiet Set to `FALSE` to display output of knitr and
 #'   pandoc. This is useful when debugging.

--- a/vignettes/test/rendering.Rmd
+++ b/vignettes/test/rendering.Rmd
@@ -85,7 +85,7 @@ x
 
 <details>
 <summary>Some R code</summary>
-  
+
 ```{r}
 1 + 2
 ```
@@ -151,3 +151,16 @@ stop(crayon::italic("This is italic"))
 ```
 
 Some more text
+
+
+---
+
+# TOC
+
+## An `.unlisted` Section {.unlisted}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+<h3 data-toc-skip> A `data-toc-skip`ped Section {data-toc-skip} </h3>
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.


### PR DESCRIPTION
this is a shot in the dark at https://github.com/r-lib/pkgdown/issues/1430.

I am guessing that you don't want to support the standard pandoc way to suppress sections from the TOC (`{.unlisted}`) because that presumably does not play nice with [bootstrap-toc](https://afeld.github.io/bootstrap-toc/).

I thought I'd just pass `data-toc-skip` as an attribute to pandoc:

```rmd
### More Skipping {data-toc-skip=true}
```

But this does not work, because pkgdown seems to default to `html_document(section_divs = TRUE)`, and thus, the attribute ends up in a parent div, and not the actual `<h3>` tag or whatever.
As a result, bootstrap-toc won't find it.

So the only solution I could think of without getting into the guts of pkgdown was plain HTML, so I thought I'd document that.