### PR TITLE
protect CLI rule against narrow terminals closes #1435

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* Protect the rules drawn by the CLI (as for example, in `build_site()`) against
+  very narrow terminal windows with small `getOption('width')`s 
+  (@maxheld83, #1435).
+
 * `build_news()` recognises more styles of release heading (#1437).
 
 * Missing topics makes the build fail when the environment variable `CI` is set

--- a/R/utils.r
+++ b/R/utils.r
@@ -91,6 +91,8 @@ rule <- function(x = NULL, line = "-") {
   }
 
   line_length <- width - nchar(x) - nchar(prefix) - nchar(suffix)
+  # protect against negative values which can result in narrow terminals
+  line_length <- max(0, line_length)
   cat_line(prefix, crayon::bold(x), suffix, strrep(line, line_length))
 }
 


### PR DESCRIPTION
I first thought that this kind of thing was now done [cli](https://github.com/r-lib/cli)s job, but that had just been removed in https://github.com/r-lib/pkgdown/commit/77f909b0138a1d7191ad9bb3cf95e78d8e8d93b9, so here's a small fix.

This can be tested with

```r
pkgdown:::rule(paste0(rep(LETTERS, 4), collapse = "")) 
```

which should fail on pretty much any terminal width.

Since this isn't an exported function, I did not add a test.