### PR TITLE
updating opg-validator link

### DIFF
--- a/vignettes/metadata.Rmd
+++ b/vignettes/metadata.Rmd
@@ -21,7 +21,7 @@ Package authors can customize the metadata used by Twitter and the [Open Graph p
 You can preview and validate the appearance of the social media cards with online tools:
 
 * [Twitter Card Validator][twitter-validator]
-* [Google Results Test][ogp-validator]
+* [Google Rich Results Test][ogp-validator]
 
 ## Site-wide customization
 

--- a/vignettes/metadata.Rmd
+++ b/vignettes/metadata.Rmd
@@ -115,5 +115,5 @@ In articles, the `opengraph` section works in the same way as the site-wide `tem
 
 [ogp]: https://ogp.me/
 [twitter-validator]: https://cards-dev.twitter.com/validator
-[ogp-validator]: https://search.google.com/structured-data/testing-tool
+[ogp-validator]: https://search.google.com/test/rich-results
 [twitter-card]: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards

--- a/vignettes/metadata.Rmd
+++ b/vignettes/metadata.Rmd
@@ -21,7 +21,7 @@ Package authors can customize the metadata used by Twitter and the [Open Graph p
 You can preview and validate the appearance of the social media cards with online tools:
 
 * [Twitter Card Validator][twitter-validator]
-* [Google Structured Data Testing Tool][ogp-validator]
+* [Google Results Test][ogp-validator]
 
 ## Site-wide customization
 


### PR DESCRIPTION
Google Structured Data Testing Tool is deprecated, and Google now recommends Google Rich Results Test instead.