### PR TITLE
Add ability to autolink to Jira issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,10 @@ right below the opening `<body>` tag; and before the closing tag `</body>` (#148
 
 * `build_rmarkdown_format` internally sets `html_document(anchor_sections = FALSE)` so to avoid needless dependencies (@atusy, #1426).
 
+* Automatically link Jira issues by setting your project name(s) with 
+`repo: jira_projects: [...]` and specifying a custom issue URL with
+`repo: url: issue: ...` in `_pkgdown.yml` (@jonkeane, #1466).
+
 # pkgdown 1.6.1
 
 * The article index (used for autolinking vignettes across packages) 

--- a/R/build.r
+++ b/R/build.r
@@ -287,6 +287,19 @@
 #' The varying components (e.g. path, issue number, user name) are pasted on
 #' the end of these URLs so they should have trailing `/`s.
 #'
+#' pkgdown can automatically link to Jira issues as well, but you must specify
+#' both a custom `issue` URL as well as your Jira project names to auto-link in
+#' `jira_projects`. You can specify as many projects as you would like in a last
+#' (in the example below we would link both the `PROJ` and `OTHER` Jira
+#' projects):
+#'
+#' ```yaml
+#' repo:
+#'   jira_projects: [PROJ, OTHER]
+#'   url:
+#'     issue: https://jira.organisation.com/jira/browse/
+#' ```
+#'
 #' pkgdown defaults to using the "master" branch for source file URLs. This can
 #' be configured to use a specific branch when linking to source files by
 #' specifying a branch name:

--- a/R/repo.R
+++ b/R/repo.R
@@ -44,6 +44,12 @@ repo_auto_link <- function(pkg, text) {
   if (!is.null(url$issue)) {
     issue_link <- paste0("<a href='", url$issue, "\\1'>#\\1</a>")
     text <- gsub("#(\\d+)", issue_link, text, perl = TRUE)
+
+    if (!is.null(pkg$repo$jira_projects)) {
+      issue_link <- paste0("<a href='", url$issue, "\\1\\2'>\\1\\2</a>")
+      issue_regex <- paste0("(", paste0(pkg$repo$jira_projects, collapse = "|"),")(-\\d+)")
+      text <- gsub(issue_regex, issue_link, text, perl = TRUE)
+    }
   }
 
   text

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -325,6 +325,16 @@ supply your own in the \code{repo} component:\if{html}{\out{<div class="yaml">}}
 The varying components (e.g. path, issue number, user name) are pasted on
 the end of these URLs so they should have trailing \code{/}s.
 
+pkgdown can automatically link to Jira issues as well, but you must specify
+both a custom \code{issue} URL as well as your Jira project names to auto-link in
+\code{jira_projects}. You can specify as many projects as you would like in a last
+(in the example below we would link both the \code{PROJ} and \code{OTHER} Jira
+projects):\if{html}{\out{<div class="yaml">}}\preformatted{repo:
+  jira_projects: [PROJ, OTHER]
+  url:
+    issue: https://jira.organisation.com/jira/browse/
+}\if{html}{\out{</div>}}
+
 pkgdown defaults to using the "master" branch for source file URLs. This can
 be configured to use a specific branch when linking to source files by
 specifying a branch name:\if{html}{\out{<div class="yaml">}}\preformatted{repo:

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -17,6 +17,15 @@ test_that("issues are automatically linked", {
   expect_equal(repo_auto_link(pkg, "#123"), "<a href='TEST/123'>#123</a>")
 })
 
+test_that("Jira issues are automatically linked", {
+  pkg <- list(repo = repo_meta(issue = "TEST/"))
+  pkg$repo$jira_projects <- c("JIRA", "OTHER")
+  expect_equal(repo_auto_link(pkg, "JIRA-123"), "<a href='TEST/JIRA-123'>JIRA-123</a>")
+  expect_equal(repo_auto_link(pkg, "OTHER-4321"), "<a href='TEST/OTHER-4321'>OTHER-4321</a>")
+  # but only the jira projects specified are caught
+  expect_equal(repo_auto_link(pkg, "NOPE-123"), "NOPE-123")
+})
+
 # repo_source -------------------------------------------------------------
 
 test_that("repo_source() truncates automatically", {


### PR DESCRIPTION
The automatic github issue linking in pkgdown is really great. For projects that use jira (e.g. [the apache arrow project](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-6103?filter=allopenissues)) it would be really great to be able to auto-link those issues as well.

This PR implements that autolinking by a package developer supplying a `jira_projects` item as well as a custom `issue` URL in the `repo` field of the _pkgdown.yml. Only when both of those are present does it add a regex like the github issues regex, but for the project names specified.

If this approach is acceptable, I'm happy to also add documentation explaining this setup in the appropriate place. 

Thanks for all of the awesomeness that is pkgdown.