### PR TITLE
Update documentation: devel mode confusing

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -72,22 +72,24 @@
 #'
 #' There are currently four possible modes:
 #'
-#' * **release** (`mode: release`): Default mode. Site written to `docs/`, 
-#'   the version gets the default colouring, and no message.
+#' * **release** (`mode: release`), the default. Site is written to `docs/`.
+#'   Version in navbar gets the default colouring.
 #'
-#' * **development** (`mode: devel`) : written to `docs/dev/`, the version gets a danger label,
-#'   and message stating these are docs for an in-development version of the
-#'   package. The `noindex` meta tag is used to ensure that these packages are
-#'   not indexed by search engines.
+#' * **development** (`mode: devel`). Site is written to `docs/dev/`.
+#'   Version in navbar gets the "danger" class and a message stating these are
+#'   docs for an in-development version of the package. The `noindex` meta tag
+#'   is used to ensure that these packages are not indexed by search engines.
 #'
-#' * **unreleased** (`mode: unreleased`): the package is written to `docs/`, the version gets a "danger"
-#'   label, and the message indicates the package is not yet on CRAN.
+#' * **unreleased** (`mode: unreleased`). Site is written to `docs/`.
+#'   Version in navbar gets the "danger" class, and a message indicating the
+#'   package is not yet on CRAN.
 #'
 #' * **automatic** (`mode: auto`): pkgdown automatically detects the mode
 #'   based on the version number:
-#'   * `0.0.0.9000` (`0.0.0.*`): unreleased
-#'   * four version components: development
-#'   * everything else -> release
+#'
+#'   * `0.0.0.9000` (`0.0.0.*`): unreleased.
+#'   * four version components: development.
+#'   * everything else -> release.
 #'
 #' There are three other options that you can control:
 #'

--- a/R/build.r
+++ b/R/build.r
@@ -62,20 +62,7 @@
 #' * The optional tooltip associated with the version.
 #' * The indexing of the site by search engines.
 #'
-#' There are currently three possible development modes:
-#'
-#' * **release**: site written to `docs/`, the version gets the default
-#'   colouring, and no message.
-#'
-#' * **development**: written to `docs/dev/`, the version gets a danger label,
-#'   and message stating these are docs for an in-development version of the
-#'   package. The `noindex` meta tag is used to ensure that these packages are
-#'   not indexed by search engines.
-#'
-#' * **unreleased**: the package is written to `docs/`, the version gets a "danger"
-#'   label, and the message indicates the package is not yet on CRAN.
-#'
-#' The default development mode is "release". You can override it by adding a
+#' You can override the default development mode by adding a
 #' new `development` field to `_pkgdown.yml`, e.g.
 #'
 #' ```
@@ -83,18 +70,24 @@
 #'   mode: devel
 #' ```
 #'
-#' You can also have pkgdown automatically detect the mode with:
+#' There are currently four possible modes:
 #'
-#' ```
-#' development:
-#'   mode: auto
-#' ```
+#' * **release** (`mode: release`): Default mode. Site written to `docs/`, 
+#'   the version gets the default colouring, and no message.
 #'
-#' The mode will be automatically determined based on the version number:
+#' * **development** (`mode: devel`) : written to `docs/dev/`, the version gets a danger label,
+#'   and message stating these are docs for an in-development version of the
+#'   package. The `noindex` meta tag is used to ensure that these packages are
+#'   not indexed by search engines.
 #'
-#' * `0.0.0.9000` (`0.0.0.*`): unreleased
-#' * four version components: development
-#' * everything else -> release
+#' * **unreleased** (`mode: unreleased`): the package is written to `docs/`, the version gets a "danger"
+#'   label, and the message indicates the package is not yet on CRAN.
+#'
+#' * **automatic** (`mode: auto`): pkgdown automatically detects the mode
+#'   based on the version number:
+#'   * `0.0.0.9000` (`0.0.0.*`): unreleased
+#'   * four version components: development
+#'   * everything else -> release
 #'
 #' There are three other options that you can control:
 #'

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -130,20 +130,21 @@ new \code{development} field to \verb{_pkgdown.yml}, e.g.\preformatted{developme
 
 There are currently four possible modes:
 \itemize{
-\item \strong{release} (\code{mode: release}): Default mode. Site written to \verb{docs/},
-the version gets the default colouring, and no message.
-\item \strong{development} (\code{mode: devel}) : written to \verb{docs/dev/}, the version gets a danger label,
-and message stating these are docs for an in-development version of the
-package. The \code{noindex} meta tag is used to ensure that these packages are
-not indexed by search engines.
-\item \strong{unreleased} (\code{mode: unreleased}): the package is written to \verb{docs/}, the version gets a "danger"
-label, and the message indicates the package is not yet on CRAN.
+\item \strong{release} (\code{mode: release}), the default. Site is written to \verb{docs/}.
+Version in navbar gets the default colouring.
+\item \strong{development} (\code{mode: devel}). Site is written to \verb{docs/dev/}.
+Version in navbar gets the "danger" class and a message stating these are
+docs for an in-development version of the package. The \code{noindex} meta tag
+is used to ensure that these packages are not indexed by search engines.
+\item \strong{unreleased} (\code{mode: unreleased}). Site is written to \verb{docs/}.
+Version in navbar gets the "danger" class, and a message indicating the
+package is not yet on CRAN.
 \item \strong{automatic} (\code{mode: auto}): pkgdown automatically detects the mode
 based on the version number:
 \itemize{
-\item \verb{0.0.0.9000} (\verb{0.0.0.*}): unreleased
-\item four version components: development
-\item everything else -> release
+\item \verb{0.0.0.9000} (\verb{0.0.0.*}): unreleased.
+\item four version components: development.
+\item everything else -> release.
 }
 }
 

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -123,32 +123,28 @@ The development mode of a site controls four main things:
 \item The indexing of the site by search engines.
 }
 
-There are currently three possible development modes:
-\itemize{
-\item \strong{release}: site written to \verb{docs/}, the version gets the default
-colouring, and no message.
-\item \strong{development}: written to \verb{docs/dev/}, the version gets a danger label,
-and message stating these are docs for an in-development version of the
-package. The \code{noindex} meta tag is used to ensure that these packages are
-not indexed by search engines.
-\item \strong{unreleased}: the package is written to \verb{docs/}, the version gets a "danger"
-label, and the message indicates the package is not yet on CRAN.
-}
-
-The default development mode is "release". You can override it by adding a
+You can override the default development mode by adding a
 new \code{development} field to \verb{_pkgdown.yml}, e.g.\preformatted{development:
   mode: devel
 }
 
-You can also have pkgdown automatically detect the mode with:\preformatted{development:
-  mode: auto
-}
-
-The mode will be automatically determined based on the version number:
+There are currently four possible modes:
+\itemize{
+\item \strong{release} (\code{mode: release}): Default mode. Site written to \verb{docs/},
+the version gets the default colouring, and no message.
+\item \strong{development} (\code{mode: devel}) : written to \verb{docs/dev/}, the version gets a danger label,
+and message stating these are docs for an in-development version of the
+package. The \code{noindex} meta tag is used to ensure that these packages are
+not indexed by search engines.
+\item \strong{unreleased} (\code{mode: unreleased}): the package is written to \verb{docs/}, the version gets a "danger"
+label, and the message indicates the package is not yet on CRAN.
+\item \strong{automatic} (\code{mode: auto}): pkgdown automatically detects the mode
+based on the version number:
 \itemize{
 \item \verb{0.0.0.9000} (\verb{0.0.0.*}): unreleased
 \item four version components: development
 \item everything else -> release
+}
 }
 
 There are three other options that you can control:\preformatted{development:


### PR DESCRIPTION
A proposition following issue #1465 .  
This aims to write in the documentation the values that `mode` can take in `_pkgdown.yml` before facing an error.
