### PR TITLE
Stop using the deprecated 'markdown_github' variant

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -3,7 +3,7 @@ markdown <- function(path = NULL, ..., strip_header = FALSE) {
   on.exit(unlink(tmp), add = TRUE)
 
   if (rmarkdown::pandoc_available("2.0")) {
-    from <- "markdown_github-hard_line_breaks+smart+auto_identifiers+tex_math_dollars+tex_math_single_backslash+markdown_in_html_blocks+header_attributes"
+    from <- "gfm-hard_line_breaks+smart+auto_identifiers+tex_math_dollars"
   } else if (rmarkdown::pandoc_available("1.12.3")) {
     from <- "markdown_github-hard_line_breaks+tex_math_dollars+tex_math_single_backslash+header_attributes"
   } else {


### PR DESCRIPTION
Relates to #1470, which I'm also seeing

The "markdown_github" variant was deprecated in pandoc 2.0 (2017-10-29), although the significance of this seems to be changing, i.e. its use is causing more and more friction. Which makes sense.

In addition to switching to "gfm", I have brutally removed various incompatible extensions, some of which may have been load-bearing. Indeed I can't pass tests locally with this branch, so I expect to see CI failure. But I think this is indicative of a change that needs to happen.

*I get a clean pkgdown build for reprex, FWIW, when I install this PR. The `Deprecated: markdown_github. Use gfm instead.` warnings go away and there are no obvious deficiencies with the site.*