### PR TITLE
Fix Typo - Missing ":" - Line 167:17 - build.R

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -164,7 +164,7 @@
 #'      - text: "Category B"
 #'      - text: Title B1
 #'        menu:
-#'        - text "Sub-category B11"
+#'        - text: "Sub-category B11"
 #'          href: articles/b11.html
 #'      twitter:
 #'        icon: "fab fa-twitter fa-lg"

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -213,7 +213,7 @@ The following YAML snippet illustrates some of the most important features.\pref
      - text: "Category B"
      - text: Title B1
        menu:
-       - text "Sub-category B11"
+       - text: "Sub-category B11"
          href: articles/b11.html
      twitter:
        icon: "fab fa-twitter fa-lg"

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -53,7 +53,7 @@ locally. See 'Setup' for details on setting up your repository to use this.
 }
 \section{Setup}{
 
-For a quick setup, you can use \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown_travis()}}. It  will help you
+For a quick setup, you can use \code{\link[usethis:use_pkgdown_travis]{usethis::use_pkgdown_travis()}}. It  will help you
 with the following detailed steps.
 \itemize{
 \item Add the following to your \code{.travis.yml} file.\preformatted{before_cache: Rscript -e 'remotes::install_cran("pkgdown")'


### PR DESCRIPTION
I was testing out the example displayed in section "YAML config - navbar" in build_site() reference page (https://pkgdown.r-lib.org/reference/build_site.html). I got an error when I blindly copied the example and executed it on my computer. Later I found the cause to be a missing colon in one key-value pair, which is in line 167 column 17 in https://github.com/r-lib/pkgdown/edit/master/R/build.r .

I realized that its just a typo on the webpage, rather than a bug in code - perhaps that's why none of the GitHub actions are able to detect this typo.

![image](https://user-images.githubusercontent.com/22992723/106259356-205a8200-6245-11eb-9160-90d98319dc44.png)
