### PR TITLE
Fall back on the bare templates directory in template packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* pkgdown will fall back on the bare templates directory if there is no subdirectory
+  corresponding to the Bootstrap version (#1496, @apreshill).
+
 * pkgdown can now use the templates "in-header.html"/"after-head.html", "before-body.html" and 
 "after-body.html" whose content will be placed 
 (similarly to bookdown options `in_header`, `before_body` and `after_body`), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,5 @@
 # pkgdown (development version)
 
-* pkgdown will fall back on the bare templates directory if there is no subdirectory
-  corresponding to the Bootstrap version (#1496, @apreshill).
-
 * pkgdown can now use the templates "in-header.html"/"after-head.html", "before-body.html" and 
 "after-body.html" whose content will be placed 
 (similarly to bookdown options `in_header`, `before_body` and `after_body`), 

--- a/R/init.R
+++ b/R/init.R
@@ -72,7 +72,10 @@ copy_assets <- function(pkg = ".") {
 
   # Copy assets from package
   if (!is.null(template$package)) {
-    copy_asset_dir(pkg, path_package_pkgdown(template$package, "assets"))
+    copy_asset_dir(
+      pkg,
+      path_package_pkgdown(template$package, bs_version = NULL, "assets")
+      )
   }
 }
 

--- a/R/render.r
+++ b/R/render.r
@@ -213,9 +213,9 @@ template_path <- function(pkg = ".") {
   } else if (!is.null(template$package)) {
     path_package_pkgdown(
       template$package,
-      "templates",
-      paste0("BS", get_bs_version(pkg))
-    )
+      bs_version = get_bs_version(pkg),
+      "templates"
+      )
   } else {
     character()
   }

--- a/R/render.r
+++ b/R/render.r
@@ -215,7 +215,7 @@ template_path <- function(pkg = ".") {
       template$package,
       bs_version = get_bs_version(pkg),
       "templates"
-      )
+    )
   } else {
     character()
   }

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -87,11 +87,11 @@ path_package_pkgdown <- function(package, bs_version = NULL, ...) {
     stop(package, " is not installed", call. = FALSE)
   }
 
-  path <- ifelse(
-    is.null(bs_version),
-    file.path(...),
+  path <- if (is.null(bs_version)) {
+    file.path(...)
+  } else {
     file.path(..., paste0("BS", bs_version))
-  )
+  }
 
   if (is.null(devtools_meta(package))) {
     pkg_path <- system.file("pkgdown", path, package = package, mustWork = FALSE)

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -82,22 +82,28 @@ path_first_existing <- function(...) {
   NULL
 }
 
-path_package_pkgdown <- function(package, ...) {
+path_package_pkgdown <- function(package, bs_version = NULL, ...) {
   if (!requireNamespace(package, quietly = TRUE)) {
     stop(package, " is not installed", call. = FALSE)
   }
 
+  path <- ifelse(
+    is.null(bs_version),
+    file.path(...),
+    file.path(..., paste0("BS", bs_version))
+  )
+
   if (is.null(devtools_meta(package))) {
-    pkg_path <- system.file("pkgdown", ..., package = package, mustWork = FALSE)
+    pkg_path <- system.file("pkgdown", path, package = package, mustWork = FALSE)
   } else {
     # Needed for testing packages that provide templates
-    pkg_path <- path(getNamespaceInfo(package, "path"), "inst", "pkgdown", ...)
+    pkg_path <- path(getNamespaceInfo(package, "path"), "inst", "pkgdown", path)
   }
 
   if (!file.exists(pkg_path)) {
     # fall back on the bare templates directory
-    if (grepl("templatesBS.", paste0(...))) {
-      return(path_package_pkgdown(package, "templates"))
+    if (!is.null(bs_version)) {
+      return(path_package_pkgdown(package, bs_version = NULL, ...))
     }
 
     stop(

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -95,6 +95,11 @@ path_package_pkgdown <- function(package, ...) {
   }
 
   if (!file.exists(pkg_path)) {
+    # fall back on the bare templates directory
+    if (grepl("templatesBS.", paste0(...))) {
+      return(path_package_pkgdown(package, "templates"))
+    }
+
     stop(
       package, " does not contain ", src_path("inst/pkgdown/", ...),
       call. = FALSE


### PR DESCRIPTION
Fix #1496

Cc @apreshill @cderv, I am sorry for this oversight.

The other method for overriding templates (having some folder and providing its `path` in the config file) still works.