### PR TITLE
Add TOC feature for the home sidebar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,10 @@ right below the opening `<body>` tag; and before the closing tag `</body>` (#148
 * Links for GitHub Enterprise and GitLab Enterprise repositories are detected 
   by assuming such host address begin with `github.` or `gitlab.` 
   (@ijlyttle, #1452).
+  
 * Make sidebar specification more flexible: users can now
     * change the order of sidebar elements
+    * add a table of contents for the README
     * add custom sidebar sections (title, text that has to be HTML)
     * completely suppress the navbar (even "Dev status")
     * provide their own HTML for the navbar. (#1443, #1488)

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -171,7 +171,7 @@ data_home_sidebar_links <- function(pkg = ".") {
 
 data_home_readme <- function(pkg) {
   sidebar_section(
-    "In this README",
+    "Table of contents",
     '<nav id="toc" data-toggle="toc" class="sticky-top"></nav>'
     )
 }

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -173,7 +173,7 @@ data_home_toc <- function(pkg) {
   sidebar_section(
     "Table of contents",
     '<nav id="toc" data-toggle="toc" class="sticky-top"></nav>'
-    )
+  )
 }
 
 sidebar_section <- function(heading, bullets, class = make_slug(heading)) {

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -75,7 +75,8 @@ data_home_sidebar <- function(pkg = ".") {
     community = data_home_sidebar_community(pkg),
     citation = data_home_sidebar_citation(pkg),
     authors = data_home_sidebar_authors(pkg),
-    dev = sidebar_section("Dev Status", "placeholder")
+    dev = sidebar_section("Dev Status", "placeholder"),
+    readme = data_home_readme(pkg)
   )
 
   if (is.null(pkg$meta$home$sidebar$structure)) {
@@ -99,11 +100,6 @@ data_home_sidebar <- function(pkg = ".") {
       ) %>%
       set_names(names(components))
   )
-
-  if ("readme" %in%  pkg$meta$home$sidebar$structure
-    && is.null(sidebar_components[["readme"]])) {
-    sidebar_components[["readme"]] = data_home_readme(pkg)
-  }
 
   missing <- setdiff(sidebar_structure, names(sidebar_components))
 

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -100,6 +100,11 @@ data_home_sidebar <- function(pkg = ".") {
       set_names(names(components))
   )
 
+  if ("readme" %in%  pkg$meta$home$sidebar$structure
+    && is.null(sidebar_components[["readme"]])) {
+    sidebar_components[["readme"]] = data_home_readme(pkg)
+  }
+
   missing <- setdiff(sidebar_structure, names(sidebar_components))
 
   if (length(missing) > 0) {
@@ -168,13 +173,19 @@ data_home_sidebar_links <- function(pkg = ".") {
   sidebar_section("Links", links)
 }
 
+data_home_readme <- function(pkg) {
+  text <- '<nav id="toc" data-toggle="toc" class="sticky-top">
+    </nav>'
+  sidebar_section("In this README", text)
+}
+
 sidebar_section <- function(heading, bullets, class = make_slug(heading)) {
   if (length(bullets) == 0)
     return(character())
 
   paste0(
     "<div class='", class, "'>\n",
-    "<h2>", heading, "</h2>\n",
+    "<h2 data-toc-skip>", heading, "</h2>\n",
     "<ul class='list-unstyled'>\n",
     paste0("<li>", bullets, "</li>\n", collapse = ""),
     "</ul>\n",

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -81,7 +81,7 @@ data_home_sidebar <- function(pkg = ".") {
 
   if (is.null(pkg$meta$home$sidebar$structure)) {
     sidebar_html <- paste0(
-      purrr::compact(sidebar_components),
+      purrr::compact(sidebar_components[default_sidebar_structure()]),
       collapse = "\n"
     )
     return(sidebar_html)
@@ -170,9 +170,10 @@ data_home_sidebar_links <- function(pkg = ".") {
 }
 
 data_home_readme <- function(pkg) {
-  text <- '<nav id="toc" data-toggle="toc" class="sticky-top">
-    </nav>'
-  sidebar_section("In this README", text)
+  sidebar_section(
+    "In this README",
+    '<nav id="toc" data-toggle="toc" class="sticky-top"></nav>'
+    )
 }
 
 sidebar_section <- function(heading, bullets, class = make_slug(heading)) {

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -76,7 +76,7 @@ data_home_sidebar <- function(pkg = ".") {
     citation = data_home_sidebar_citation(pkg),
     authors = data_home_sidebar_authors(pkg),
     dev = sidebar_section("Dev Status", "placeholder"),
-    readme = data_home_readme(pkg)
+    toc = data_home_toc(pkg)
   )
 
   if (is.null(pkg$meta$home$sidebar$structure)) {
@@ -169,7 +169,7 @@ data_home_sidebar_links <- function(pkg = ".") {
   sidebar_section("Links", links)
 }
 
-data_home_readme <- function(pkg) {
+data_home_toc <- function(pkg) {
   sidebar_section(
     "Table of contents",
     '<nav id="toc" data-toggle="toc" class="sticky-top"></nav>'

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -123,15 +123,16 @@
 #'
 #' You can change the order of sidebar components:
 #' `links`, `license` (with an "s"), `community`, `citation`,
-#' `authors`, `dev` (badges); and you can add custom components.
+#' `authors`, `dev` (badges); you can add a README table of contents `readme`,
+#' you can add custom components.
 #' The example below creates a sidebar whose only components will be the
-#' authors section, a custom section, and a Dev Status section if there are
-#' badges.
+#' authors section, a custom section, a README table of contents,
+#' and a Dev Status section if there are badges.
 #'
 #' ```
 #' home:
 #'   sidebar:
-#'     structure: [authors, custom, dev]
+#'     structure: [authors, custom, readme, dev]
 #'     components:
 #'       custom:
 #'         title: Funding

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -123,7 +123,7 @@
 #'
 #' You can change the order of sidebar components:
 #' `links`, `license` (with an "s"), `community`, `citation`,
-#' `authors`, `dev` (badges); you can add a README table of contents `readme`,
+#' `authors`, `dev` (badges); you can add a README table of contents `toc`,
 #' you can add custom components.
 #' The example below creates a sidebar whose only components will be the
 #' authors section, a custom section, a table of contents for the README,
@@ -132,7 +132,7 @@
 #' ```
 #' home:
 #'   sidebar:
-#'     structure: [authors, custom, readme, dev]
+#'     structure: [authors, custom, toc, dev]
 #'     components:
 #'       custom:
 #'         title: Funding

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -126,7 +126,7 @@
 #' `authors`, `dev` (badges); you can add a README table of contents `readme`,
 #' you can add custom components.
 #' The example below creates a sidebar whose only components will be the
-#' authors section, a custom section, a README table of contents,
+#' authors section, a custom section, a table of contents for the README,
 #' and a Dev Status section if there are badges.
 #'
 #' ```

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -132,12 +132,13 @@ elements:\preformatted{home:
 
 You can change the order of sidebar components:
 \code{links}, \code{license} (with an "s"), \code{community}, \code{citation},
-\code{authors}, \code{dev} (badges); and you can add custom components.
+\code{authors}, \code{dev} (badges); you can add a README table of contents \code{readme},
+you can add custom components.
 The example below creates a sidebar whose only components will be the
-authors section, a custom section, and a Dev Status section if there are
-badges.\preformatted{home:
+authors section, a custom section, a README table of contents,
+and a Dev Status section if there are badges.\preformatted{home:
   sidebar:
-    structure: [authors, custom, dev]
+    structure: [authors, custom, readme, dev]
     components:
       custom:
         title: Funding
@@ -149,7 +150,7 @@ You can provide a ready-made sidebar HTML:\preformatted{home:
     html: path-to-sidebar.html
 }
 
-You can completely remove the sidebar.\preformatted{home:
+Finally, you can completely remove the sidebar.\preformatted{home:
   sidebar: FALSE
 }
 

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -135,7 +135,7 @@ You can change the order of sidebar components:
 \code{authors}, \code{dev} (badges); you can add a README table of contents \code{readme},
 you can add custom components.
 The example below creates a sidebar whose only components will be the
-authors section, a custom section, a README table of contents,
+authors section, a custom section, a table of contents for the README,
 and a Dev Status section if there are badges.\preformatted{home:
   sidebar:
     structure: [authors, custom, readme, dev]

--- a/tests/testthat/_snaps/build-home-community.md
+++ b/tests/testthat/_snaps/build-home-community.md
@@ -1,0 +1,12 @@
+# community section is added if COC present
+
+    Code
+      cat(comm)
+    Output
+      <div class='community'>
+      <h2 data-toc-skip>Community</h2>
+      <ul class='list-unstyled'>
+      <li><a href="CODE_OF_CONDUCT.html">Code of conduct</a></li>
+      </ul>
+      </div>
+

--- a/tests/testthat/_snaps/data_home_sidebar.md
+++ b/tests/testthat/_snaps/data_home_sidebar.md
@@ -45,11 +45,11 @@
 # data_home_sidebar() can add a README
 
     Code
-      xml2::xml_find_first(result, ".//div[@class='in-this-readme']")
+      xml2::xml_find_first(result, ".//div[@class='table-of-contents']")
     Output
       {html_node}
-      <div class="in-this-readme">
-      [1] <h2 data-toc-skip>In this README</h2>
+      <div class="table-of-contents">
+      [1] <h2 data-toc-skip>Table of contents</h2>
       [2] <ul class="list-unstyled">\n<li><nav id="toc" data-toggle="toc" class="st ...
 
 # data_home_sidebar() outputs informative error messages

--- a/tests/testthat/_snaps/data_home_sidebar.md
+++ b/tests/testthat/_snaps/data_home_sidebar.md
@@ -4,7 +4,7 @@
       cat(data_home_sidebar(pkg))
     Output
       <div class='license'>
-      <h2>License</h2>
+      <h2 data-toc-skip>License</h2>
       <ul class='list-unstyled'>
       <li>NA</li>
       </ul>
@@ -12,7 +12,7 @@
       
       
       <div class='developers'>
-      <h2>Developers</h2>
+      <h2 data-toc-skip>Developers</h2>
       <ul class='list-unstyled'>
       <li><a href='http://hadley.nz'>Hadley Wickham</a> <br />
       <small class = 'roles'> Author, maintainer </small>  </li>
@@ -22,7 +22,7 @@
       </div>
       
       <div class='dev-status'>
-      <h2>Dev Status</h2>
+      <h2 data-toc-skip>Dev Status</h2>
       <ul class='list-unstyled'>
       <li>placeholder</li>
       </ul>
@@ -39,8 +39,18 @@
     Output
       {html_node}
       <div class="fancy-section">
-      [1] <h2>Fancy section</h2>
+      [1] <h2 data-toc-skip>Fancy section</h2>
       [2] <ul class="list-unstyled">\n<li>How cool is pkgdown?!</li>\n</ul>
+
+# data_home_sidebar() can add a README
+
+    Code
+      xml2::xml_find_first(result, ".//div[@class='in-this-readme']")
+    Output
+      {html_node}
+      <div class="in-this-readme">
+      [1] <h2 data-toc-skip>In this README</h2>
+      [2] <ul class="list-unstyled">\n<li><nav id="toc" data-toggle="toc" class="st ...
 
 # data_home_sidebar() outputs informative error messages
 

--- a/tests/testthat/test-build-home-community.R
+++ b/tests/testthat/test-build-home-community.R
@@ -20,8 +20,7 @@ test_that("community section is added if COC present", {
   skip_if_not(dir_exists(path(pkg, ".github"))[[1]])
 
   comm <- data_home_sidebar_community(pkg)
-  expect_equal(comm,
-               "<div class='community'>\n<h2>Community</h2>\n<ul class='list-unstyled'>\n<li><a href=\"CODE_OF_CONDUCT.html\">Code of conduct</a></li>\n</ul>\n</div>\n")
+  expect_snapshot(cat(comm))
 })
 
 test_that("community section is not added if no community files", {

--- a/tests/testthat/test-data_home_sidebar.R
+++ b/tests/testthat/test-data_home_sidebar.R
@@ -68,7 +68,7 @@ test_that("data_home_sidebar() can add a README", {
   pkg <- test_path("assets/sidebar")
   pkg <- as_pkgdown(pkg)
 
-  pkg$meta$home$sidebar <- list(structure = c("license", "readme"))
+  pkg$meta$home$sidebar <- list(structure = c("license", "toc"))
 
   result <- xml2::read_html(
     data_home_sidebar(pkg)

--- a/tests/testthat/test-data_home_sidebar.R
+++ b/tests/testthat/test-data_home_sidebar.R
@@ -75,7 +75,7 @@ test_that("data_home_sidebar() can add a README", {
   )
 
   expect_snapshot(
-    xml2::xml_find_first(result, ".//div[@class='in-this-readme']")
+    xml2::xml_find_first(result, ".//div[@class='table-of-contents']")
   )
 })
 

--- a/tests/testthat/test-data_home_sidebar.R
+++ b/tests/testthat/test-data_home_sidebar.R
@@ -64,6 +64,21 @@ test_that("data_home_sidebar() can get a custom component", {
   )
 })
 
+test_that("data_home_sidebar() can add a README", {
+  pkg <- test_path("assets/sidebar")
+  pkg <- as_pkgdown(pkg)
+
+  pkg$meta$home$sidebar <- list(structure = c("license", "readme"))
+
+  result <- xml2::read_html(
+    data_home_sidebar(pkg)
+  )
+
+  expect_snapshot(
+    xml2::xml_find_first(result, ".//div[@class='in-this-readme']")
+  )
+})
+
 test_that("data_home_sidebar() outputs informative error messages", {
   # no component definition for a component named in structure
   pkg <- test_path("assets/sidebar")


### PR DESCRIPTION
Here's how it looks like for a structure `[links, license, readme, dev]`

![image](https://user-images.githubusercontent.com/8360597/107918876-c0651a80-6f6a-11eb-8495-067292460130.png)
