### PR TITLE
fix doc for build_home() and pkgdown/index.md

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -5,7 +5,7 @@
 #' `DESCRIPTION` and `inst/CITATION` (if present).
 #'
 #' @section Home page:
-#' The home page (`index.html`) is generated from `_pkgdown/index.md`,
+#' The home page (`index.html`) is generated from `pkgdown/index.md`,
 #' `index.md`, or `README.md`, in that order. Most packages will use `README.md`
 #' because that's also displayed by GitHub and CRAN. Use `index.md` if you want
 #' your package website to look different to your README, and use

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -25,7 +25,7 @@ package root (and in \verb{.github/}), and builds an authors page from
 }
 \section{Home page}{
 
-The home page (\code{index.html}) is generated from \verb{_pkgdown/index.md},
+The home page (\code{index.html}) is generated from \code{pkgdown/index.md},
 \code{index.md}, or \code{README.md}, in that order. Most packages will use \code{README.md}
 because that's also displayed by GitHub and CRAN. Use \code{index.md} if you want
 your package website to look different to your README, and use
@@ -132,13 +132,13 @@ elements:\preformatted{home:
 
 You can change the order of sidebar components:
 \code{links}, \code{license} (with an "s"), \code{community}, \code{citation},
-\code{authors}, \code{dev} (badges); you can add a README table of contents \code{readme},
+\code{authors}, \code{dev} (badges); you can add a README table of contents \code{toc},
 you can add custom components.
 The example below creates a sidebar whose only components will be the
 authors section, a custom section, a table of contents for the README,
 and a Dev Status section if there are badges.\preformatted{home:
   sidebar:
-    structure: [authors, custom, readme, dev]
+    structure: [authors, custom, toc, dev]
     components:
       custom:
         title: Funding

--- a/man/pkgdown-package.Rd
+++ b/man/pkgdown-package.Rd
@@ -8,9 +8,10 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-Generate an attractive and useful website from a source package.
-    'pkgdown' converts your documentation, vignettes, 'README', and more to 
-    'HTML' making it easy to share information about your package online.
+Generate an attractive and useful website from a
+    source package.  'pkgdown' converts your documentation, vignettes,
+    'README', and more to 'HTML' making it easy to share information about
+    your package online.
 }
 \seealso{
 Useful links:
@@ -27,6 +28,7 @@ Useful links:
 Authors:
 \itemize{
   \item Jay Hesselberth (\href{https://orcid.org/0000-0002-6299-179X}{ORCID})
+  \item Maëlle Salmon (\href{https://orcid.org/0000-0002-2815-0399}{ORCID})
 }
 
 Other contributors:


### PR DESCRIPTION
`pkgdown/index.md` is recognized and not `_pkgdown/index.md`

https://github.com/r-lib/pkgdown/blob/d34ce5fc8317e409437c502e8af3c2bca2b894c3/R/build-home-index.R#L4-L9

cc @apreshill