### PR TITLE
no html_dependency_bootstrap() for custom output

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -265,7 +265,8 @@ build_article <- function(name,
 
       options <- list(
         template = template$path,
-        self_contained = FALSE
+        self_contained = FALSE,
+        theme = NULL
       )
     } else {
       options <- list()


### PR DESCRIPTION
Not sure I am thinking of all the possible implications.
E.g. how would one set the theme for one page only, should it be allowed.
In any case in the current state https://pkgdown.r-lib.org/articles/test/output.html was loading Bootstrap files twice. See https://github.com/r-lib/pkgdown/tree/gh-pages/articles/test/output_files