### PR TITLE
Methods can be put on class "function".

### DIFF
--- a/R/usage.R
+++ b/R/usage.R
@@ -186,7 +186,7 @@ usage_code.tag_S3method <- function(x) {
   generic <- paste0(usage_code(x[[1]]), collapse = "")
   class <- paste0(usage_code(x[[2]]), collapse = "")
 
-  paste0("S3method(`", generic, "`, ", class, ")")
+  paste0("S3method(`", generic, "`, `", class, "`)")
 }
 
 #' @export
@@ -197,7 +197,7 @@ usage_code.tag_S4method <- function(x) {
   generic <- paste0(usage_code(x[[1]]), collapse = "")
   class <- paste0(usage_code(x[[2]]), collapse = "")
 
-  paste0("S4method(`", generic, "`, list(", class, "))")
+  paste0("S4method(`", generic, "`, list(`", class, "`))")
 }
 #' @export
 usage_code.tag_usage <- function(x) {

--- a/R/usage.R
+++ b/R/usage.R
@@ -117,7 +117,7 @@ fun_info <- function(fun) {
       list(
         type = "s4",
         name = as.character(x[[2]]),
-        signature = as.character(x[[3]][-1])
+        signature = sub("^`(.*)`$", "\\1", as.character(as.list(x[[3]])[-1]))
       )
     } else if (is_call(x, c("::", ":::"))) {
       # TRUE if fun has a namespace, pkg::fun()
@@ -195,9 +195,10 @@ usage_code.tag_method <- usage_code.tag_S3method
 #' @export
 usage_code.tag_S4method <- function(x) {
   generic <- paste0(usage_code(x[[1]]), collapse = "")
-  class <- paste0(usage_code(x[[2]]), collapse = "")
-
-  paste0("S4method(`", generic, "`, list(`", class, "`))")
+  class <- strsplit(usage_code(x[[2]]), ",")[[1]]
+  class <- paste0("`", class, "`")
+  class <- paste0(class, collapse = ",")
+  paste0("S4method(`", generic, "`, list(", class, "))")
 }
 #' @export
 usage_code.tag_usage <- function(x) {

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -390,8 +390,8 @@ test_that("Methods for class function work", {
   expect_equal(out[1], "# S3 method for function")
   expect_equal(out[2], "fun(x, y)")
 
-  out <- rd2html("\\S4method{fun}{function}(x, y)")
-  expect_equal(out[1], "# S4 method for function")
+  out <- rd2html("\\S4method{fun}{function,function}(x, y)")
+  expect_equal(out[1], "# S4 method for function,function")
   expect_equal(out[2], "fun(x, y)")
 })
 

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -381,6 +381,20 @@ test_that("S3 methods gets comment", {
   expect_equal(out[2], "fun(x, y)")
 })
 
+test_that("Methods for class function work", {
+  out <- rd2html("\\S3method{fun}{function}(x, y)")
+  expect_equal(out[1], "# S3 method for function")
+  expect_equal(out[2], "fun(x, y)")
+
+  out <- rd2html("\\method{fun}{function}(x, y)")
+  expect_equal(out[1], "# S3 method for function")
+  expect_equal(out[2], "fun(x, y)")
+
+  out <- rd2html("\\S4method{fun}{function}(x, y)")
+  expect_equal(out[1], "# S4 method for function")
+  expect_equal(out[2], "fun(x, y)")
+})
+
 test_that("eqn", {
   out <- rd2html(" \\eqn{\\alpha}{alpha}")
   expect_equal(out, "\\(\\alpha\\)")

--- a/tests/testthat/test-usage.R
+++ b/tests/testthat/test-usage.R
@@ -31,6 +31,11 @@ test_that("can parse function/methods", {
   expect_equal(usage$name, "f")
   expect_equal(usage$signature, c("NULL"))
 
+  usage <- parse_usage("\\S4method{f}{function,function}(x, y)")[[1]]
+  expect_equal(usage$type, "s4")
+  expect_equal(usage$name, "f")
+  expect_equal(usage$signature, c("function", "function"))
+
   usage <- parse_usage("pkg::func()")[[1]]
   expect_equal(usage$type, "fun")
   expect_equal(usage$name, "func")


### PR DESCRIPTION
I get the warning below for `rgl`, caused by man page https://github.com/dmurdoch/rgl/blob/master/man/persp3d.function.Rd :

```
> pkgdown::build_reference_index()
Warning: Failed to parse usage:

S3method(`persp3d`, function)(x, 
  xlim = c(0, 1), ylim = c(0, 1), 
  slim = NULL, tlim = NULL, 
  n = 101, 
  xvals = seq.int(min(xlim), max(xlim), length.out = n[1]), 
  yvals = seq.int(min(ylim), max(ylim), length.out = n[2]), 
  svals = seq.int(min(slim), max(slim), length.out = n[1]), 
  tvals = seq.int(min(tlim), max(tlim), length.out = n[2]), 
  xlab, ylab, zlab, 
  col = "gray", otherargs = list(), 
  normal = NULL, texcoords = NULL, ...)
S3method(`plot3d`, function)(x, ...)
```

The problem is that "function" is legal as a class name, but not in the expression `S3method(`plot3d`, function)(x, ...)` produced during parsing.  This patch fixes it, and does a similar fix for S4 (where I'm not sure `function` is legal in a signature, but just in case).