### PR TITLE
fix bug appearing when BS = 4 and no header

### DIFF
--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -194,10 +194,10 @@ tweak_homepage_html <- function(html,
 
 class_page_header <- function(bs_version, header) {
   if (bs_version == 3) {
-    return(paste0("<div class='page-header'>", header, "</div>"))
+    paste0("<div class='page-header'>", header, "</div>")
+  } else {
+    paste0("<div class='pb-2 mt-4 mb-2 border-bottom'>", header, "</div>")
   }
-  paste0("<div class='pb-2 mt-4 mb-2 border-bottom'>", header, "</div>")
-
 }
 
 tweak_sidebar_html <- function(html, sidebar) {

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -196,7 +196,7 @@ class_page_header <- function(bs_version, header) {
   if (bs_version == 3) {
     return(paste0("<div class='page-header'>", header, "</div>"))
   }
-  sprintf("<div class='pb-2 mt-4 mb-2 border-bottom'>%s</div>", header)
+  paste0("<div class='pb-2 mt-4 mb-2 border-bottom'>", header, "</div>")
 
 }
 


### PR DESCRIPTION
Due to

``` r
header <- xml2::xml_missing()
paste0("ok", header)
#> [1] "okNA"
sprintf("ok%s", header)
#> character(0)
```

<sup>Created on 2021-03-15 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9001)</sup>