### PR TITLE
The `\name{}` field in an Rd file shouldn't be used in the topic index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* Automatic links to reference pages were generated incorrectly if the
+  `\name{}` entry in the `*.Rd` file didn't match the filename
+  (@dmurdoch, #1586).
+
 * New "Customize your pkgdown website" vignette (#1573).
 
 * Added extension points to make HTML widgets (and RGL in particular) work

--- a/R/context.R
+++ b/R/context.R
@@ -10,7 +10,8 @@ section_init <- function(pkg, depth, override = list(), .frame = parent.frame())
 
 local_options_link <- function(pkg, depth, .frame = parent.frame()) {
   article_index <- set_names(path_file(pkg$vignettes$file_out), pkg$vignettes$name)
-  topic_index <- invert_index(set_names(pkg$topics$alias, pkg$topics$name))
+  Rdname <- gsub(".Rd$", "", pkg$topic$file_in)
+  topic_index <- invert_index(set_names(pkg$topics$alias, Rdname))
 
   withr::local_options(
     list(

--- a/R/context.R
+++ b/R/context.R
@@ -10,7 +10,7 @@ section_init <- function(pkg, depth, override = list(), .frame = parent.frame())
 
 local_options_link <- function(pkg, depth, .frame = parent.frame()) {
   article_index <- set_names(path_file(pkg$vignettes$file_out), pkg$vignettes$name)
-  Rdname <- gsub(".Rd$", "", pkg$topic$file_in)
+  Rdname <- fs::path_ext_remove(pkg$topic$file_in)
   topic_index <- invert_index(set_names(pkg$topics$alias, Rdname))
 
   withr::local_options(


### PR DESCRIPTION
Fix #1576 

The `topic_index` is documented here:  https://github.com/r-lib/downlit/blob/e22f072cfeaf91fbe7c38aeabd351aaa184d36fd/R/topic-index.R#L2, to map "aliases to Rd file names (sans extension)".  The `\name{}` field can differ, so it shouldn't be used here. 

This fixes https://github.com/r-lib/downlit/issues/83 .