### PR TITLE
Fix badge regression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* README badges in a single paragraph, placed between the `badges: end` and `badges: end` comments,
+  are detected again (#1603). 
+
 * Automatic links to reference pages were generated incorrectly if the
   `\name{}` entry in the `*.Rd` file didn't match the filename
   (@dmurdoch, #1586).

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -275,7 +275,7 @@ badges_extract <- function(html) {
   x <- xml2::xml_find_first(html, "//div[@id='badges']")
   strict <- FALSE
 
-  # then try usethis-readme-like paragraph;
+  # then try usethis-readme-like more complex structure;
   if (length(x) == 0) {
     # Find start comment, then all elements after
     # which are followed by the end comment.
@@ -283,6 +283,13 @@ badges_extract <- function(html) {
       //comment()[contains(., 'badges: start')][1]
       /following-sibling::*[following-sibling::comment()[contains(., 'badges: end')]]
     ")
+
+  }
+
+  # then try usethis-readme-like paragraph;
+  # where the badges: end comment is inside the paragraph after badges: start
+  if (length(x) == 0) {
+    x <- xml2::xml_find_all(html, ".//*/comment()[contains(., 'badges: start')]/following-sibling::p[1]")
   }
 
   # finally try first paragraph

--- a/tests/testthat/test-html-tweak.R
+++ b/tests/testthat/test-html-tweak.R
@@ -198,7 +198,28 @@ test_that("badges in special element can be accompanied by text", {
   )
 })
 
-test_that("badges-paragraph a la usethis can be found", {
+test_that("badges-paragraph à la usethis can be found", {
+  string <- '
+  <blockquote>
+  <p>Connect to thisisatest, from R</p>
+  </blockquote>
+  <!-- badges: start -->
+  <p>
+  <a href=\"https://www.repostatus.org/#wip\" class=\"external-link\">
+    <img src=\"https://www.repostatus.org/badges/latest/wip.svg\" alt=\"Project Status: WIP.\">
+  </a>
+  <a href=\"https://travis-ci.org/ropensci/rotemplate\" class=\"external-link\">
+  <img src=\"https://travis-ci.org/ropensci/rotemplate.svg?branch=master\" alt=\"Build Status\">
+  </a>
+  <!-- badges: end -->
+  </p>'
+
+  badges_page <- xml2::read_html(string)
+  expect_equal(length(badges_extract(badges_page)), 2)
+})
+
+
+test_that("complex badges structure can be found", {
   string <- '
   <blockquote>
   <p>Connect to thisisatest, from R</p>


### PR DESCRIPTION
#1174 had introduced a regression.

The test case that had been removed

```html
<p><a href="https://travis-ci.org/thisisatest/thisisatest"><img src="https://travis-ci.org/thisisatest/thisisatest.svg?branch=master" alt="Linux Build Status"></a> <!-- badges: end --></p>
```

has the second comment inside the paragraph which is what happens in quite a few packages out there.

For rOpenSci packages (cc @jeroen) badges were never detected even when the README had no one-liner quote because the first paragraph returned by `xml2::xml_find_first(html, "//p")` was a Matomo tracking image.