### PR TITLE
Exclude h1 from TOC

### DIFF
--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -157,7 +157,7 @@ data_home_sidebar_links <- function(pkg = ".") {
 data_home_toc <- function(pkg) {
   sidebar_section(
     "Table of contents",
-    '<nav id="toc" data-toggle="toc" class="sticky-top"></nav>'
+    '<nav id="toc" class="sticky-top"></nav>'
   )
 }
 

--- a/inst/assets/BS4/pkgdown.js
+++ b/inst/assets/BS4/pkgdown.js
@@ -9,6 +9,11 @@
       offset: 60
     });
 
+    Toc.init({
+      $nav: $("#toc"),
+      $scope: $("h2, h3, h4, h5, h6")
+    });
+
     // Activate popovers
     $('[data-toggle="popover"]').popover({
       container: 'body',

--- a/inst/templates/BS4/content-article.html
+++ b/inst/templates/BS4/content-article.html
@@ -50,7 +50,7 @@ $body$
  <div class="col-md-3 d-none d-md-block" id="sidebar">
     $if(toc)$
     <div class="sticky-top">
-    <nav id="toc" data-toggle="toc" >
+    <nav id="toc">
 
       <h2 data-toc-skip>Contents</h2>
 

--- a/inst/templates/BS4/content-news.html
+++ b/inst/templates/BS4/content-news.html
@@ -13,7 +13,7 @@
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <div class="sticky-top">
-    <nav id="toc" data-toggle="toc" >
+    <nav id="toc">
 
       <h2 data-toc-skip>Contents</h2>
 

--- a/inst/templates/BS4/content-reference-index.html
+++ b/inst/templates/BS4/content-reference-index.html
@@ -39,7 +39,7 @@
 
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <div class="sticky-top">
-    <nav id="toc" data-toggle="toc" >
+    <nav id="toc">
 
       <h2 data-toc-skip>Contents</h2>
 

--- a/inst/templates/BS4/content-reference-topic.html
+++ b/inst/templates/BS4/content-reference-topic.html
@@ -44,7 +44,7 @@
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <div class="sticky-top">
-    <nav id="toc" data-toggle="toc" >
+    <nav id="toc">
 
       <h2 data-toc-skip>Contents</h2>
 

--- a/inst/templates/BS4/content-title-body.html
+++ b/inst/templates/BS4/content-title-body.html
@@ -12,7 +12,7 @@
 
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
    <div class="sticky-top">
-    <nav id="toc" data-toggle="toc" >
+    <nav id="toc">
 
       <h2 data-toc-skip>Contents</h2>
 

--- a/tests/testthat/_snaps/data_home_sidebar.md
+++ b/tests/testthat/_snaps/data_home_sidebar.md
@@ -67,7 +67,7 @@
       {html_node}
       <div class="table-of-contents">
       [1] <h2 data-toc-skip>Table of contents</h2>
-      [2] <ul class="list-unstyled">\n<li><nav id="toc" data-toggle="toc" class="st ...
+      [2] <ul class="list-unstyled">\n<li><nav id="toc" class="sticky-top"></nav></ ...
 
 # data_home_sidebar() outputs informative error messages
 


### PR DESCRIPTION
Fix #1583

Now to customize the depth of the TOC cf #1357 bootstrap-toc only supports two levels anyway. https://github.com/afeld/bootstrap-toc/issues/27