### PR TITLE
fix 404 navbar and CSS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* The 404 page (default or from `.github/404.md`) is no longer built in the development mode (see `?build_site`) as e.g. GitHub pages only uses the 404.html page that is at the root, that is to say, the 404 page built for the unreleased or release modes. (#1622)
+
+* All links on the 404 pages (navbar, scripts, CSS) are now absolute if there is an URL in the configuration file. (#1622)
+
 * Heading links/IDs in the changelog are now permanent except from links corresponding to the development version. They are built as the combination of the heading slug and package version number. (@Bisaloo, #1015)
 
 * pkgdown's deploy_to_branch() now cleans out the website directory by default (`clean = TRUE`). To revert to previous behaviour, call it with `clean = FALSE`. (#1394)

--- a/R/build-404.R
+++ b/R/build-404.R
@@ -13,7 +13,7 @@ build_404 <- function(pkg = ".") {
       ),
       path = "404.html"
     )
-    update_html(path_abs("404.html", start = pkg$dst_path), tweak_404)
+    update_html(path_abs("404.html", start = pkg$dst_path), tweak_404, pkg = pkg)
   }
 
   invisible()

--- a/R/build-404.R
+++ b/R/build-404.R
@@ -13,6 +13,7 @@ build_404 <- function(pkg = ".") {
       ),
       path = "404.html"
     )
+    update_html(path_abs("404.html", start = pkg$dst_path), tweak_404)
   }
 
   invisible()

--- a/R/build-home-md.R
+++ b/R/build-home-md.R
@@ -30,4 +30,9 @@ render_md <- function(pkg, filename) {
     ),
     path = path_ext_set(basename(filename), "html")
   )
+
+  if (basename(filename) == "404.md") {
+    update_html(path_abs("404.html", start = pkg$dst_path), tweak_404, pkg = pkg)
+  }
+
 }

--- a/R/build-home-md.R
+++ b/R/build-home-md.R
@@ -12,6 +12,11 @@ build_home_md <- function(pkg) {
   handled <- c("README.md", "LICENSE.md", "LICENCE.md", "NEWS.md", "cran-comments.md")
   mds <- mds[!path_file(mds) %in% handled]
 
+  # Do not build 404 page if in-dev
+  if (pkg$development$in_dev) {
+    mds <- mds[fs::path_file(mds) != "404.md"]
+  }
+
   lapply(mds, render_md, pkg = pkg)
   invisible()
 }

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -404,16 +404,7 @@ tweak_404 <- function(html, pkg = pkg) {
   # Logo
   logo_path <- logo_path(pkg, depth = 0)
   if (!is.null(logo_path)) {
-    if (pkg$development$in_dev) {
-      logo_path <- paste0(
-        pkg$meta$url, "/",
-        meta_development(pkg$meta, pkg$version)$destination,
-        "/",
-        logo_path
-      )
-    } else {
-      logo_path <- paste0(pkg$meta$url, "/", logo_path)
-    }
+    logo_path <- paste0(url, logo_path)
   }
 
   TRUE

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -386,7 +386,7 @@ tweak_404 <- function(html, pkg = pkg) {
 
   # Links
   links <- xml2::xml_find_all(html, ".//a | .//link")
-  rel_links <- links[!grepl("https?\\:\\/\\/", xml2::xml_attr(links, "href"))]
+  rel_links <- links[!grepl("https?\\://", xml2::xml_attr(links, "href"))]
   if (length(rel_links) > 0) {
     new_urls <- paste0(url, xml2::xml_attr(rel_links, "href"))
     xml2::xml_attr(rel_links, "href") <- new_urls
@@ -395,7 +395,7 @@ tweak_404 <- function(html, pkg = pkg) {
   # Scripts
   scripts <- xml2::xml_find_all(html, ".//script")
   scripts <- scripts[!is.na(xml2::xml_attr(scripts, "src"))]
-  rel_scripts <- scripts[!grepl("https?\\:\\/\\/", xml2::xml_attr(scripts, "src"))]
+  rel_scripts <- scripts[!grepl("https?\\://", xml2::xml_attr(scripts, "src"))]
   if (length(rel_scripts) > 0) {
     new_srcs <- paste0(url, xml2::xml_attr(rel_scripts, "src"))
     xml2::xml_attr(rel_scripts, "src") <- new_srcs

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -89,6 +89,10 @@ tweak_navbar_links <- function(html, pkg = pkg) {
 
   url <- paste0(pkg$meta$url, "/")
 
+  if (pkg$development$in_dev) {
+    url <- paste0(url, meta_development(pkg$meta, pkg$version)$destination, "/")
+  }
+
   html <- xml2::read_html(html)
 
   links <- xml2::xml_find_all(html, ".//a")

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -85,7 +85,7 @@ tweak_all_links <- function(html, pkg = pkg) {
 }
 
 
-tweak_navbar_links <- function(html, pkg = pkg) {
+tweak_404_links <- function(html, pkg = pkg) {
 
   url <- paste0(pkg$meta$url, "/")
 
@@ -95,7 +95,7 @@ tweak_navbar_links <- function(html, pkg = pkg) {
 
   html <- xml2::read_html(html)
 
-  links <- xml2::xml_find_all(html, ".//a")
+  links <- xml2::xml_find_all(html, ".//a | .//link")
   hrefs <- xml2::xml_attr(links, "href")
 
   needs_tweak <- !grepl("https?\\:\\/\\/", hrefs)
@@ -104,6 +104,18 @@ tweak_navbar_links <- function(html, pkg = pkg) {
     xml2::xml_attr(links[needs_tweak], "href") <- paste0(
       url,
       xml2::xml_attr(links[needs_tweak], "href")
+    )
+  }
+
+  scripts <- xml2::xml_find_all(html, ".//script")
+  srcs <- xml2::xml_attr(scripts, "src")
+
+  needs_tweak <- !grepl("https?\\:\\/\\/", srcs)
+
+  if (any(needs_tweak)) {
+    xml2::xml_attr(scripts[needs_tweak], "src") <- paste0(
+      url,
+      xml2::xml_attr(scripts[needs_tweak], "src")
     )
   }
 

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -85,7 +85,7 @@ tweak_all_links <- function(html, pkg = pkg) {
 }
 
 
-tweak_404_links <- function(html, pkg = pkg) {
+tweak_404_links <- function(html, pkg = pkg, what) {
 
   url <- paste0(pkg$meta$url, "/")
 
@@ -119,7 +119,7 @@ tweak_404_links <- function(html, pkg = pkg) {
     )
   }
 
-  return(as.character(xml2::xml_find_first(html, ".//body")))
+  return(as.character(xml2::xml_find_first(html, paste0(".//", what))))
 }
 
 tweak_tables <- function(html) {

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -402,9 +402,9 @@ tweak_404 <- function(html, pkg = pkg) {
   }
 
   # Logo
-  logo_path <- logo_path(pkg, depth = 0)
-  if (!is.null(logo_path)) {
-    logo_path <- paste0(url, logo_path)
+  logo <- xml2::xml_find_first(html, ".//img[@class='pkg-logo']")
+  if (inherits(logo, "xml_node")) {
+    xml2::xml_attr(logo, "src") <- paste0(url, logo_path(pkg, depth = 0))
   }
 
   TRUE

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -108,6 +108,7 @@ tweak_404_links <- function(html, pkg = pkg, what) {
   }
 
   scripts <- xml2::xml_find_all(html, ".//script")
+  scripts <- scripts[!is.na(xml2::xml_attr(scripts, "src"))]
   srcs <- xml2::xml_attr(scripts, "src")
 
   needs_tweak <- !grepl("https?\\:\\/\\/", srcs)

--- a/R/init.R
+++ b/R/init.R
@@ -46,7 +46,9 @@ init_site <- function(pkg = ".") {
 
   build_site_meta(pkg)
   build_logo(pkg)
-  build_404(pkg)
+  if (!pkg$development$in_dev) {
+    build_404(pkg)
+  }
 
   invisible()
 }

--- a/R/render.r
+++ b/R/render.r
@@ -27,9 +27,7 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
     depth <- length(strsplit(path, "/")[[1]]) - 1L
   }
 
-  logo_path <- logo_path(pkg, depth = depth)
-
-  data$logo <- list(src = logo_path)
+  data$logo <- list(src = logo_path(pkg, depth = depth))
 
   data <- utils::modifyList(data, data_template(pkg, depth = depth))
   data$pkgdown <- list(

--- a/R/render.r
+++ b/R/render.r
@@ -27,7 +27,25 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
     depth <- length(strsplit(path, "/")[[1]]) - 1L
   }
 
-  data$logo <- list(src = logo_path(pkg, depth = depth))
+  logo_path <- logo_path(pkg, depth = depth)
+
+  # Absolute URL for 404
+  if (!is.null(logo_path)) {
+    if (path == "404.html" && !is.null(pkg$meta$url)) {
+      if (pkg$development$in_dev) {
+        logo_path <- paste0(
+          pkg$meta$url, "/",
+          meta_development(pkg$meta, pkg$version)$destination,
+          "/",
+          logo_path
+        )
+      } else {
+        logo_path <- paste0(pkg$meta$url, "/", logo_path)
+      }
+    }
+  }
+
+  data$logo <- list(src = logo_path)
 
   data <- utils::modifyList(data, data_template(pkg, depth = depth))
   data$pkgdown <- list(

--- a/R/render.r
+++ b/R/render.r
@@ -36,12 +36,6 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   data$has_favicons <- has_favicons(pkg)
   data$opengraph <- utils::modifyList(data_open_graph(pkg), data$opengraph %||% list())
 
-  # The real location of 404.html is dynamic (#1129).
-  # Relative root does not work, use the full URL if available.
-  if (path == "404.html" && length(pkg$meta$url)) {
-    data$site$root <- paste0(pkg$meta$url, "/")
-  }
-
   data$footer <- pkgdown_footer(data, pkg)
 
   # Dependencies for head

--- a/R/render.r
+++ b/R/render.r
@@ -29,22 +29,6 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
 
   logo_path <- logo_path(pkg, depth = depth)
 
-  # Absolute URL for 404
-  if (!is.null(logo_path)) {
-    if (path == "404.html" && !is.null(pkg$meta$url)) {
-      if (pkg$development$in_dev) {
-        logo_path <- paste0(
-          pkg$meta$url, "/",
-          meta_development(pkg$meta, pkg$version)$destination,
-          "/",
-          logo_path
-        )
-      } else {
-        logo_path <- paste0(pkg$meta$url, "/", logo_path)
-      }
-    }
-  }
-
   data$logo <- list(src = logo_path)
 
   data <- utils::modifyList(data, data_template(pkg, depth = depth))
@@ -85,11 +69,6 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   components <- purrr::map(templates, render_template, data = data)
   components <- purrr::set_names(components, pieces)
   components$template <- name
-
-  if (path == "404.html" && !is.null(pkg$meta$url)) {
-    components$head <- tweak_404_links(components$head, pkg = pkg, what = "head")
-    components$navbar <- tweak_404_links(components$navbar, pkg = pkg, what = "body")
-  }
 
   # render complete layout
   template <- find_template(

--- a/R/render.r
+++ b/R/render.r
@@ -69,8 +69,8 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   components$template <- name
 
   if (path == "404.html" && !is.null(pkg$meta$url)) {
-    components$head <- tweak_404_links(components$head, pkg = pkg)
-    components$navbar <- tweak_404_links(components$navbar, pkg = pkg)
+    components$head <- tweak_404_links(components$head, pkg = pkg, what = "head")
+    components$navbar <- tweak_404_links(components$navbar, pkg = pkg, what = "body")
   }
 
   # render complete layout

--- a/R/render.r
+++ b/R/render.r
@@ -69,7 +69,8 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   components$template <- name
 
   if (path == "404.html" && !is.null(pkg$meta$url)) {
-    components$navbar <- tweak_navbar_links(components$navbar, pkg = pkg)
+    components$head <- tweak_404_links(components$head, pkg = pkg)
+    components$navbar <- tweak_404_links(components$navbar, pkg = pkg)
   }
 
   # render complete layout

--- a/tests/testthat/_snaps/html-tweak.md
+++ b/tests/testthat/_snaps/html-tweak.md
@@ -6,6 +6,28 @@
       </div>
     </div>
 
+# tweak_404() make URLs absolute
+
+    Code
+      cat(as.character(xml2::xml_child(prod_html)))
+    Output
+      <body><div><div><div>
+          <a href="https://example.com/reference.html"></a>
+          <link href="https://example.com/reference.css">
+      <script src="https://example.com/reference.js"></script><img src="https://example.com/" class="pkg-logo">
+      </div></div></div></body>
+
+---
+
+    Code
+      cat(as.character(xml2::xml_child(dev_html)))
+    Output
+      <body><div><div><div>
+          <a href="https://example.com/dev/reference.html"></a>
+          <link href="https://example.com/dev/reference.css">
+      <script src="https://example.com/dev/reference.js"></script><img src="https://example.com/dev/" class="pkg-logo">
+      </div></div></div></body>
+
 # page header modification succeeds
 
     <h1 class="hasAnchor"><a href="#plot" class="anchor"> </a><img src="someimage" alt=""/> some text

--- a/tests/testthat/_snaps/html-tweak.md
+++ b/tests/testthat/_snaps/html-tweak.md
@@ -23,9 +23,9 @@
       cat(as.character(xml2::xml_child(dev_html)))
     Output
       <body><div><div><div>
-          <a href="https://example.com/dev/reference.html"></a>
-          <link href="https://example.com/dev/reference.css">
-      <script src="https://example.com/dev/reference.js"></script><img src="https://example.com/dev/" class="pkg-logo">
+          <a href="https://example.com/reference.html"></a>
+          <link href="https://example.com/reference.css">
+      <script src="https://example.com/reference.js"></script><img src="https://example.com/" class="pkg-logo">
       </div></div></div></body>
 
 # page header modification succeeds

--- a/tests/testthat/test-html-tweak.R
+++ b/tests/testthat/test-html-tweak.R
@@ -129,10 +129,24 @@ test_that("tweak_all_links() add the external-link class", {
 
 test_that("tweak_navbar_links() make URLs absolute", {
   html <- '<div><div><div><a href = "reference.html"></a></div></div></div>'
-  pkg <- list(meta = list(url = "https://example.com"))
+
+  pkg <- list(
+    meta = list(url = "https://example.com"),
+    development = list(in_dev = FALSE)
+  )
   expect_equal(
     tweak_navbar_links(html, pkg),
     "<body><div><div><div><a href=\"https://example.com/reference.html\"></a></div></div></div></body>"
+  )
+
+  pkg <- list(
+    meta = list(url = "https://example.com", development = "devel"),
+    version = "3.0.0.999",
+    development = list(in_dev = TRUE)
+  )
+  expect_equal(
+    tweak_navbar_links(html, pkg),
+    "<body><div><div><div><a href=\"https://example.com/dev/reference.html\"></a></div></div></div></body>"
   )
 })
 

--- a/tests/testthat/test-html-tweak.R
+++ b/tests/testthat/test-html-tweak.R
@@ -127,27 +127,34 @@ test_that("tweak_all_links() add the external-link class", {
   expect_false("class" %in% names(xml2::xml_attrs(links[[4]])))
 })
 
-test_that("tweak_404_links() make URLs absolute", {
-  html <- '<div><div><div><a href = "reference.html"></a></div></div></div>'
+test_that("tweak_404() make URLs absolute", {
+  html <- function() {
+  xml2::read_html(
+    '<div><div><div>
+    <a href = "reference.html"></a>
+    <link href = "reference.css"></link>
+    <script src = "reference.js"></script>
+    <img src = "reference.png" class="pkg-logo"></img>
+    </div></div></div>'
+  )
+  }
 
   pkg <- list(
     meta = list(url = "https://example.com"),
     development = list(in_dev = FALSE)
   )
-  expect_equal(
-    tweak_404_links(html, pkg, "body"),
-    "<body><div><div><div><a href=\"https://example.com/reference.html\"></a></div></div></div></body>"
-  )
+  prod_html <- html()
+  tweak_404(prod_html, pkg)
+  expect_snapshot(cat(as.character(xml2::xml_child(prod_html))))
 
   pkg <- list(
     meta = list(url = "https://example.com", development = "devel"),
     version = "3.0.0.999",
     development = list(in_dev = TRUE)
   )
-  expect_equal(
-    tweak_404_links(html, pkg, "body"),
-    "<body><div><div><div><a href=\"https://example.com/dev/reference.html\"></a></div></div></div></body>"
-  )
+  dev_html <- html()
+  tweak_404(dev_html, pkg)
+  expect_snapshot(cat(as.character(xml2::xml_child(dev_html))))
 })
 
 # homepage ----------------------------------------------------------------

--- a/tests/testthat/test-html-tweak.R
+++ b/tests/testthat/test-html-tweak.R
@@ -127,7 +127,7 @@ test_that("tweak_all_links() add the external-link class", {
   expect_false("class" %in% names(xml2::xml_attrs(links[[4]])))
 })
 
-test_that("tweak_navbar_links() make URLs absolute", {
+test_that("tweak_404_links() make URLs absolute", {
   html <- '<div><div><div><a href = "reference.html"></a></div></div></div>'
 
   pkg <- list(
@@ -135,7 +135,7 @@ test_that("tweak_navbar_links() make URLs absolute", {
     development = list(in_dev = FALSE)
   )
   expect_equal(
-    tweak_navbar_links(html, pkg),
+    tweak_404_links(html, pkg, "body"),
     "<body><div><div><div><a href=\"https://example.com/reference.html\"></a></div></div></div></body>"
   )
 
@@ -145,7 +145,7 @@ test_that("tweak_navbar_links() make URLs absolute", {
     development = list(in_dev = TRUE)
   )
   expect_equal(
-    tweak_navbar_links(html, pkg),
+    tweak_404_links(html, pkg, "body"),
     "<body><div><div><div><a href=\"https://example.com/dev/reference.html\"></a></div></div></div></body>"
   )
 })


### PR DESCRIPTION
Fix #1534, follow-up to #1524

I also noticed the link to the pkgdown stylesheet and JS was an absolute URL to the production stylesheet and JS, which is why https://pkgdown.r-lib.org/dev/404.html does not look good (only page linked from nowhere, which is why I missed it :upside_down_face: ).

The path to the logo also needs to be absolute on the 404 page.
