### PR TITLE
add external-link classes in navbar, footer and sidebar too

### DIFF
--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -82,9 +82,12 @@ data_home_sidebar <- function(pkg = ".") {
   )
 
   if (is.null(pkg$meta$home$sidebar$structure)) {
-    sidebar_html <- paste0(
-      purrr::compact(sidebar_components[default_sidebar_structure()]),
-      collapse = "\n"
+    sidebar_html <- tweak_all_links_char(
+      paste0(
+        purrr::compact(sidebar_components[default_sidebar_structure()]),
+        collapse = "\n"
+      ),
+      pkg = pkg
     )
     return(sidebar_html)
   }

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -83,6 +83,17 @@ tweak_all_links <- function(html, pkg = pkg) {
   invisible()
 }
 
+tweak_all_links_char <- function(txt, pkg = pkg) {
+  html <- xml2::read_html(txt)
+  tweak_all_links(html, pkg = pkg)
+  paste0(
+    paste0(
+      as.character(xml2::xml_contents(xml2::xml_child(html))),
+      collapse = "\n"
+    ),
+    "\n"
+  )
+}
 
 tweak_navbar_links <- function(html, pkg = pkg) {
 

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -206,7 +206,8 @@ bs4_navbar_links_tags <- function(links, depth = 0L) {
             href = "#", class = "nav-link dropdown-toggle",
             `data-toggle` = "dropdown", role = "button",
             `aria-expanded` = "false", `aria-haspopup` = "true",
-            link_text
+            link_text,
+            id = digest::digest(link_text, algo = "crc32")
           ),
           htmltools::tags$div(
             class = "dropdown-menu",
@@ -236,12 +237,12 @@ bs4_navbar_links_tags <- function(links, depth = 0L) {
     textTags <- bs4_navbar_link_text(x)
 
     if (is_submenu) {
-      return(htmltools::tags$a(class = "dropdown-item", href = x$href, textTags))
+      return(htmltools::tags$a(class = "dropdown-item", href = x$href, textTags, id = digest::digest(textTags, algo = "crc32")))
     }
 
     htmltools::tags$li(
       class = "nav-item",
-      htmltools::tags$a(class = "nav-link", href = x$href, textTags)
+      htmltools::tags$a(class = "nav-link", href = x$href, textTags, id = digest::digest(textTags, algo = "crc32"))
     )
 
   }

--- a/R/render.r
+++ b/R/render.r
@@ -264,7 +264,7 @@ render_template <- function(path, data) {
   if (length(template) == 0)
     return("")
 
-  html <- whisker::whisker.render(template, data)
+  whisker::whisker.render(template, data)
 }
 
 find_template <- function(type, name, ext = ".html", template_path = NULL,

--- a/R/render.r
+++ b/R/render.r
@@ -65,6 +65,8 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   )
   components <- purrr::map(templates, render_template, data = data)
   components <- purrr::set_names(components, pieces)
+  components$navbar <- tweak_all_links_char(components$navbar, pkg = pkg)
+  components$footer <- tweak_all_links_char(components$footer, pkg = pkg)
   components$template <- name
 
   if (path == "404.html" && !is.null(pkg$meta$url)) {
@@ -262,7 +264,7 @@ render_template <- function(path, data) {
   if (length(template) == 0)
     return("")
 
-  whisker::whisker.render(template, data)
+  html <- whisker::whisker.render(template, data)
 }
 
 find_template <- function(type, name, ext = ".html", template_path = NULL,


### PR DESCRIPTION
Fix #1630

Example of a CSS rule users could add for the navbar

```css
nav .external-link::after {
font-family: "Font Awesome 5 Free";
content: " \f35d";
font-weight: 900;
color: #5E5E5E;
}
```

Now, it can look weird as it does not exclude the GitHub icon.

![image](https://user-images.githubusercontent.com/8360597/115537283-f55b5980-a29a-11eb-9227-e7a025c97246.png)
