### PR TITLE
Align message/warning/error styling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # pkgdown (development version)
 
+* Styling for errors, warnings, and messages has been tweaked. Messages 
+  are now displayed the same way as output, and warnings and errors are
+  bolded, but not coloured. This is part of a suite of changes that allow
+  package authors greater control over message/warning/error appearance. 
+
 * pkgdown websites using BS4 will be more accessible, besides a better color contrast:
     * the heading anchors now have the property aria-hidden which should reduce noise for screenreader users.
     * the aria-labelledby property for navbar dropdowns was fixed.

--- a/inst/assets/BS3/pkgdown.css
+++ b/inst/assets/BS3/pkgdown.css
@@ -305,9 +305,8 @@ a.sourceLine:hover {
 .kw      {color: #264D66;} /* keyword */
 .co      {color: #888888;} /* comment */
 
-.message { color: black;   font-weight: bolder;}
-.error   { color: orange;  font-weight: bolder;}
-.warning { color: #6A0366; font-weight: bolder;}
+.error   {font-weight: bolder;}
+.warning {font-weight: bolder;}
 
 /* Clipboard --------------------------*/
 

--- a/inst/assets/BS4/syntax-highlighting.css
+++ b/inst/assets/BS4/syntax-highlighting.css
@@ -63,3 +63,5 @@ span.cn {color:#8f5902}
 span.sc {color:#20794D}
 span.dv {color:#AD0000}
 span.kw {color:#007BA5}
+span.error   {font-weight: bolder;}
+span.warning {font-weight: bolder;}


### PR DESCRIPTION
Reduce styling to allow the package to style as needed.

@maelle where does the corresponding code for BS4 live? 