### PR TITLE
Topic index should be a character vector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* Autolinking no longer failures if a package contains duplicated Rd aliases.
+
 * pkgdown websites using BS4 will be more accessible, besides a better color contrast:
     * the heading anchors now have the property aria-hidden which should reduce noise for screenreader users.
     * the aria-labelledby property for navbar dropdowns was fixed.

--- a/R/context.R
+++ b/R/context.R
@@ -11,7 +11,7 @@ section_init <- function(pkg, depth, override = list(), .frame = parent.frame())
 local_options_link <- function(pkg, depth, .frame = parent.frame()) {
   article_index <- set_names(path_file(pkg$vignettes$file_out), pkg$vignettes$name)
   Rdname <- fs::path_ext_remove(pkg$topics$file_in)
-  topic_index <- invert_index(set_names(pkg$topics$alias, Rdname))
+  topic_index <- unlist(invert_index(set_names(pkg$topics$alias, Rdname)))
 
   withr::local_options(
     list(


### PR DESCRIPTION
Fixes r-lib/downlit#74

This is already documented in downlit, so I'm pretty sure it's a pkgdown issue.