### PR TITLE
improve xpath for building search index

### DIFF
--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -235,7 +235,10 @@ bs4_index_data <- function(node, previous_headings, title, dir, path) {
   xml2::xml_remove(xml2::xml_find_all(node_copy, ".//*[contains(@class, 'dont-index')]"))
 
   # Helpers for XPath queries
-  all <- function(...) paste0(".//", c(...), collapse = "|")
+  all <- function(...) {
+    not <- sprintf("[not(%s)]", paste0(paste0("descendant::", c(...)), collapse = "|"))
+    paste0(".//", c(...), not, collapse = "|")
+  }
   text_xpath <- all("p", "li", "caption", "figcaption", "dt", "dd", "blockquote", "div[contains(@class, 'line-block')]")
   code_xpath <- all("pre")
 

--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -235,6 +235,9 @@ bs4_index_data <- function(node, previous_headings, title, dir, path) {
   xml2::xml_remove(xml2::xml_find_all(node_copy, ".//*[contains(@class, 'dont-index')]"))
 
   # Helpers for XPath queries
+  # We want to find all nodes corresponding to ... but whose descendants
+  # do not correspond to any ... otherwise we would treat some text/code twice,
+  # e.g. the text of p nested within li.
   all <- function(...) {
     not <- sprintf("[not(%s)]", paste0(paste0("descendant::", c(...)), collapse = "|"))
     paste0(".//", c(...), not, collapse = "|")

--- a/tests/testthat/_snaps/build-search-docs/search.json
+++ b/tests/testthat/_snaps/build-search-docs/search.json
@@ -6,7 +6,7 @@
     "previous_headings": [""],
     "what": ["Authors"],
     "title": ["Authors"],
-    "text": ["Hadley Wickham. Author, maintainer. Hadley Wickham. Author, maintainer. . Copyright holder, funder. . Copyright holder, funder."],
+    "text": ["Hadley Wickham. Author, maintainer. . Copyright holder, funder."],
     "code": [""]
   },
   {
@@ -46,7 +46,7 @@
     "previous_headings": [""],
     "what": ["sub-heading"],
     "title": ["testpackage 1.0.0"],
-    "text": ["first thing (#111 @githubuser) first thing (#111 @githubuser) second thing second thing"],
+    "text": ["first thing (#111 @githubuser) second thing"],
     "code": [""]
   }
 ]


### PR DESCRIPTION
Fix #1656 

``` r
all <- function(...) {
  not <- sprintf("[not(%s)]", paste0(paste0("descendant::", c(...)), collapse = "|"))
  paste0(".//", c(...), not, collapse = "|")
}
all("p", "li", "caption", "figcaption", "dt", "dd", "blockquote", "div[contains(@class, 'line-block')]")
#> [1] ".//p[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//li[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//caption[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//figcaption[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//dt[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//dd[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//blockquote[not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]|.//div[contains(@class, 'line-block')][not(descendant::p|descendant::li|descendant::caption|descendant::figcaption|descendant::dt|descendant::dd|descendant::blockquote|descendant::div[contains(@class, 'line-block')])]"
all("pre")
#> [1] ".//pre[not(descendant::pre)]"
```

<sup>Created on 2021-05-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0.9000)</sup>