### PR TITLE
Tweak styling of TOC

### DIFF
--- a/inst/assets/BS4/pkgdown.css
+++ b/inst/assets/BS4/pkgdown.css
@@ -441,6 +441,8 @@ mark {
 }
 .algolia-autocomplete .aa-dropdown-menu .aa-suggestion.aa-cursor {
   background-color: #B2D7FF;
+}
+
 /* Compromise to avoid flash of invisible text + flash of unstyled text */
 body {
   font-display: fallback;

--- a/inst/assets/BS4/pkgdown.css
+++ b/inst/assets/BS4/pkgdown.css
@@ -265,6 +265,7 @@ nav[data-toggle="toc"] .nav > li > a {
   padding-left: 0.5rem;
   margin-left: -0.5rem;
   border-radius: 1rem;
+  border: white solid;
 }
 
 /* Under hover */

--- a/inst/assets/BS4/pkgdown.css
+++ b/inst/assets/BS4/pkgdown.css
@@ -258,37 +258,37 @@ h2[data-toc-skip], #pkgdown-sidebar h2[data-toc-skip] {
 flex-direction: column;
 }
 
+
+/* Base TOC item */
 nav[data-toggle="toc"] .nav > li > a {
-  font-size: inherit;
   color: inherit;
-  padding-left: 3px;
-  font-weight: inherit;
-  margin-left: -3px;
+  padding-left: 0.5rem;
+  margin-left: -0.5rem;
+  border-radius: 1rem;
 }
 
+/* Under hover */
 nav[data-toggle="toc"] .nav > li > a:hover,
-nav[data-toggle="toc"] .nav > li > a:focus {
-  color: inherit;
-  border-left: none;
-  background-color: #eee;
-  padding-left: 3px;
-  margin-left: -3px;
-}
-
+nav[data-toggle="toc"] .nav > li > a:focus,
+/* Current */
 nav[data-toggle="toc"] .nav-link.active,
 nav[data-toggle="toc"] .nav-link.active:hover,
-nav[data-toggle="toc"] .nav-link.active:focus {
-  color: inherit;
+nav[data-toggle="toc"] .nav-link.active:focus
+{
   background-color: #eee;
-  font-weight: inherit;
-  padding-left: 3px;
-  border-left: none;
-  margin-left: -3px;
 }
 
-nav[data-toggle="toc"] .nav .nav > li > a {
-  font-size: 15px;
+/* Nav: second level (shown on .active) */
+nav[data-toggle="toc"] .nav-link + ul {
+  display: none;
 }
+nav[data-toggle="toc"] .nav-link.active + ul {
+  display: block;
+}
+nav[data-toggle="toc"] .nav .nav > li > a {
+  margin-left: 0.5rem;
+}
+
 /* version badge  */
 #version-badge {
   border: none;

--- a/inst/templates/BS4/head.html
+++ b/inst/templates/BS4/head.html
@@ -24,7 +24,6 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- bootstrap-toc -->
-<link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.1/dist/bootstrap-toc.min.css"/>
 <script src="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.1/dist/bootstrap-toc.min.js"></script>
 
 <!-- headroom.js -->


### PR DESCRIPTION
The main difference in styling is that the active/hover item now gets a border radius to match the navbar. But it was very hard to see what was going with the combination of bootstrap-toc styling and manual overrides, so I dropped the default styling.