### PR TITLE
Do not include dev website paths in search index of production website

### DIFF
--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -38,10 +38,7 @@ build_sitemap <- function(pkg = ".") {
     url <- paste0(url, pkg$prefix)
   }
 
-  urls <- paste0(
-    url,
-    get_site_paths(pkg)
-  )
+  urls <- paste0(url, get_site_paths(pkg))
 
   doc <- xml2::read_xml(
     paste0("<urlset xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'></urlset>")
@@ -310,11 +307,10 @@ capitalise <- function(string) {
 }
 
 get_site_paths <- function(pkg) {
-  paths <- fs::path_rel(
-    fs::dir_ls(pkg$dst_path, glob = "*.html", recurse = TRUE),
-    pkg$dst_path
-  )
+  paths <- fs::dir_ls(pkg$dst_path, glob = "*.html", recurse = TRUE)
+  paths_rel <- fs::path_rel(paths, pkg$dst_path)
+
   # do not include dev package website in search index / sitemap
-  dev_destination <- meta_development(pkg$meta)$destination
-  paths[!fs::path_has_parent(paths, dev_destination)]
+  dev_destination <- meta_development(pkg$meta, pkg$version)$destination
+  paths_rel[!fs::path_has_parent(paths_rel, "dev")]
 }

--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -102,11 +102,17 @@ build_search <- function(pkg = ".",
 }
 
 build_search_index <- function(pkg) {
-    paths <- fs::path_rel(
+  paths <- fs::path_rel(
     fs::dir_ls(pkg$dst_path, glob = "*.html", recurse = TRUE),
     pkg$dst_path
   )
   paths <- paths[!paths %in% c("404.html", "articles/index.html", "reference/index.html")]
+
+  if (!pkg$development$in_dev) {
+    # do not include dev package website in search index
+    dev_destination <- meta_development(pkg$meta)$destination
+    paths <- paths[!grepl(paste0("^", dev_destination, "/"), paths)]
+  }
 
   # user-defined exclusions
   paths <- paths[!paths %in% pkg$meta$search$exclude]

--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -108,11 +108,9 @@ build_search_index <- function(pkg) {
   )
   paths <- paths[!paths %in% c("404.html", "articles/index.html", "reference/index.html")]
 
-  if (!pkg$development$in_dev) {
-    # do not include dev package website in search index
-    dev_destination <- meta_development(pkg$meta)$destination
-    paths <- paths[!grepl(paste0("^", dev_destination, "/"), paths)]
-  }
+  # do not include dev package website in search index
+  dev_destination <- meta_development(pkg$meta)$destination
+  paths <- paths[!grepl(paste0("^", dev_destination, "/"), paths)]
 
   # user-defined exclusions
   paths <- paths[!paths %in% pkg$meta$search$exclude]

--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -40,10 +40,7 @@ build_sitemap <- function(pkg = ".") {
 
   urls <- paste0(
     url,
-    fs::path_rel(
-      fs::dir_ls(pkg$dst_path, glob = "*.html", recurse = TRUE),
-      pkg$dst_path
-    )
+    get_site_paths(pkg)
   )
 
   doc <- xml2::read_xml(
@@ -102,15 +99,8 @@ build_search <- function(pkg = ".",
 }
 
 build_search_index <- function(pkg) {
-  paths <- fs::path_rel(
-    fs::dir_ls(pkg$dst_path, glob = "*.html", recurse = TRUE),
-    pkg$dst_path
-  )
+  paths <- get_site_paths(pkg)
   paths <- paths[!paths %in% c("404.html", "articles/index.html", "reference/index.html")]
-
-  # do not include dev package website in search index
-  dev_destination <- meta_development(pkg$meta)$destination
-  paths <- paths[!grepl(paste0("^", dev_destination, "/"), paths)]
 
   # user-defined exclusions
   paths <- paths[!paths %in% pkg$meta$search$exclude]
@@ -317,4 +307,14 @@ is_heading <- function(node) {
 
 capitalise <- function(string) {
   paste0(toupper(substring(string, 1, 1)), substring(string, 2))
+}
+
+get_site_paths <- function(pkg) {
+  paths <- fs::path_rel(
+    fs::dir_ls(pkg$dst_path, glob = "*.html", recurse = TRUE),
+    pkg$dst_path
+  )
+  # do not include dev package website in search index / sitemap
+  dev_destination <- meta_development(pkg$meta)$destination
+  paths[!fs::path_has_parent(paths, dev_destination)]
 }


### PR DESCRIPTION
Fix #1680

Thanks to report by @mcanouil in https://github.com/r-lib/pkgdown/issues/1680#issuecomment-838628384

Something to keep in mind too if one day pkgdown keeps website of different releases.

