### PR TITLE
allow aligning tables in R Markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,7 @@ Suggests:
     evaluate,
     htmltools,
     htmlwidgets,
+    kableExtra,
     knitr,
     lifecycle,
     methods,

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -89,6 +89,7 @@ tweak_tables <- function(html) {
   # Ensure all tables have class="table"
   table <- xml2::xml_find_all(html, ".//table")
   tweak_class_prepend(table, "table")
+  xml2::xml_add_parent(table, "div", style = "display: flex;")
 
   invisible()
 }

--- a/R/html-tweak.R
+++ b/R/html-tweak.R
@@ -89,6 +89,9 @@ tweak_tables <- function(html) {
   # Ensure all tables have class="table"
   table <- xml2::xml_find_all(html, ".//table")
   tweak_class_prepend(table, "table")
+
+  # Add a parent div with flex display
+  # to allow the table itself to be left/right/center aligned
   xml2::xml_add_parent(table, "div", style = "display: flex;")
 
   invisible()

--- a/vignettes/table.Rmd
+++ b/vignettes/table.Rmd
@@ -47,3 +47,9 @@ df %>%
                 position = "left",
                 font_size = 13)
 ```
+
+```{r table4}
+df <- dt <- mtcars[1:5, 1:6]
+df %>% 
+  knitr::kable()
+```

--- a/vignettes/table.Rmd
+++ b/vignettes/table.Rmd
@@ -1,0 +1,49 @@
+---
+title: "table"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{table}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a 
+
+```{r setup}
+library(kableExtra)
+library(magrittr)
+```
+
+```{r table1}
+df <- dt <- mtcars[1:5, 1:6]
+df %>% 
+  kbl(caption = "A table ...", align = "lcccccc") %>%
+  kable_styling(full_width = F,
+                font_size = 13)
+```
+
+
+```{r table2}
+df <- dt <- mtcars[1:5, 1:6]
+df %>% 
+  kbl(caption = "A table ...", align = "lcccccc") %>%
+  kable_styling(full_width = F,
+                position = "right",
+                font_size = 13)
+```
+
+```{r table3}
+df <- dt <- mtcars[1:5, 1:6]
+df %>% 
+  kbl(caption = "A table ...", align = "lcccccc") %>%
+  kable_styling(full_width = F,
+                position = "left",
+                font_size = 13)
+```


### PR DESCRIPTION
Fix #1544

- [ ] Remove example before merging. https://60b5d6a3ef2afd543aa9b96f--pkgdown-dev.netlify.app/dev/articles/table.html

- [ ] I suppose it would also be better to not hard-code the style into the HTML: if the change in this PR is approved, I could fix and merge after the bslib infrastructure is more stable. :slightly_smiling_face: 