### PR TITLE
article_index fix

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -9,7 +9,7 @@ section_init <- function(pkg, depth, override = list(), .frame = parent.frame())
 }
 
 local_options_link <- function(pkg, depth, .frame = parent.frame()) {
-  article_index <- set_names(path_file(pkg$vignettes$file_out), pkg$vignettes$name)
+  article_index <- set_names(pkg$vignettes$file_out, path_file(pkg$vignettes$name))
   Rdname <- get_rdname(pkg$topics)
   topic_index <- unlist(invert_index(set_names(pkg$topics$alias, Rdname)))
 

--- a/R/init.R
+++ b/R/init.R
@@ -138,7 +138,7 @@ build_site_meta <- function(pkg = ".") {
 }
 
 site_meta <- function(pkg) {
-  article_index <- set_names(path_file(pkg$vignettes$file_out), pkg$vignettes$name)
+  article_index <- set_names(pkg$vignettes$file_out, path_file(pkg$vignettes$name))
 
   meta <- list(
     pandoc = as.character(rmarkdown::pandoc_version()),


### PR DESCRIPTION
Fix #1730 

I ended up noticing the structure of the article index produced by pkgdown and set as option `downlit.article_index` was different from the ones downlit creates for source packages.

In downlit, `find_article()` will recognize an article if its name is in the names of a vector. Then what it returns is the path relative to the article path (e.g. "usethis.html" or "articles/usethis-setup.html").

Edit: no fix is needed in downlit. On its own downlit would only produce an article index with _vignettes_. `downlit:::article_index_remote("googledrive")` is wrong because it uses the metadata published by pkgdown.

``` r
pkgload::load_all("/home/maelle/Documents/pkgdown/googledrive")
#> ℹ Loading googledrive
#> ! Internal auth failed; calling `drive_deauth()`.
downlit:::article_index_source("googledrive")
#>                  bring-your-own-app                       example-files 
#>  "articles/bring-your-own-app.html"       "articles/example-files.html" 
#>                 file-identification                 messages-and-errors 
#> "articles/file-identification.html" "articles/messages-and-errors.html" 
#>                      multiple-files                         permissions 
#>      "articles/multiple-files.html"         "articles/permissions.html" 
#>                         googledrive 
#>                  "googledrive.html"
downlit:::article_index_remote("googledrive")
#>  articles/bring-your-own-app       articles/example-files 
#>    "bring-your-own-app.html"         "example-files.html" 
#> articles/file-identification articles/messages-and-errors 
#>   "file-identification.html"   "messages-and-errors.html" 
#>      articles/multiple-files         articles/permissions 
#>        "multiple-files.html"           "permissions.html" 
#>                  googledrive 
#>           "googledrive.html"
```

<sup>Created on 2021-07-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>