### PR TITLE
new way to call bslib

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -214,6 +214,7 @@ create_bs_assets <- function(pkg) {
     srcType = "file",
     hrefFilter = transform_path
   )
+  # save tags that will be re-used and tweaked depending on page depth
   write_lines(tags, file.path(pkg$dst_path, "data-deps.txt"))
 
 }

--- a/R/init.R
+++ b/R/init.R
@@ -215,7 +215,7 @@ create_bs_assets <- function(pkg) {
     hrefFilter = transform_path
   )
   # save tags that will be re-used and tweaked depending on page depth
-  write_lines(tags, file.path(pkg$dst_path, "data-deps.txt"))
+  write_lines(tags, data_deps_path(pkg))
 
 }
 
@@ -242,4 +242,8 @@ check_bootswatch_theme <- function(bootswatch_theme, bs_version, pkg) {
 
 pkgdown_bslib_defaults <- function() {
   list(`navbar-nav-link-padding-x` = "1rem")
+}
+
+data_deps_path <- function(pkg) {
+  file.path(pkg$dst_path, "deps", "data-deps.txt")
 }

--- a/R/render.r
+++ b/R/render.r
@@ -408,10 +408,10 @@ footer_pkgdown <- function(data) {
 }
 
 data_deps <- function(pkg, depth) {
-  if (!file.exists(file.path(pkg$dst_path, "data-deps.txt"))) {
+  if (!file.exists(data_deps_path(pkg))) {
     abort("Run pkgdown::init_site() first.")
   }
-  data_deps <- read_lines(file.path(pkg$dst_path, "data-deps.txt"))
+  data_deps <- read_lines(data_deps_path(pkg))
   if (depth == 0) {
     return(data_deps)
   }

--- a/R/render.r
+++ b/R/render.r
@@ -420,8 +420,12 @@ data_deps <- function(pkg, depth) {
     paste0(rep("..", depth), collapse = "/"), # as many levels up as depth
     "/deps"
   )
-  gsub('src="deps', sprintf('src="%s', deps_path), data_deps)
-  gsub('href="deps', sprintf('href="%s', deps_path), data_deps)
+
+  c(
+    gsub('src="deps', sprintf('src="%s', deps_path), data_deps),
+    gsub('href="deps', sprintf('href="%s', deps_path), data_deps)
+  )
+
 }
 
 

--- a/tests/testthat/test-build-search-docs.R
+++ b/tests/testthat/test-build-search-docs.R
@@ -18,6 +18,7 @@ test_that("build_search() builds the expected search.json", {
   pkg$bs_version <- 4
   tmp <- withr::local_tempdir()
   pkg$dst_path <- tmp
+  init_site(pkg)
   build_news(pkg)
   build_home(pkg)
   build_sitemap(pkg)


### PR DESCRIPTION
Fix #1695 

Other approaches (thanks @cderv for the insightful discussion) would involve still calling bslib & friends in `render_page()`, but **caching** the result somehow (maybe "stateful function", maybe `rlang::env_cache()` -- again thanks @cderv).

Pros of the approach of this PR
+ to me it seems more logical to create assets in `init_site()`, when I first thought of caching I had the impression to apply a band-aid on bad design of mine.
+ you can run `init_site()` once and be done with it for several R sessions where you e.g. only work on articles.

Con of the approach of this PR
+ it is a bit awkward to save tags in a text file.
+ if you change the bslib params in the configuration and build articles, you won't see the new styling.

Note that this PR uses regex for now :sweat_smile: but the tags could be tweaked with XPath.