### PR TITLE
Fix duplication in reference index

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -42,9 +42,15 @@ reference:
   contents:
   - build_site
   - init_site
-  - starts_with("build_")
-  - preview_site
   - pkgdown_sitrep
+  - build_favicons
+  - build_home
+  - build_reference
+  - build_articles
+  - build_news
+  - build_search
+  - build_tutorials
+  - preview_site
 
 - title: Deployment
   contents:


### PR DESCRIPTION
Fix #1766 h/t @cderv 

Upside: one can now choose a logical order.
Downside: having to choose that logical order.

AFAIK there's no way to use `starts_with` "except stuff already listed elsewhere".