### PR TITLE
Apply usual logic to search.json location rather than faulty special one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,7 +45,7 @@
 * pkgdown's deploy_to_branch() now cleans out the website directory by default (`clean = TRUE`). To revert to previous behaviour, call it with `clean = FALSE`. (#1394)
 
 * pkgdown now supports local searching. It is enabled by default because no set-up is needed for users to
-  search pkgdown websites. (#1629, with help from @gustavdelius in #1655)
+  search pkgdown websites. (#1629, with help from @gustavdelius in #1655 and @dieghernan @GregorDeCillia in #1770)
 
 * pkgdown builds a more exhaustive sitemap.xml even for websites built with Bootstrap 3. 
   This might change Algolia results if you use Algolia for search. (#1629)

--- a/R/render.r
+++ b/R/render.r
@@ -46,9 +46,6 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   # Potential opt-out of syntax highlighting CSS
   data$needs_highlight_css <- !isFALSE(pkg$meta[["template"]]$params$highlightcss)
 
-  # Search index location
-  data$`search-index` <- paste0("/", pkg$prefix, "search.json")
-
   # render template components
   pieces <- c(
     "head", "navbar", "header", "content", "docsearch", "footer",

--- a/inst/templates/BS4/navbar.html
+++ b/inst/templates/BS4/navbar.html
@@ -17,7 +17,7 @@
       {{/left}}
 
       <form class="form-inline my-2 my-lg-0" role="search">
-        <input type="search" class="form-control mr-sm-2" aria-label="Search" name="search-input" data-search-index="{{{search-index}}}" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off">
+        <input type="search" class="form-control mr-sm-2" aria-label="Search" name="search-input" data-search-index="{{#site}}{{root}}{{/site}}search.json" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off">
       </form>
 
       {{#right}}


### PR DESCRIPTION
Fix #1770