### PR TITLE
Fix failing test

### DIFF
--- a/tests/testthat/_snaps/build-news.md
+++ b/tests/testthat/_snaps/build-news.md
@@ -11,3 +11,13 @@
     </ul></div>
     </div>
 
+# correct timeline for first ggplot2 releases
+
+    Code
+      pkg_timeline("ggplot2")[1:3, ]
+    Output
+        version       date
+      1     0.5 2007-06-01
+      2   0.5.1 2007-06-09
+      3   0.5.2 2007-06-18
+

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -39,14 +39,7 @@ test_that("pkg_timeline returns NULL if CRAN dates suppressed", {
 test_that("correct timeline for first ggplot2 releases", {
   skip_on_cran()
 
-  timeline <- pkg_timeline("ggplot2")[1:3, ]
-  expected <- data.frame(
-    version = c("0.5", "0.5.1", "0.5.2"),
-    date = as.Date(c("2007-06-01", "2007-06-09", "2007-06-18")),
-    stringsAsFactors = FALSE
-  )
-
-  expect_equal(timeline, expected)
+  expect_snapshot(pkg_timeline("ggplot2")[1:3, ])
 })
 
 test_that("determines page style from meta", {


### PR DESCRIPTION
See https://github.com/r-lib/pkgdown/runs/3630961903?check_suite_focus=true

```r
── Failure (test-build-news.R:49:3): correct timeline for first ggplot2 releases ──
`timeline` (`actual`) not equal to `expected` (`expected`).

`attr(actual, 'row.names')` is a character vector ('0.5', '0.5.1', '0.5.2')
`attr(expected, 'row.names')` is an integer vector (1, 2, 3)
```

I am not sure I understand https://github.com/wch/r-source/blob/47ee316d567649a1a659c9180e37b29178965ec7/doc/NEWS.Rd#L1193 that'd be the only related change I could find.