### PR TITLE
`\value{}` can have multiple item/text blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Fix rendering of `\special{}` tags with complex contents (@klmr, #1744).
 
+* `\value{}` now does a better job of handling multiple mingled items and text 
+  (#1479).
+
 * `build_reference()` now allows linking to topics from other packages (either function names e.g. `rlang::is_installed` or topic names e.g. `sass::font_face`). (#1664)
 
 * pkgdown, for Bootstrap 4, supports tabsets in articles [as in R Markdown](https://bookdown.org/yihui/rmarkdown-cookbook/html-tabs.html) including [fading effect](https://bookdown.org/yihui/rmarkdown/html-document.html#tabbed-sections) (@JamesHWade, #1667).

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -381,8 +381,6 @@ parse_descriptions <- function(rd, ...) {
     return(character())
   }
 
-  is_item <- purrr::map_lgl(rd, inherits, "tag_item")
-
   parse_item <- function(x) {
     if (inherits(x, "tag_item")) {
       paste0(

--- a/tests/testthat/test-rd-data.R
+++ b/tests/testthat/test-rd-data.R
@@ -1,0 +1,38 @@
+# Value blocks ------------------------------------------------------------
+
+test_that("leading text parsed as paragraph", {
+  expected <- c(
+    "<p>text</p>",
+    "<dl>", "<dt>x</dt><dd><p>y</p></dd>", "</dl>"
+  )
+  expect_equal(value2html("\ntext\n\\item{x}{y}"), expected)
+  expect_equal(value2html("text\\item{x}{y}"), expected)
+})
+
+test_that("leading text is optional", {
+  expect_equal(
+    value2html("\\item{x}{y}"),
+    c("<dl>", "<dt>x</dt><dd><p>y</p></dd>", "</dl>")
+  )
+})
+
+test_that("leading text is optional", {
+  expect_equal( value2html("text"),"<p>text</p>")
+})
+
+test_that("items are optional", {
+  value <- rd_text("\\value{text}", fragment = FALSE)
+  expect_equal(as_data(value[[1]])$contents, "<p>text</p>")
+})
+
+test_that("can have multiple interleaved blocks", {
+  expect_equal(
+    value2html("text1\\item{a}{b}\\item{c}{d}text2\\item{e}{f}"),
+    c(
+      "<p>text1</p>",
+      "<dl>", "<dt>a</dt><dd><p>b</p></dd><dt>c</dt><dd><p>d</p></dd>","</dl>",
+      "<p>text2</p>",
+      "<dl>", "<dt>e</dt><dd><p>f</p></dd>", "</dl>"
+    )
+  )
+})

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -422,30 +422,6 @@ test_that("special", {
   expect_equal(out, "( ... )")
 })
 
-
-# Value blocks ------------------------------------------------------------
-
-test_that("leading text parsed as paragraph", {
-  expected <- "<p>text</p>\n<dt>x</dt><dd><p>y</p></dd>"
-
-  value1 <- rd_text("\\value{\ntext\n\\item{x}{y}}", fragment = FALSE)
-  expect_equal(as_data(value1[[1]])$contents, expected)
-
-  value2 <- rd_text("\\value{text\\item{x}{y}}", fragment = FALSE)
-  expect_equal(as_data(value2[[1]])$contents, expected)
-})
-
-test_that("leading text is optional", {
-  value <- rd_text("\\value{\\item{x}{y}}", fragment = FALSE)
-  expect_equal(as_data(value[[1]])$contents, "<dt>x</dt><dd><p>y</p></dd>")
-})
-
-test_that("items are optional", {
-  value <- rd_text("\\value{text}", fragment = FALSE)
-  expect_equal(as_data(value[[1]])$contents, "<p>text</p>")
-})
-
-
 # figures -----------------------------------------------------------------
 
 test_that("figures are converted to img", {


### PR DESCRIPTION
Fixes #1479