### PR TITLE
Only set version tooltip if development mode set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* The version tooltip showed in the top navbar is now only set if you've 
+  explcitly set the `development$mode` in `_pkgdown.yml` (#1768).
+
 * `build_reference()` will run `pkgdown/pre-reference.R` before and 
   `pkgdown/post-reference.R` after running examples. These allow you to
   do any setup or teardown operations you might need (#1602).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # pkgdown (development version)
 
 * The version tooltip showed in the top navbar is now only set if you've 
-  explcitly set the `development$mode` in `_pkgdown.yml` (#1768).
+  explicitly set the `development$mode` in `_pkgdown.yml` (#1768).
 
 * Reference index section with `title: internal` is now silently dropped,
   allowing you to suppress warnings about topics that are not listed in the

--- a/R/development.R
+++ b/R/development.R
@@ -3,9 +3,10 @@ meta_development <- function(meta, version) {
 
   destination <- purrr::pluck(development, "destination", .default = "dev")
 
-  mode <- purrr::pluck(development, "mode", .default = "release")
+  mode <- purrr::pluck(development, "mode", .default = "default")
   mode <- switch(mode,
     auto = dev_mode(version),
+    default = ,
     release = ,
     devel = ,
     unreleased = mode,
@@ -17,12 +18,13 @@ meta_development <- function(meta, version) {
 
   version_label <- purrr::pluck(development, "version_label")
   if (is.null(version_label)) {
-    version_label <- if (mode == "release") "default" else "danger"
+    version_label <- if (mode %in% c("release", "default")) "default" else "danger"
   }
 
   version_tooltip <- purrr::pluck(development, "version_tooltip")
   if (is.null(version_tooltip)) {
     version_tooltip <- switch(mode,
+      default = "",
       release = "Released version",
       devel = "In-development version",
       unreleased = "Unreleased version"

--- a/tests/testthat/test-development.R
+++ b/tests/testthat/test-development.R
@@ -1,8 +1,20 @@
 test_that("empty yaml gets correct defaults", {
   dev <- meta_development(list())
-  expect_equal(dev$mode, "release")
+  expect_equal(dev$mode, "default")
   expect_equal(dev$in_dev, FALSE)
   expect_equal(dev$version_label, "default")
+})
+
+test_that("explicit devel status gets tooltip", {
+  tooltip <- function(mode) {
+    meta <- list(development = list(mode = mode))
+    version <- package_version("1.0.0.9000")
+    meta_development(meta, version)$version_tooltip
+  }
+
+  expect_equal(tooltip("auto"), "In-development version")
+  expect_equal(tooltip("release"), "Released version")
+  expect_equal(tooltip(NULL), "")
 })
 
 test_that("mode = auto uses version", {


### PR DESCRIPTION
Fixes #1768

@jennybc I'm pretty sure this is the correct logic (and hopefully you can follow it with too much of the pkgdown context), but I'd appreciate a second pair of eyes.