### PR TITLE
deploy_to_branch: Don't clobber remote's configured refspec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* `deploy_to_branch()` now calls `git remote set-branches` with `--add` to avoid
+  overwriting the existing `remote.{remote}.fetch` value (@kyleam, #1382).
+
 * Support for `as_is: true` and non-default output formats for vignettes/
   articles has been somewhat improved. Support is fundamentally limited due to
   the challenges of integrating HTML from output formats that pkgdown doesn't

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -122,7 +122,7 @@ deploy_to_branch <- function(pkg = ".",
 
   # Explicitly set the branches tracked by the origin remote.
   # Needed if we are using a shallow clone, such as on travis-CI
-  git("remote", "set-branches", remote, branch)
+  git("remote", "set-branches", "--add", remote, branch)
 
   git("fetch", remote, branch)
 


### PR DESCRIPTION
cfd478ef (Explicitly set the remote's branch before fetching,
2020-03-25) made deploy_to_branch() call `git remote set-branches`
before fetching.  This prevents the downstream `git worktree --track`
call from failing in shallow clones (#1271), or more generally
whenever `remote.{remote}.fetch` is set to a refspec that excludes
gh-pages (or whatever the specified deploy branch is).

However, the set-branches call overwrites the configured value
entirely.  For example, if a remote 'origin' that has the default
`+refs/heads/*:refs/remotes/origin/*` refspec, that will be rewritten
to `+refs/heads/gh-pages:refs/remotes/origin/gh-pages`.  When the user
next calls `git fetch origin` expecting to bring in all of the
standard refs, only the gh-pages ref will be updated.

Avoid this problem by extending the `remote.{remote}.fetch` value with
`set-branches --add` rather than overwriting it.

Note that it _seems_ like a cleaner option would be to update the
fetch call to use an explicit refspec (e.g.,
`+refs/heads/gh-pages:refs/remotes/origin/gh-pages`).  That will work
in the sense that `refs/remotes/origin/gh-pages` will be created, but
`worktree add --track` will still fail with the same error reported in
gh-1271 because it cares about what the `.fetch` value is.

Another option would be to not use `--track` when adding the worktree.
I don't spot anything in the downstream code (e.g., the `git push`)
that relies on the upstream branch being configured, but using
`set-branches --add` is the more minimal fix.