### PR TITLE
Apply HTML tweaks more consistently

### DIFF
--- a/R/build-news.R
+++ b/R/build-news.R
@@ -293,16 +293,13 @@ tweak_news_heading <- function(html, version, timeline, bs_version) {
 
 # Manually de-duplicate repeated section anchors using version
 tweak_news_anchor <- function(html, version) {
-  h <- xml2::xml_find_all(html, "(.//h3|.//h4|.//h5|.//h6)")
+  div <- xml2::xml_find_all(html, ".//div")
+  div <- div[has_class(div, "section")]
 
-  id <- xml2::xml_attr(h, "id")
+  id <- xml2::xml_attr(div, "id")
   id <- gsub("-[0-9]+", "", id) # remove pandoc de-duplication suffixes
   id <- paste0(id, "-", gsub("[^a-z0-9]+", "-", version)) # . breaks scrollspy
-
-  xml2::xml_attr(h, "id") <- id
-  # Also need to update anchors, since these were added earlier
-  a <- xml2::xml_find_first(h, ".//a[@class='anchor']")
-  xml2::xml_attr(a, "href") <- paste0("#", id)
+  xml2::xml_attr(div, "id") <- id
 
   invisible()
 }

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -256,11 +256,6 @@ build_reference_index <- function(pkg = ".") {
     path = "reference/index.html"
   )
 
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference/index.html"), encoding = "UTF-8")
-  tweak_link_external(html, pkg = pkg)
-  tweak_anchors(html)
-  xml2::write_html(html, file.path(pkg$dst_path, "reference/index.html"))
-
   invisible()
 }
 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -73,15 +73,10 @@ markdown_path_html <- function(path, strip_header = FALSE, pkg = list()) {
     xml2::xml_remove(h1)
   }
 
-  downlit::downlit_html_node(xml)
-  tweak_link_md(xml)
-  tweak_link_external(xml, pkg = pkg)
-  tweak_anchors(xml)
-
   structure(xml, title = title)
 }
 
-markdown_to_html <- function(text, dedent = 4) {
+markdown_to_html <- function(text, dedent = 4, bs_version = 3) {
   if (dedent) {
     text <- gsub(paste0("($|\n)", strrep(" ", dedent)), "\\1", text, perl = TRUE)
   }
@@ -93,7 +88,7 @@ markdown_to_html <- function(text, dedent = 4) {
   convert_markdown_to_html(md_path, html_path)
 
   html <- xml2::read_html(html_path, encoding = "UTF-8")
-  tweak_anchors(html)
+  tweak_page(html, list(bs_version = bs_version))
   html
 }
 

--- a/R/render.R
+++ b/R/render.R
@@ -71,13 +71,10 @@ render_page <- function(pkg = ".", name, data, path = "", depth = NULL, quiet = 
   rendered <- render_template(template, components)
 
   html <- xml2::read_html(rendered, encoding = "UTF-8")
+
+  tweak_page(html, pkg = pkg)
   if (pkg$bs_version > 3) {
-    tweak_footnotes(html)
     activate_navbar(html, data$output_file %||% path, pkg)
-    trim_toc(html)
-  }
-  if (pkg$desc$has_dep("R6")) {
-    tweak_link_R6(html, pkg$package)
   }
   for (tweak in tweaks) {
     tweak(html)

--- a/R/tweak-page.R
+++ b/R/tweak-page.R
@@ -1,17 +1,25 @@
 # File level tweaks --------------------------------------------
-
-tweak_rmarkdown_html <- function(html, input_path, pkg = pkg) {
+tweak_page <- function(html, pkg = list()) {
   # Automatically link function mentions
   downlit::downlit_html_node(html)
   tweak_anchors(html)
   tweak_link_md(html)
   tweak_link_external(html, pkg = pkg)
+  tweak_tables(html)
+  tweak_img_src(html)
 
   if (pkg$bs_version > 3) {
     tweak_footnotes(html)
     tweak_tabsets(html)
+    trim_toc(html)
   }
 
+  if (!is.null(pkg$desc) && pkg$desc$has_dep("R6")) {
+    tweak_link_R6(html, pkg$package)
+  }
+}
+
+tweak_rmarkdown_html <- function(html, input_path, pkg = pkg) {
   # Tweak classes of navbar
   toc <- xml2::xml_find_all(html, ".//div[@id='tocnav']//ul")
   xml2::xml_attr(toc, "class") <- "nav nav-pills nav-stacked"
@@ -29,8 +37,10 @@ tweak_rmarkdown_html <- function(html, input_path, pkg = pkg) {
     )
   }
 
-  tweak_img_src(html)
-  tweak_tables(html)
+  # Has to occur after path normalisation
+  # This get called twice on the contents of content-article.html, but that
+  # should be harmless
+  tweak_page(html, pkg = pkg)
 
   invisible()
 }
@@ -80,9 +90,6 @@ tweak_homepage_html <- function(html,
         .where = "before"
       )
   }
-
-  tweak_img_src(html)
-  tweak_tables(html)
 
   invisible()
 }

--- a/tests/testthat/_snaps/build-news.md
+++ b/tests/testthat/_snaps/build-news.md
@@ -1,16 +1,3 @@
-# github links are added to news items
-
-    <div class="section level2">
-    <h2 id="testpackage-010" class="page-header" data-toc-text="0.1.0">testpackage 0.1.0<a class="anchor" aria-label="anchor" href="#testpackage-010"></a>
-    </h2>
-    <div class="section level3">
-    <h3 id="major-changes-0-1-0">Major changes<a class="anchor" aria-label="anchor" href="#major-changes-0-1-0"></a>
-    </h3>
-    <ul><li><p>Bug fixes (<a href='https://github.com/hadley'>@hadley</a>, <a href='https://github.com/hadley/pkgdown/issues/100'>#100</a>)</p></li>
-    <li><p>Merges (<a href='https://github.com/josue-rodriguez'>@josue-rodriguez</a>)</p></li>
-    </ul></div>
-    </div>
-
 # news headings get class and release date
 
     <div>

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -11,7 +11,7 @@
       [1] "<p>Developed by bla.</p>"
       
       $right
-      [1] "<p>Site built with <a href=\"https://pkgdown.r-lib.org/\" class=\"external-link\">pkgdown</a> 42.</p>"
+      [1] "<p>Site built with <a href=\"https://pkgdown.r-lib.org/\">pkgdown</a> 42.</p>"
       
 
 # pkgdown_footer() can use custom components
@@ -23,7 +23,7 @@
       [1] "<p>Developed by bla. <strong><em>Wow</em></strong></p>"
       
       $right
-      [1] "<p>Site built with <a href=\"https://pkgdown.r-lib.org/\" class=\"external-link\">pkgdown</a> 42.</p>"
+      [1] "<p>Site built with <a href=\"https://pkgdown.r-lib.org/\">pkgdown</a> 42.</p>"
       
 
 ---
@@ -35,7 +35,7 @@
       [1] "<p><strong><em>Wow</em></strong></p>"
       
       $right
-      [1] "<p>Site built with <a href=\"https://pkgdown.r-lib.org/\" class=\"external-link\">pkgdown</a> 42.</p>"
+      [1] "<p>Site built with <a href=\"https://pkgdown.r-lib.org/\">pkgdown</a> 42.</p>"
       
 
 # pkgdown_footer() throws informative error messages

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -6,8 +6,16 @@ test_that("github links are added to news items", {
     list(news = list(cran_dates = FALSE))
   )
   news_tbl <- data_news(pkg)
+  html <- xml2::read_xml(news_tbl$html)
 
-  expect_snapshot_output(cat(news_tbl$html))
+  expect_equal(
+    xpath_attr(html, ".//a", "href"),
+    c(
+      "https://github.com/hadley",
+      "https://github.com/hadley/pkgdown/issues/100",
+      "https://github.com/josue-rodriguez"
+    )
+  )
 })
 
 test_that("pkg_timeline fails cleanly for unknown package", {
@@ -105,12 +113,11 @@ test_that("sections tweaked down a level", {
 
 test_that("anchors de-duplicated with version", {
   html <- xml2::read_xml("<body>
-    <h3 id='x-1'>Heading <a class='anchor'></a></h3>
+    <div class='section' id='x-1'>Heading</div>
   </body>")
   tweak_news_anchor(html, "1.0")
 
-  expect_equal(xpath_attr(html, "//h3", "id"), "x-1-0")
-  expect_equal(xpath_attr(html, "//a", "href"), "#x-1-0")
+  expect_equal(xpath_attr(html, ".//div", "id"), "x-1-0")
 })
 
 test_that("news headings get class and release date", {

--- a/tests/testthat/test-rmarkdown.R
+++ b/tests/testthat/test-rmarkdown.R
@@ -15,7 +15,7 @@ test_that("render_rmarkdown copies image files in subdirectories", {
 test_that("render_rmarkdown yields useful error", {
   skip_if_no_pandoc()
   tmp <- dir_create(file_temp())
-  pkg <- list(src_path = test_path("."), dst_path = tmp)
+  pkg <- list(src_path = test_path("."), dst_path = tmp, bs_version = 3)
 
   expect_snapshot(error = TRUE, {
     render_rmarkdown(pkg, "assets/pandoc-fail.Rmd", "test.html")

--- a/tests/testthat/test-tweak-page.R
+++ b/tests/testthat/test-tweak-page.R
@@ -16,7 +16,7 @@ test_that("links to vignettes & figures tweaked", {
     <img src="../man/figures/x.png" />
   </body>')
 
-  tweak_homepage_html(html, bs_version = 3)
+  tweak_page(html, list(bs_version = 3, desc = desc::desc(text = "")))
   expect_equal(
     xpath_attr(html, ".//img", "src"),
     c("articles/x.png", "../articles/x.png", "reference/figures/x.png", "../reference/figures/x.png")


### PR DESCRIPTION
New tweak_page() applies the standard set of tweaks in render_page(). This means that markdown_*() no longer applies any tweaks so the news tweaking can be simplified.

Fixes #1835