### PR TITLE
Add link to JS console intro

### DIFF
--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -66,7 +66,7 @@ template:
     pkgdown-nav-height: 100px
 ```
 
-You can find the correct height by running `$(".navbar").outerHeight()` in the javascript console.
+You can find the correct height by running `$(".navbar").outerHeight()` in the [javascript console](https://developer.mozilla.org/en-US/docs/Tools/Web_Console).
 
 ### bslib variables
 


### PR DESCRIPTION
The direct link would be https://developer.mozilla.org/en-US/docs/Tools/Web_Console/The_command_line_interpreter but better to provide some context on the Web Console itself and then newbies can navigate to the part of that page about running JS? :thinking: 