### PR TITLE
Adds a built-in `package` component to the footer

### DIFF
--- a/R/build-footer.R
+++ b/R/build-footer.R
@@ -38,7 +38,8 @@ footnote_components <- function(pkg = ".") {
 
   print_yaml(list(
     developed_by = developed_by,
-    built_with = built_with
+    built_with = built_with,
+    package = pkg[["package"]]
   ))
 }
 

--- a/man/rmd-fragments/footer-configuration.Rmd
+++ b/man/rmd-fragments/footer-configuration.Rmd
@@ -11,10 +11,11 @@ footer:
     right: built_with
 ```
 
-Which draws from the two built-in components:
+Which uses two of the three built-in components:
 
 -   `developed_by`, a sentence describing the main authors of the package. (See `?build_home` if you want to tweak *which* authors appear in the footer.)
--   `built_with`, a sentence advertising pkgdown
+-   `built_with`, a sentence advertising pkgdown.
+-   `package`, the name of the package.
 
 You can override these defaults with the `footer` field.
 The example below puts the authors information on the right along with a legal disclaimer, and puts the pkgdown link on the left.

--- a/tests/testthat/test-build-footer.R
+++ b/tests/testthat/test-build-footer.R
@@ -8,6 +8,22 @@ test_that("works by default", {
   expect_snapshot(data_footer(pkg))
 })
 
+test_that("includes package component", {
+  pkg <- structure(
+    list(
+      package = "noodlr",
+      desc = desc::desc(text = "Authors@R: person('First', 'Last', role = 'cre')"),
+      meta = list(
+        footer = list(
+          structure = list(left = "package")
+        )
+      )
+    ),
+    class = "pkgdown"
+  )
+  expect_equal(data_footer(pkg)$left, "<p>noodlr</p>")
+})
+
 test_that("can use custom components", {
   pkg <- structure(list(
     desc = desc::desc(text = "Authors@R: person('a', 'b', roles = 'cre')"),


### PR DESCRIPTION
Adds a `package` component to the built-in footer components, allowing patterns such as

```yaml
footer:
  structure:
    left: [package, universe]
  components:
    universe: |
      is part of a universe of packages...
```

which will render in the pkgdown pages as

> pkgdown is part of a universe of packages

(with the name of the package being documented, not pkgdown, in the final text).