### PR TITLE
Tweak word-wrap rule for preventing horizontal scrollbar?

### DIFF
--- a/vignettes/test/rendering.Rmd
+++ b/vignettes/test/rendering.Rmd
@@ -10,6 +10,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 ```
 
 This vignette tests pkgdown output rendering for several use cases.
+Ccccccccccccaaaaaaaaaaaaaaatttttttttttttttttssssssssssssssss 
 
 ## Footnotes
 


### PR DESCRIPTION
On small devices e.g. IPhone, the article I edited gets a horizontal scrollbar which hides the toggle button (well one can scroll to find it).

