### PR TITLE
Find external article resources from rendered HTML

### DIFF
--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -74,6 +74,7 @@ render_rmarkdown <- function(pkg, input, output, ..., copy_images = TRUE, quiet 
     )
 
     ext <- rbind(ext, ext2)
+    ext <- ext[!duplicated(ext$path), ]
 
     # copy web + explicit files beneath vignettes/
     is_child <- path_has_parent(ext$path, ".")

--- a/tests/testthat/assets/articles-resources/DESCRIPTION
+++ b/tests/testthat/assets/articles-resources/DESCRIPTION
@@ -1,0 +1,7 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A longer statement about the package.
+Authors@R:
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre"))
+RoxygenNote: 6.0.1

--- a/tests/testthat/assets/articles-resources/vignettes/resources.Rmd
+++ b/tests/testthat/assets/articles-resources/vignettes/resources.Rmd
@@ -1,0 +1,8 @@
+---
+title: "Hidden External resource"
+---
+
+There's a hidden external resource in this vignette.
+
+![external dependency](`r "external.png"`)
+

--- a/tests/testthat/test-build-articles.R
+++ b/tests/testthat/test-build-articles.R
@@ -101,7 +101,7 @@ test_that("finds external resources referenced by R code in the article html", {
 
   expect_output(path <- build_article("resources", pkg))
 
-  # ensure that we the HTML references `<img src="external" />` directly
+  # ensure that we the HTML references `<img src="external.png" />` directly
   expect_equal(
     xpath_attr(xml2::read_html(path), ".//img", "src"),
     "external.png"

--- a/tests/testthat/test-build-articles.R
+++ b/tests/testthat/test-build-articles.R
@@ -95,3 +95,20 @@ test_that("can set width", {
   html <- xml2::read_html(path)
   expect_equal(xpath_text(html, ".//pre")[[2]], "## [1] 50")
 })
+
+test_that("finds external resources referenced by R code in the article html", {
+  pkg <- local_pkgdown_site(test_path("assets", "articles-resources"))
+
+  expect_output(path <- build_article("resources", pkg))
+
+  # ensure that we the HTML references `<img src="external" />` directly
+  expect_equal(
+    xpath_attr(xml2::read_html(path), ".//img", "src"),
+    "external.png"
+  )
+
+  # expect that `external.png` was copied to the rendered article directory
+  expect_true(
+    file_exists(path(path_dir(path), "external.png"))
+  )
+})


### PR DESCRIPTION
When external resources are introduced by R code during the render process, `rmarkdown::find_external_resources()` will miss those resources because they aren't statically discoverable from the source of the document.

In the tests, I used this markdown to illustrate the issue

```markdown
![](`r "external.png"`)
```

I think we can squeeze a little bit more out of `rmarkdown::find_external_resources()` by temporarily copying the rendered article back into the source folder and scanning the `.html` file again. In the above case, this method will discover `<img src="external.png" />` and correctly move the file to the documentation destination.

This PR is on the path toward creating a gallery template where we'd like pkgdown to discover local images if they are inserted dynamically by R code called inside an R chunk. In practice, this should also make it less likely that an author would need to declare `resource_files` in the YAML header.

