### PR TITLE
Preserve HTML in tabset tab titles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -355,6 +355,8 @@
 `repo: jira_projects: [...]` and specifying a custom issue URL with
 `repo: url: issue: ...` in `_pkgdown.yml` (@jonkeane, #1466).
 
+* Tab title in tabsets may include HTML (@gadenbuie, #1915).
+
 # pkgdown 1.6.1
 
 * The article index (used for autolinking vignettes across packages) 

--- a/NEWS.md
+++ b/NEWS.md
@@ -355,8 +355,6 @@
 `repo: jira_projects: [...]` and specifying a custom issue URL with
 `repo: url: issue: ...` in `_pkgdown.yml` (@jonkeane, #1466).
 
-* Tab title in tabsets may include HTML (@gadenbuie, #1915).
-
 # pkgdown 1.6.1
 
 * The article index (used for autolinking vignettes across packages) 

--- a/R/tweak-tabset.R
+++ b/R/tweak-tabset.R
@@ -46,13 +46,13 @@ tweak_tabset <- function(div) {
 # Add an item (tab) to the tablist
 tablist_item <- function(tab, nav, parent_id) {
   id <- section_id(tab)
-  title <- xml_text1(xml2::xml_child(tab))
+  title <- tablist_title(tab)
 
   # Activate (if there was "{.active}" in the source Rmd)
   active <- has_class(tab, "active")
   li_class <- paste0("nav-link", if (active) " active")
   li <- xml2::xml_add_child(nav, "li", role = "presentation", class = "nav-item")
-  xml2::xml_add_child(li, "button", title,
+  button <- xml2::xml_add_child(li, "button",
     `data-bs-toggle` = "tab",
     `data-bs-target` = paste0("#", id),
     id = paste0(id, "-tab"),
@@ -63,7 +63,20 @@ tablist_item <- function(tab, nav, parent_id) {
     class = li_class
   )
 
+  # Preserve html in title by adding from xml_nodeset item by item
+  for (title_item in title) {
+    xml2::xml_add_child(button, title_item)
+  }
+
   invisible()
+}
+
+tablist_title <- function(tab) {
+  # remove anchor link from tab heading
+  tab_heading_anchor <- xml2::xml_find_first(tab, ".//a[@class = 'anchor']")
+  xml2::xml_remove(tab_heading_anchor)
+
+  xml2::xml_contents(xml2::xml_child(tab))
 }
 
 # Add content of a tab to a tabset

--- a/tests/testthat/test-tweak-tabset.R
+++ b/tests/testthat/test-tweak-tabset.R
@@ -59,3 +59,41 @@ test_that("can fade", {
     c("fade tab-pane", "show active fade tab-pane")
   )
 })
+
+test_that("can accept html", {
+  html <- markdown_to_html("
+    ## Tabset {.tabset}
+
+    ### Tab 1 `with_code` {#toc-1}
+
+    Contents 1
+
+    ### <i class=\"fa fab-github\"></i> Tab 2 {#toc-2}
+
+    Contents 2
+
+    ### Normal Tab {#toc-normal}
+
+    Contents of normal tab
+  ")
+
+  tweak_tabsets(html)
+
+  expect_match(
+    as.character(xpath_xml(html, ".//*[@id = 'toc-1-tab']")),
+    "Tab 1 <code>with_code</code>",
+    fixed = TRUE
+  )
+
+  expect_match(
+    as.character(xpath_xml(html, ".//*[@id = 'toc-2-tab']")),
+    "<i class=\"fa fab-github\"></i> Tab 2",
+    fixed = TRUE
+  )
+
+  expect_match(
+    as.character(xpath_xml(html, ".//*[@id = 'toc-normal-tab']")),
+    ">Normal Tab</button>",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Fixes #1914 by keeping the tab title as an `xml_nodeset` using `xml2::xml_contents()`.

Repeating the reprex from #1914:

``` r
pkgload::load_all()
#> ℹ Loading pkgdown

html <- markdown_to_html("
## Tabset {.tabset}

### Tab 1 `with_code` {#toc-1}

Contents 1

### <i class=\"fa fab-github\"></i> Tab 2 {#toc-2}

Contents 2

### Normal Tab {#toc-normal}

Contents of normal tab
")

tweak_tabsets(html)

print_xpath_html_and_text <- function(x, xpath) {
  x <- xml2::xml_find_first(x, xpath)
  print(as.character(x))
  xml2::xml_contents(x)
}
```

We now keep the `<code>` formatting in the tab title for the first tab

```r
print_xpath_html_and_text(html, ".//*[@id = 'toc-1-tab']")
#> [1] "<button data-bs-toggle=\"tab\" data-bs-target=\"#toc-1\" id=\"toc-1-tab\" type=\"button\" role=\"tab\" aria-controls=\"toc-1\" aria-selected=\"true\" class=\"active nav-link\">Tab 1 <code>with_code</code></button>"
#> {xml_nodeset (2)}
#> [1] Tab 1 
#> [2] <code>with_code</code>
```

and the `<i>` icon element in the second tab

```r
print_xpath_html_and_text(html, ".//*[@id = 'toc-2-tab']")
#> [1] "<button data-bs-toggle=\"tab\" data-bs-target=\"#toc-2\" id=\"toc-2-tab\" type=\"button\" role=\"tab\" aria-controls=\"toc-2\" aria-selected=\"false\" class=\"nav-link\"><i class=\"fa fab-github\"></i> Tab 2</button>"
#> {xml_nodeset (2)}
#> [1] <i class="fa fab-github"></i>
#> [2]  Tab 2
```

as well as plain text as in the final tab.

```r
print_xpath_html_and_text(html, ".//*[@id = 'toc-normal-tab']")
#> [1] "<button data-bs-toggle=\"tab\" data-bs-target=\"#toc-normal\" id=\"toc-normal-tab\" type=\"button\" role=\"tab\" aria-controls=\"toc-normal\" aria-selected=\"false\" class=\"nav-link\">Normal Tab</button>"
#> {xml_nodeset (1)}
#> [1] Normal Tab
```