### PR TITLE
Fix name of netlify access token environment variable

### DIFF
--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -230,7 +230,7 @@ This lets your package support both versions of bootstrap and pkgdown.
 Lastly, it might be useful for you to get a preview of the website in internal pull requests.
 For that, you could use Netlify and GitHub Actions (or apply a similar logic to your toolset):
 
--   Create a new Netlify website (either from scratch by dragging and dropping a simple index.html, or by creating a site from a GitHub repository and then unlinking that repository); from the site settings get its ID to be saved as `NETLIFY_SITE_ID` in your repo secrets; from your account developer settings get a token to be saved as `NETLIFY_TOKEN` in your repo secrets.
+-   Create a new Netlify website (either from scratch by dragging and dropping a simple index.html, or by creating a site from a GitHub repository and then unlinking that repository); from the site settings get its ID to be saved as `NETLIFY_SITE_ID` in your repo secrets; from your account developer settings get a token to be saved as `NETLIFY_AUTH_TOKEN` in your repo secrets.
 -   Starting from the standard pkgdown workflow `usethis::use_github_action("pkgdown")`, add some logic to build the site and deploy it to Netlify for pull requests from inside the repository, not pull requests from forks. [Example workflow](https://github.com/r-lib/pkgdown/blob/master/.github/workflows/pkgdown.yaml).
 
 ## Conclusion


### PR DESCRIPTION
For PR previews, the vignette links to [this example workflow](https://github.com/r-lib/pkgdown/blob/main/.github/workflows/pkgdown.yaml) which uses `nwtgck/actions-netlify@v1.1`. This netlify action searches the netlify access token in the environment variables with the name `NETLIFY_AUTH_TOKEN` and not `NETLIFY_TOKEN`. See https://github.com/nwtgck/actions-netlify/blob/9b51bd37bcaba08043fd9b0ba2ebba10fed202a2/README.md?plain=1#L49

This PR corrects the name. 