### PR TITLE
allow code examples to overflow

### DIFF
--- a/inst/BS5/assets/pkgdown.scss
+++ b/inst/BS5/assets/pkgdown.scss
@@ -374,7 +374,7 @@ div.csl-indent {
 /* code ===================================================================== */
 
 pre, pre code {
-  white-space: pre-wrap;
+  white-space: pre;
   word-break: break-all;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
This will address #1957 by allowing output in code blocks to overflow instead of wrap if the content is too long.