### PR TITLE
First copy reference files then build home

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -439,7 +439,6 @@ build_site_local <- function(pkg = ".",
 
   init_site(pkg)
 
-  build_home(pkg, override = override, preview = FALSE)
   build_reference(pkg,
     lazy = lazy,
     examples = examples,
@@ -449,6 +448,7 @@ build_site_local <- function(pkg = ".",
     preview = FALSE,
     devel = devel
   )
+  build_home(pkg, override = override, preview = FALSE)
   build_articles(pkg, lazy = lazy, override = override, preview = FALSE)
   build_tutorials(pkg, override = override, preview = FALSE)
   build_news(pkg, override = override, preview = FALSE)


### PR DESCRIPTION
If you have an image in README.md, then `build_site` will return a warning message on   `build_home` function.
```
Warning message:
Missing images in 'README.md': 'reference/figures/image_name.png'
ℹ pkgdown can only use images in 'man/figures' and 'vignettes' 
```

`build_reference` function should be run before   `build_home` function call.
