### PR TITLE
typo in NEWS.md for configuration name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -270,7 +270,7 @@
 
 ## HTML, CSS and JS
 
-* New `template` option `trailingslash_redirect` that allows adding a script to 
+* New `template` option `trailing_slash_redirect` that allows adding a script to 
   redirect `your-package-url.com` to `your-package-url.com/` (#1439, @cderv, 
   @apreshill).
 


### PR DESCRIPTION
trailingslash_redirect -> trailing_slash_redirect

Doc is ok: https://pkgdown.r-lib.org/reference/build_site.html#template with the code
https://github.com/r-lib/pkgdown/blob/dcec859cab08ff8852f5ee5ab09f3f57ec038805/R/build-home-index.R#L49

but current changelog is not
https://pkgdown.r-lib.org/news/index.html#html-css-and-js-2-0-0