### PR TITLE
Don't initialize scrollspy when `#toc` element is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 * New Korean (`ko`) translation thanks to @mrchypark and @peremen (#1994).
 
+* Fixed issues that occurred on pages without a table of contents (@gadenbuie, #1998).
+
 # pkgdown 2.0.1
 
 * Fix CRAN failures.

--- a/inst/BS5/assets/pkgdown.js
+++ b/inst/BS5/assets/pkgdown.js
@@ -9,10 +9,12 @@
       $scope: $("main h2, main h3, main h4, main h5, main h6")
     });
 
-    $('body').scrollspy({
-      target: '#toc',
-      offset: 56 // headroom height
-    });
+    if ($('#toc').length) {
+      $('body').scrollspy({
+        target: '#toc',
+        offset: 56 // headroom height
+      });
+    }
 
     // Activate popovers
     $('[data-bs-toggle="popover"]').popover({


### PR DESCRIPTION
Fixes #1959 by only initializing the TOC scrollspy when the `#toc` element exists. This probably also resolves #1889.
