### PR TITLE
Adjust Rmd that use h1 as top-level headings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Vignettes/articles that use `<h1>` as top-level heading automatically have
   headings adjusted one level down so that's there's one top-level heading 
-  (#2005).
+  (#2004).
 
 * `deploy_to_branch()` gains a `subdir` argument, allowing you to deploy the
   site to a subdirectory (@gadenbuie, #2001).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* Vignettes/articles that use `<h1>` as top-level heading automatically have
+  headings adjusted one level down so that's there's one top-level heading 
+  (#2005).
+
 * `deploy_to_branch()` gains a `subdir` argument, allowing you to deploy the
   site to a subdirectory (@gadenbuie, #2001).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # pkgdown (development version)
 
-* Vignettes/articles that use `<h1>` as top-level heading automatically have
-  headings adjusted one level down so that's there's one top-level heading 
-  (#2004).
+* Vignettes/articles that use `<h1>` as section headings automatically have
+  all headings adjusted one level down so that's there's one top-level heading 
+  (#2004). This ensures that there's one `<h1>`, the title, on each page,
+  and makes the TOC in the sidebar work correctly.
 
 * `deploy_to_branch()` gains a `subdir` argument, allowing you to deploy the
   site to a subdirectory (@gadenbuie, #2001).

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -316,14 +316,16 @@ tweak_news_anchor <- function(html, version) {
 }
 
 tweak_section_levels <- function(html) {
-  xml2::xml_set_name(xml2::xml_find_all(html, ".//h5"), "h6")
-  xml2::xml_set_name(xml2::xml_find_all(html, ".//h4"), "h5")
-  xml2::xml_set_name(xml2::xml_find_all(html, ".//h3"), "h4")
-  xml2::xml_set_name(xml2::xml_find_all(html, ".//h2"), "h3")
-  xml2::xml_set_name(xml2::xml_find_all(html, ".//h1"), "h2")
-
-  # Important because search index uses section class rather than heading
   sections <- xml2::xml_find_all(html, ".//div[contains(@class, 'section level')]")
+
+  # Update headings
+  xml2::xml_set_name(xml2::xml_find_all(sections, ".//h5"), "h6")
+  xml2::xml_set_name(xml2::xml_find_all(sections, ".//h4"), "h5")
+  xml2::xml_set_name(xml2::xml_find_all(sections, ".//h3"), "h4")
+  xml2::xml_set_name(xml2::xml_find_all(sections, ".//h2"), "h3")
+  xml2::xml_set_name(xml2::xml_find_all(sections, ".//h1"), "h2")
+
+  # Update section
   xml2::xml_attr(sections, "class") <- paste0("section level", get_section_level(sections) + 1)
 
   invisible()

--- a/R/tweak-page.R
+++ b/R/tweak-page.R
@@ -54,7 +54,7 @@ tweak_rmarkdown_html <- function(html, input_path, pkg = list(bs_version = 3)) {
     )
   }
 
-  # If top-level headings use h1, move eveything down one level
+  # If top-level headings use h1, move everything down one level
   h1 <- xml2::xml_find_all(html, "//h1")
   if (length(h1) > 1) {
     tweak_section_levels(html)

--- a/R/tweak-page.R
+++ b/R/tweak-page.R
@@ -36,7 +36,7 @@ tweak_page <- function(html, name, pkg = list(bs_version = 3)) {
   }
 }
 
-tweak_rmarkdown_html <- function(html, input_path, pkg = pkg) {
+tweak_rmarkdown_html <- function(html, input_path, pkg = list(bs_version = 3)) {
   # Tweak classes of navbar
   toc <- xml2::xml_find_all(html, ".//div[@id='tocnav']//ul")
   xml2::xml_attr(toc, "class") <- "nav nav-pills nav-stacked"
@@ -52,6 +52,12 @@ tweak_rmarkdown_html <- function(html, input_path, pkg = pkg) {
       xml2::xml_set_attr,
       attr = "src"
     )
+  }
+
+  # If top-level headings use h1, move eveything down one level
+  h1 <- xml2::xml_find_all(html, "//h1")
+  if (length(h1) > 1) {
+    tweak_section_levels(html)
   }
 
   # Has to occur after path normalisation

--- a/tests/testthat/test-build-articles.R
+++ b/tests/testthat/test-build-articles.R
@@ -58,7 +58,7 @@ test_that("can override html_document() options", {
 
   # Check that number_sections is respected
   html <- xml2::read_html(path)
-  expect_equal(xpath_text(html, ".//h1//span"), c("1", "2"))
+  expect_equal(xpath_text(html, ".//h2//span"), c("1", "2"))
 
   # And no links or scripts are inlined
   expect_equal(xpath_length(html, ".//body//link"), 0)
@@ -83,7 +83,7 @@ test_that("can override options with _output.yml", {
 
   # Check that number_sections is respected
   html <- xml2::read_html(path)
-  expect_equal(xpath_text(html, ".//h1//span"), c("1", "2"))
+  expect_equal(xpath_text(html, ".//h2//span"), c("1", "2"))
 })
 
 test_that("can set width", {

--- a/tests/testthat/test-build-articles.R
+++ b/tests/testthat/test-build-articles.R
@@ -60,6 +60,9 @@ test_that("can override html_document() options", {
   html <- xml2::read_html(path)
   expect_equal(xpath_text(html, ".//h2//span"), c("1", "2"))
 
+  # But title isn't affected
+  expect_equal(xpath_text(html, ".//h1"), "html_document + as_is")
+
   # And no links or scripts are inlined
   expect_equal(xpath_length(html, ".//body//link"), 0)
   expect_equal(xpath_length(html, ".//body//script"), 0)

--- a/tests/testthat/test-tweak-page.R
+++ b/tests/testthat/test-tweak-page.R
@@ -115,3 +115,17 @@ test_that("sidebar removed if empty", {
   expect_equal(xpath_length(html, ".//aside"), 0)
 })
 
+
+
+# rmarkdown ---------------------------------------------------------------
+
+test_that("h1 headings adjusted to h2 (and so on)", {
+  html <- xml2::read_html("
+    <h1>1</h1>
+    <h2>1.1</h2>
+    <h1>2</h1>
+  ")
+  tweak_rmarkdown_html(html)
+  expect_equal(xpath_text(html, ".//h2"), c("1", "2"))
+  expect_equal(xpath_text(html, ".//h3"), "1.1")
+})

--- a/tests/testthat/test-tweak-page.R
+++ b/tests/testthat/test-tweak-page.R
@@ -119,13 +119,29 @@ test_that("sidebar removed if empty", {
 
 # rmarkdown ---------------------------------------------------------------
 
-test_that("h1 headings adjusted to h2 (and so on)", {
+test_that("h1 section headings adjusted to h2 (and so on)", {
   html <- xml2::read_html("
-    <h1>1</h1>
-    <h2>1.1</h2>
-    <h1>2</h1>
+    <div class='page-header'>
+      <h1>Title</h1>
+      <h4>Author</h4>
+    </div>
+    <div class='section level1'>
+      <h1>1</h1>
+      <div class='section level2'>
+      <h2>1.1</h2>
+      </div>
+    </div>
+    <div class='section level1'>
+      <h1>2</h1>
+    </div>
   ")
   tweak_rmarkdown_html(html)
+  expect_equal(xpath_text(html, ".//h1"), "Title")
   expect_equal(xpath_text(html, ".//h2"), c("1", "2"))
   expect_equal(xpath_text(html, ".//h3"), "1.1")
+  expect_equal(xpath_text(html, ".//h4"), "Author")
+  expect_equal(
+    xpath_attr(html, ".//div", "class"),
+    c("page-header", "section level2", "section level3", "section level2")
+  )
 })


### PR DESCRIPTION
Fixes #2004. Closes #2005.