### PR TITLE
fix repo URL parsing for GitLab

### DIFF
--- a/R/repo.R
+++ b/R/repo.R
@@ -64,8 +64,9 @@ package_repo <- function(desc, meta) {
   }
 
   # Otherwise try and guess from `BugReports` (1st priority) and `URL`s (2nd priority)
+  # the /-/issues pattern corresponds to GitLab repos
   urls <- c(
-    sub("/issues/?", "/", desc$get_field("BugReports", default = character())),
+    sub("/-/", "", sub("/issues/?", "/", desc$get_field("BugReports", default = character()))),
     desc$get_urls()
   )
 

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -82,11 +82,18 @@ test_that("can find github from BugReports or URL", {
   )
   expect_equal(package_repo(desc, list()), ref)
 })
-
 test_that("can find gitlab url", {
   ref <- repo_meta_gh_like("https://gitlab.com/msberends/AMR")
   desc <- desc::desc(text = c(
-    "BugReports: https://gitlab.com/msberends/AMR"
+    "BugReports: https://gitlab.com/msberends/AMR/issues"
+  ))
+  expect_equal(package_repo(desc, list()), ref)
+})
+
+test_that("can find gitlab url with special issues URL", {
+  ref <- repo_meta_gh_like("https://gitlab.com/msberends/AMR")
+  desc <- desc::desc(text = c(
+    "BugReports: https://gitlab.com/msberends/AMR/-/issues"
   ))
   expect_equal(package_repo(desc, list()), ref)
 })


### PR DESCRIPTION
Fix #2015

Maybe it could be more readable. :sweat_smile: 