### PR TITLE
Allow to control abort on missing topics.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* Environment variable ABORT_ON_MISSING_TOPICS can be used to enable/disable
+  failing a build if a topic is missing. Default is still to enable only in CI.
+
 # pkgdown 2.0.2
 
 * New Korean (`ko`) translation thanks to @mrchypark and @peremen (#1994).

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -143,7 +143,7 @@ check_missing_topics <- function(rows, pkg) {
   missing <- !in_index & !pkg$topics$internal
   if (any(missing)) {
     text <- sprintf("Topics missing from index: %s", unname(pkg$topics$name[missing]))
-    if (on_ci()) {
+    if (abort_on_missing_topics()) {
       abort(text)
     } else {
       warn(text)
@@ -151,6 +151,6 @@ check_missing_topics <- function(rows, pkg) {
   }
 }
 
-on_ci <- function() {
-  isTRUE(as.logical(Sys.getenv("CI")))
+abort_on_missing_topics <- function() {
+  isTRUE(as.logical(Sys.getenv("ABORT_ON_MISSING_TOPICS", Sys.getenv("CI"))))
 }


### PR DESCRIPTION
This does not change any default behavior, but allows us to enable this locally, or disable it on CI, if needed.