### PR TITLE
fix search highlighting

### DIFF
--- a/inst/BS5/assets/pkgdown.js
+++ b/inst/BS5/assets/pkgdown.js
@@ -70,7 +70,7 @@
     /* Search marking --------------------------*/
     var url = new URL(window.location.href);
     var toMark = url.searchParams.get("q");
-    var mark = new Mark("main.col-md-9");
+    var mark = new Mark("#main");
     if (toMark) {
       mark.mark(toMark, {
         accuracy: {

--- a/inst/BS5/assets/pkgdown.js
+++ b/inst/BS5/assets/pkgdown.js
@@ -70,7 +70,7 @@
     /* Search marking --------------------------*/
     var url = new URL(window.location.href);
     var toMark = url.searchParams.get("q");
-    var mark = new Mark("#main");
+    var mark = new Mark("main#main");
     if (toMark) {
       mark.mark(toMark, {
         accuracy: {

--- a/inst/BS5/assets/pkgdown.js
+++ b/inst/BS5/assets/pkgdown.js
@@ -70,7 +70,7 @@
     /* Search marking --------------------------*/
     var url = new URL(window.location.href);
     var toMark = url.searchParams.get("q");
-    var mark = new Mark("div.col-md-9");
+    var mark = new Mark("main.col-md-9");
     if (toMark) {
       mark.mark(toMark, {
         accuracy: {


### PR DESCRIPTION
Fix #2023 

In the preview it might look it does not work... because the search index has absolute URLs so when using search you are directed to the real website. :zany_face: 

Hence a direct link where things work https://61eaa925c88dfdfcb02cfe12--pkgdown-dev.netlify.app/dev/reference/init_site.html?q=build#build-ignored-files

Cc @jayhesselberth 