### PR TITLE
Parse alternative text for figure tag on multiple lines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* Manual pages `\figure{file}{alternative text}` tags with multines alternative text can now be parsed. (#2080)
+
 # pkgdown 2.0.3
 
 * Fixes for R CMD check

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -328,7 +328,7 @@ as_html.tag_figure <- function(x, ...) {
   if (n == 1) {
     paste0("<img src='figures/", path, "' alt='' />")
   } else if (n == 2) {
-    opt <- as.character(x[[2]])
+    opt <- paste(trimws(as.character(x[[2]])), collapse = " ")
     if (substr(opt, 1, 9) == "options: ") {
       extra <- substr(opt, 9, nchar(opt))
       paste0("<img src='figures/", path, "'",  extra, " />")

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -455,3 +455,8 @@ test_that("figures are converted to img", {
     "<img src='figures/a' height=1 />"
   )
 })
+
+test_that("figures with multilines alternative text can be parsed", {
+  expect_equal(rd2html("\\figure{a}{blabla
+    blop}"), "<img src='figures/a' alt='blabla blop' />")
+})


### PR DESCRIPTION
Fix #2080 