### PR TITLE
Add target argument support for navbar links.

### DIFF
--- a/R/navbar.R
+++ b/R/navbar.R
@@ -200,6 +200,9 @@ bs4_navbar_links_tags <- function(links, depth = 0L) {
   # function for links
   tackle_link <- function(x, index, is_submenu, depth) {
 
+    target = NULL
+    if (!is.na(x$target) && !is.null(x$target)) target =  x$target
+
     if (!is.null(x$menu)) {
 
       if (is_submenu) {
@@ -255,6 +258,7 @@ bs4_navbar_links_tags <- function(links, depth = 0L) {
         htmltools::tags$a(
           class = "dropdown-item",
           href = x$href,
+          target = target,
           textTags,
           "aria-label" = x$`aria-label` %||% NULL
         )
@@ -266,6 +270,7 @@ bs4_navbar_links_tags <- function(links, depth = 0L) {
       htmltools::tags$a(
         class = "nav-link",
         href = x$href,
+        target = target,
         textTags,
         "aria-label" = x$`aria-label` %||% NULL
       )


### PR DESCRIPTION
This pull request just adds support for the `target` tag in navbar links. No test snapshots need to be regenerated, still passes 100%.

Changes to `R/navbar.R`:
1. L203-205 - Add target as null variable. If `x$target` is found, reassign to that.
2. L261 & L 273 - Add target to html tag generation.

I didn't modify the version number in `DESCRIPTION`, nor did I add anything to `NEWS.md`. Wanted to make sure no other changes were necessary and I was following the appropriate guidelines for the repo.