### PR TITLE
Function arguments in reference aren't dropped by leading whitespace

### DIFF
--- a/R/rd-data.R
+++ b/R/rd-data.R
@@ -99,7 +99,7 @@ describe_contents <- function(x, ...) {
   parse_piece <- function(x) {
     if (length(x) == 0) {
       NULL
-    } else if (inherits(x[[1]], "tag_item")) {
+    } else if (any(purrr::map_lgl(x, inherits, "tag_item"))) {
       paste0("<dl>\n", parse_descriptions(x, ...), "</dl>")
     } else {
       flatten_para(x, ...)

--- a/tests/testthat/test-rd-data.R
+++ b/tests/testthat/test-rd-data.R
@@ -43,7 +43,7 @@ test_that("whitespace between items doesn't affect grouping", {
   )
 })
 
-test_that("leading whitespace doesn't affect grouping", {
+test_that("leading whitespace doesn't break items", {
   expect_equal(
     value2html("\n\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}"),
     c(

--- a/tests/testthat/test-rd-data.R
+++ b/tests/testthat/test-rd-data.R
@@ -43,6 +43,20 @@ test_that("whitespace between items doesn't affect grouping", {
   )
 })
 
+test_that("leading whitespace doesn't affect grouping", {
+  expect_equal(
+    value2html("\n\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}"),
+    c(
+      "<dl>",
+        "",
+        "<dt>a</dt>", "<dd><p>b</p></dd>", "", "",
+        "<dt>c</dt>", "<dd><p>d</p></dd>", "", "",
+        "<dt>e</dt>", "<dd><p>f</p></dd>",
+      "</dl>"
+    )
+  )
+})
+
 test_that("whitespace between text is preserved", {
   expect_equal(
     value2html("a\n\nb\n\nc"),


### PR DESCRIPTION
fixes #2108 

A recent commit - https://github.com/r-lib/pkgdown/commit/d1321f91ecc543f06e6b76409eb95e5ff7579d6b - allowed whitespace in tag_items lists. This broke a parser that checked the first element of that list which led to this behaviour 

```r
pkgdown:::value2html("\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}")
#>  [1] "<dl>"              "<dt>a</dt>"        "<dd><p>b</p></dd>"
#>  [4] ""                  ""                  "<dt>c</dt>"       
#>  [7] "<dd><p>d</p></dd>" ""                  ""                 
#> [10] "<dt>e</dt>"        "<dd><p>f</p></dd>" "</dl>"
pkgdown:::value2html("\n\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}")
#> [1] "<p></p>" "<p></p>" "<p></p>"
```

Function arguments in Rd files seem to be starting with a new line and therefore the function arguments were dropped on pkgdown sites. 

This PR makes pkgdown check the complete list of tag items instead of the first item. 

Now the above code outputs this

``` r
pkgdown:::value2html("\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}")
#>  [1] "<dl>"              "<dt>a</dt>"        "<dd><p>b</p></dd>"
#>  [4] ""                  ""                  "<dt>c</dt>"       
#>  [7] "<dd><p>d</p></dd>" ""                  ""                 
#> [10] "<dt>e</dt>"        "<dd><p>f</p></dd>" "</dl>"
pkgdown:::value2html("\n\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}")
#>  [1] "<dl>"              ""                  "<dt>a</dt>"       
#>  [4] "<dd><p>b</p></dd>" ""                  ""                 
#>  [7] "<dt>c</dt>"        "<dd><p>d</p></dd>" ""                 
#> [10] ""                  "<dt>e</dt>"        "<dd><p>f</p></dd>"
#> [13] "</dl>"
```