### PR TITLE
show missing vignettes in abort message

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -365,8 +365,10 @@ data_articles_index <- function(pkg = ".") {
 
   if (any(missing)) {
     abort(
-      "Vignettes missing from index: ",
-      paste(pkg$vignettes$name[missing], collapse = ", ")
+      paste0(
+        "Vignettes missing from index: ",
+        paste(pkg$vignettes$name[missing], collapse = ", ")
+      )
     )
   }
 


### PR DESCRIPTION
I'm getting a [new error about missing vignettes](https://github.com/carpentries/sandpaper/runs/6833596124?check_suite_focus=true#step:6:177), but it's unspecific:

```
-- Building articles -----------------------------------------------------------
Error in `data_articles_index()`:
! Vignettes missing from index: 
Backtrace:
     ▆
  1. └─pkgdown::deploy_to_branch(new_process = FALSE)
  2.   └─pkgdown::build_site_github_pages(pkg, ..., clean = clean)
  3.     └─pkgdown::build_site(...)
  4.       └─pkgdown:::build_site_local(...)
  5.         └─pkgdown::build_articles(...)
  6.           └─pkgdown::build_articles_index(pkg)
  7.             ├─pkgdown::render_page(...)
  8.             │ └─pkgdown:::render_page_html(pkg, name = name, data = data, depth = depth)
  9.             │   └─utils::modifyList(data_template(pkg, depth = depth), data)
 10.             │     └─base::stopifnot(is.list(x), is.list(val))
 11.             └─pkgdown:::data_articles_index(pkg)
 12.               └─rlang::abort(...)
```

The abort message was not including the entire message because it needed to be pasted together.