### PR TITLE
Escape angle brackets for URLs in author comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* `build_home()` now escapes angle brackets in author comments on the authors page,
+  avoiding URLs from authors comments to be hidden.
+
 # pkgdown 2.0.4
 
 * New `check_pkgdown()` provides a lightweight way to check that your 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # pkgdown (development version)
 
 * `build_home()` now escapes angle brackets in author comments on the authors page,
-  avoiding URLs from authors comments to be hidden.
+  avoiding URLs from authors comments to be hidden (#2127).
 
 # pkgdown 2.0.4
 

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -129,7 +129,7 @@ author_list <- function(x, authors_info = NULL, comment = FALSE, pkg) {
   list(
     name = name,
     roles = roles,
-    comment = x$comment,
+    comment = linkify(x$comment),
     orcid = orcid_link(orcid)
   )
 }

--- a/tests/testthat/test-build-home-citation.R
+++ b/tests/testthat/test-build-home-citation.R
@@ -33,3 +33,15 @@ test_that("multiple citations all have HTML and BibTeX formats", {
   citations <- data_citations(test_path("assets/site-citation/multi"))
   expect_snapshot_output(citations)
 })
+
+test_that("links in curly braces in authors comments are escaped", {
+  pkg_dir <- withr::local_tempdir()
+  desc <- desc::description$new(cmd = "!new")
+  desc$add_author("Jane", "Doe", comment = "reviewed see <https://github.com/r-lib/pkgdown/pulls>")
+  desc$write(file.path(pkg_dir, "DESCRIPTION"))
+  authors_data <- data_authors(pkg_dir)
+  expect_equal(
+    authors_data$all[[2]]$comment,
+    "reviewed see &lt;<a href='https://github.com/r-lib/pkgdown/pulls'>https://github.com/r-lib/pkgdown/pulls</a>&gt;"
+  )
+})


### PR DESCRIPTION
Fix https://github.com/ropensci-org/rotemplate/issues/93