### PR TITLE
fix error message for missing vignettes

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -364,10 +364,10 @@ data_articles_index <- function(pkg = ".") {
   missing <- !(pkg$vignettes$name %in% listed)
 
   if (any(missing)) {
-    abort(
-      "Vignettes missing from index: ",
+    abort(paste(
+      "Vignettes missing from index:",
       paste(pkg$vignettes$name[missing], collapse = ", ")
-    )
+    ))
   }
 
   print_yaml(list(


### PR DESCRIPTION
The mesage is the first argument in `rlang::abort()`, no longer collected via `...`