### PR TITLE
Add tests for `ruler()`

### DIFF
--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -184,7 +184,7 @@ github_push <- function(dir, commit_message, remote, branch) {
 
   rule("Commiting updated site", line = 1)
 
-  with_dir(dir, {
+  withr::with_dir(dir, {
     git("add", "-A", ".")
     git("commit", "--allow-empty", "-m", commit_message)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,6 +110,13 @@ with_dir <- function(new, code) {
   force(code)
 }
 
+with_options <- function(new, code) {
+  old <- do.call(options, as.list(new))
+  on.exit(options(old))
+  force(code)
+}
+
+
 # remove '' quoting
 # e.g. 'title' becomes title.s
 cran_unquote <- function(string) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -104,19 +104,6 @@ has_internet <- function() {
   return(getOption("pkgdown.internet", default = TRUE))
 }
 
-with_dir <- function(new, code) {
-  old <- setwd(dir = new)
-  on.exit(setwd(old))
-  force(code)
-}
-
-with_options <- function(new, code) {
-  old <- do.call(options, as.list(new))
-  on.exit(options(old))
-  force(code)
-}
-
-
 # remove '' quoting
 # e.g. 'title' becomes title.s
 cran_unquote <- function(string) {

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,16 @@
+# ruler() respects `width` argument
+
+    Code
+      ruler(width = 60)
+    Output
+      ----+----1----+----2----+----3----+----4----+----5----+----6
+      123456789012345678901234567890123456789012345678901234567890
+
+# ruler() respects `width` from `options()$width`
+
+    Code
+      ruler()
+    Output
+      ----+----1----+----2
+      12345678901234567890
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -13,7 +13,7 @@ test_that("cran_unquote works", {
 })
 
 test_that("is_internal_link() works", {
-  pkg=list(meta=list(url="https://pkgdown.r-lib.org"))
+  pkg = list(meta = list(url = "https://pkgdown.r-lib.org"))
   expect_false(is_internal_link("https://github.com", pkg = pkg))
   expect_false(is_internal_link("http://github.com", pkg = pkg))
   expect_true(is_internal_link("https://pkgdown.r-lib.org/articles", pkg = pkg))
@@ -24,4 +24,16 @@ test_that("is_internal_link() works", {
       c(TRUE, FALSE)
     )
   )
+})
+
+test_that("ruler() respects `width` argument", {
+  expect_snapshot({
+    ruler(width = 60)
+  })
+})
+
+test_that("ruler() respects `width` from `options()$width`", {
+  with_options(list(width = 20), {
+    expect_snapshot(ruler())
+  })
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -33,7 +33,7 @@ test_that("ruler() respects `width` argument", {
 })
 
 test_that("ruler() respects `width` from `options()$width`", {
-  with_options(list(width = 20), {
+  withr::with_options(list(width = 20), {
     expect_snapshot(ruler())
   })
 })


### PR DESCRIPTION
~~I don't see `{withr}` in `Suggests`, so also added a helper function needed for these tests. Happy to change that if you think it's okay to gain `{withr}` as a soft dependency.~~

I realized that `{withr}` is actually a hard dependency already, so no need to add any utility function. Also removed the existing internal copy of a `{withr}` function.