### PR TITLE
Revert #2104

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 * Correctly generates link targets for topics that have a file name ending in
   `.` (#2128).
 
+* Reverted #2030 so links to `@username` in NEWS.md work in fewer places.
+  See #2122 for details.
+
 * Restore accidentally nerfed `has_keyword()` and `has_concept()` reference
   selectors (#2126).
 

--- a/R/repo.R
+++ b/R/repo.R
@@ -38,12 +38,12 @@ repo_auto_link <- function(pkg, text) {
 
   if (!is.null(url$user)) {
     user_link <- paste0("\\1<a href='", url$user, "\\2'>@\\2</a>")
-    text <- gsub("(\\s|[(>])@([-\\w]+)", user_link, text, perl = TRUE)
+    text <- gsub("(\\s|^|\\()@([-\\w]+)", user_link, text, perl = TRUE)
   }
 
   if (!is.null(url$issue)) {
     issue_link <- paste0("<a href='", url$issue, "\\2'>#\\2</a>")
-    text <- gsub("(\\s|[(>])#(\\d+)", paste0("\\1", issue_link), text, perl = TRUE)
+    text <- gsub("(\\(|\\s)#(\\d+)", paste0("\\1", issue_link), text, perl = TRUE)
 
     if (!is.null(pkg$repo$jira_projects)) {
       issue_link <- paste0("<a href='", url$issue, "\\1\\2'>\\1\\2</a>")

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -6,17 +6,16 @@ test_that("authors are automatically linked", {
   # email addresses shouldn't get linked
   expect_equal(repo_auto_link(pkg, "x@y.com"), "x@y.com")
 
-  # must have leading whitespace or open parens or end of HTML tag
+  # must have leading whitespace or open parens
+  expect_equal(repo_auto_link(pkg, "@y"), "<a href='TEST/y'>@y</a>")
   expect_equal(repo_auto_link(pkg, " @y"), " <a href='TEST/y'>@y</a>")
   expect_equal(repo_auto_link(pkg, "(@y)"), "(<a href='TEST/y'>@y</a>)")
-  expect_equal(repo_auto_link(pkg, "<p>@y"), "<p><a href='TEST/y'>@y</a>")
 })
 
 test_that("issues are automatically linked", {
   pkg <- list(repo = repo_meta(issue = "TEST/"))
-  expect_equal(repo_auto_link(pkg, " #123"), " <a href='TEST/123'>#123</a>")
-  expect_equal(repo_auto_link(pkg, "(#123)"), "(<a href='TEST/123'>#123</a>)")
-  expect_equal(repo_auto_link(pkg, "<p>#123"), "<p><a href='TEST/123'>#123</a>")
+  expect_equal(repo_auto_link(pkg, "(#123"), "(<a href='TEST/123'>#123</a>")
+  expect_equal(repo_auto_link(pkg, "in #123"), "in <a href='TEST/123'>#123</a>")
 })
 
 test_that("URLs with hash (#) are preserved", {


### PR DESCRIPTION
Because it causes spurious matches when if links are already present. Fixes #2122.