### PR TITLE
In reference index, use all aliases if no functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgdown (development version)
 
+* If roxygen2 doesn't find any functions in the `\usage{}` section, then it
+  shows all aliases on the reference index, rather than the topic name (#1624).
+
 # pkgdown 2.0.5
 
 * Correctly generate downlit link targets for topics that have a file name 

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -48,7 +48,7 @@ data_reference_index_rows <- function(section, index, pkg) {
 
   if (has_name(section, "contents")) {
     check_all_characters(section$contents, index, pkg)
-    topics <- section_topics(section$contents, pkg)
+    topics <- section_topics(section$contents, pkg$topics, pkg$src_path)
 
     names <- topics$name
     topics$name <- NULL

--- a/R/topics.R
+++ b/R/topics.R
@@ -178,17 +178,17 @@ topic_must <- function(message, topic, ..., call = NULL) {
   )
 }
 
-section_topics <- function(match_strings, pkg) {
+section_topics <- function(match_strings, topics, src_path) {
   # Add rows for external docs
   ext_strings <- match_strings[grepl("::", match_strings, fixed = TRUE)]
-  topics <- rbind(pkg$topics, ext_topics(ext_strings))
+  topics <- rbind(topics, ext_topics(ext_strings))
 
   selected <- topics[select_topics(match_strings, topics), , ]
   tibble::tibble(
     name = selected$name,
     path = selected$file_out,
     title = selected$title,
-    aliases = purrr::map2(selected$funs, selected$name, ~ if (length(.x) > 0) .x else .y),
-    icon = find_icons(selected$alias, path(pkg$src_path, "icons"))
+    aliases = purrr::map2(selected$funs, selected$alias, ~ if (length(.x) > 0) .x else .y),
+    icon = find_icons(selected$alias, path(src_path, "icons"))
   )
 }

--- a/tests/testthat/test-topics.R
+++ b/tests/testthat/test-topics.R
@@ -138,14 +138,30 @@ test_that("an unmatched selection generates a warning", {
   )
 })
 
+test_that("uses funs or aliases", {
+  topics <- tibble::tribble(
+    ~name, ~funs,         ~alias,        ~file_out, ~title,
+    "x",   character(),   c("x1", "x2"), "x.html",  "X",
+    "y",   c("y1", "y2"), "y3",          "y.html",   "Y"
+  )
+
+  out <- section_topics(c("x", "y"), topics, ".")
+  expect_equal(out$aliases, list(c("x1", "x2"), c("y1", "y2")))
+})
+
+
 test_that("full topic selection process works", {
   pkg <- local_pkgdown_site(test_path("assets/reference"))
 
   # can mix local and remote
-  out <- section_topics(c("a", "base::mean"), pkg)
+  out <- section_topics(c("a", "base::mean"), pkg$topics, pkg$src_path)
   expect_equal(unname(out$name), c("a", "base::mean"))
 
   # concepts and keywords work
-  out <- section_topics(c("has_concept('graphics')", "has_keyword('foo')"), pkg)
+  out <- section_topics(
+    c("has_concept('graphics')", "has_keyword('foo')"),
+    pkg$topics,
+    pkg$src_path
+  )
   expect_equal(unname(out$name), c("b", "a"))
 })


### PR DESCRIPTION
Fixes #1624