### PR TITLE
Fix typo in check_missing_topics() message

### DIFF
--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -145,7 +145,7 @@ check_missing_topics <- function(rows, pkg) {
     abort(c(
       "All topics must be included in reference index",
       `x` = paste0("Missing topics: ", topics),
-      i = "Either add to _pkgdown.yml or use @keyword internal"
+      i = "Either add to _pkgdown.yml or use @keywords internal"
     ))
   }
 }

--- a/tests/testthat/_snaps/build-reference-index.md
+++ b/tests/testthat/_snaps/build-reference-index.md
@@ -53,7 +53,7 @@
       Error in `check_missing_topics()`:
       ! All topics must be included in reference index
       x Missing topics: c, e, ?
-      i Either add to _pkgdown.yml or use @keyword internal
+      i Either add to _pkgdown.yml or use @keywords internal
 
 # errors well when a content entry is empty
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -6,7 +6,7 @@
       Error in `check_missing_topics()`:
       ! All topics must be included in reference index
       x Missing topics: ?
-      i Either add to _pkgdown.yml or use @keyword internal
+      i Either add to _pkgdown.yml or use @keywords internal
 
 # fails if article index incomplete
 


### PR DESCRIPTION
If you don't haven't included all topics in the reference index you got the following error

````r
Error in `check_missing_topics()`:
      ! All topics must be included in reference index
      x Missing topics: ?
      i Either add to _pkgdown.yml or use @keyword internal
````

`@keyword` isn't a valid tag, this PR fixes this typo.