### PR TITLE
fix detection of first paragraph for badges

### DIFF
--- a/R/tweak-homepage.R
+++ b/R/tweak-homepage.R
@@ -118,6 +118,6 @@ badges_extract <- function(html) {
 }
 
 badges_extract_text <- function(x) {
-  xml <- xml2::read_html(x, encoding = "UTF-8")
-  badges_extract(xml)
+  html <- xml2::read_html(x, encoding = "UTF-8")
+  badges_extract(html)
 }

--- a/R/tweak-homepage.R
+++ b/R/tweak-homepage.R
@@ -90,7 +90,8 @@ badges_extract <- function(html) {
 
   # finally try first paragraph
   if (length(x) == 0) {
-    x <- xml2::xml_find_first(html, "//p")
+    # BS5 (main) and BS3 (div)
+    x <- xml2::xml_find_first(html, "//main/p|//div[@class='contents col-md-9']/p")
     strict <- TRUE
   }
 

--- a/tests/testthat/test-tweak-homepage.R
+++ b/tests/testthat/test-tweak-homepage.R
@@ -84,7 +84,7 @@ test_that("doesn't find badges when they don't exist", {
 
 test_that("finds single badge", {
   expect_equal(
-    badges_extract_text('<p><a href="x"><img src="y"></a></p>'),
+    badges_extract_text('<main><p><a href="x"><img src="y"></a></p></main>'),
     '<a href="x"><img src="y"></a>'
   )
 })
@@ -104,6 +104,7 @@ test_that("finds badges in #badges div", {
 
 test_that("can find badges in comments", {
   html <- '
+    <h1>blop</h1>
     <!-- badges: start -->
     <p><a href="x"><img src="y"></a></p>
     <!-- badges: end -->
@@ -112,6 +113,7 @@ test_that("can find badges in comments", {
 
   # produced by usethis
   html <- '
+    <h1>blop</h1>
     <!-- badges: start -->
     <p><a href="x"><img src="y"></a>
     <!-- badges: end -->
@@ -122,6 +124,7 @@ test_that("can find badges in comments", {
 
 test_that("ignores extraneous content", {
   html <- '
+    <h1>blop</h1>
     <!-- badges: start -->
     <p><a href="x"><img src="y"></a></p>
     <p>a</p>

--- a/tests/testthat/test-tweak-homepage.R
+++ b/tests/testthat/test-tweak-homepage.R
@@ -105,6 +105,7 @@ test_that("finds badges in #badges div", {
 test_that("can find badges in comments", {
   html <- '
     <h1>blop</h1>
+    <p>I am the first paragraph!</p>
     <!-- badges: start -->
     <p><a href="x"><img src="y"></a></p>
     <!-- badges: end -->
@@ -114,6 +115,7 @@ test_that("can find badges in comments", {
   # produced by usethis
   html <- '
     <h1>blop</h1>
+    <p>I am the first paragraph!</p>
     <!-- badges: start -->
     <p><a href="x"><img src="y"></a>
     <!-- badges: end -->
@@ -125,6 +127,7 @@ test_that("can find badges in comments", {
 test_that("ignores extraneous content", {
   html <- '
     <h1>blop</h1>
+    <p>I am the first paragraph!</p>
     <!-- badges: start -->
     <p><a href="x"><img src="y"></a></p>
     <p>a</p>


### PR DESCRIPTION
Why is badge extraction so confusing :zany_face: 

## Fix 1

Fix #2060 (misdiagnosed, for a first paragraph it should not matter whether both usethis-like comments are present since badges extraction falls back on the first paragraph)

_Motivated by rOpenSci template but potentially problematic for other niches? :sweat_smile:_

In rotemplate [for Matomo usage](https://fr.matomo.org/faq/how-to/faq_176/#enable-tracking-for-visitors-who-have-javascript-disabled) there is a `p` **outside of the body** that the current XPath for detecting the "first paragraph" was picking. 

In this PR I am making the XPath specific to the first paragraph in the body.

## Fix 2

Doing so I broke the tests, that were not testing what they were supposed to: in these tests badges were extracted thanks to being in the first paragraph. :upside_down_face: They could not be detected as usethis-like paragraphs because `xml2::read_html()` loses the first comment (as seen in #2060). 