### PR TITLE
rm ref to usethis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,5 +64,5 @@ Config/potools/style: explicit
 Config/Needs/website: usethis, servr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1.9000
 SystemRequirements: pandoc

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -7,7 +7,7 @@
 #' which we no longer recommend, so this function is deprecated. There are
 #' two replacements:
 #'
-#' * [usethis::use_pkgdown_github_pages()] will setup a GitHub action to
+#' * `usethis::use_pkgdown_github_pages()` will setup a GitHub action to
 #'   automatically build and deploy your package website to GitHub pages.
 #'
 #' * [deploy_to_branch()] can be called locally to build and deploy your
@@ -85,7 +85,7 @@ deploy_site_github <- function(
 #' Build and deploy a site locally
 #'
 #' Assumes that you're in a git clone of the project, and the package is
-#' already installed. Use [usethis::use_pkgdown_github_pages()] to automate
+#' already installed. Use `usethis::use_pkgdown_github_pages()` to automate
 #' this process using GitHub actions.
 #'
 #' @param branch The git branch to deploy to

--- a/R/init.R
+++ b/R/init.R
@@ -12,7 +12,7 @@
 #' display of your site.
 #'
 #' @section Build-ignored files:
-#' We recommend using [usethis::use_pkgdown()] to build-ignore `docs/` and
+#' We recommend using `usethis::use_pkgdown()` to build-ignore `docs/` and
 #' `_pkgdown.yml`. If use another directory, or create the site manually,
 #' you'll need to add them to `.Rbuildignore` yourself. A `NOTE` about
 #' an unexpected file during `R CMD CHECK` is an indication you have not

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -50,7 +50,7 @@ new keypair specifically for deploying the site. The easiest way is to use
 which we no longer recommend, so this function is deprecated. There are
 two replacements:
 \itemize{
-\item \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown_github_pages()}} will setup a GitHub action to
+\item \code{usethis::use_pkgdown_github_pages()} will setup a GitHub action to
 automatically build and deploy your package website to GitHub pages.
 \item \code{\link[=deploy_to_branch]{deploy_to_branch()}} can be called locally to build and deploy your
 website to any desired branch.

--- a/man/deploy_to_branch.Rd
+++ b/man/deploy_to_branch.Rd
@@ -40,6 +40,6 @@ package documentation in the \verb{v.1.2.3/} directory of your site.}
 }
 \description{
 Assumes that you're in a git clone of the project, and the package is
-already installed. Use \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown_github_pages()}} to automate
+already installed. Use \code{usethis::use_pkgdown_github_pages()} to automate
 this process using GitHub actions.
 }

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -23,7 +23,7 @@ display of your site.
 }
 \section{Build-ignored files}{
 
-We recommend using \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown()}} to build-ignore \verb{docs/} and
+We recommend using \code{usethis::use_pkgdown()} to build-ignore \verb{docs/} and
 \verb{_pkgdown.yml}. If use another directory, or create the site manually,
 you'll need to add them to \code{.Rbuildignore} yourself. A \code{NOTE} about
 an unexpected file during \verb{R CMD CHECK} is an indication you have not

--- a/man/test-links.Rd
+++ b/man/test-links.Rd
@@ -5,9 +5,7 @@
 \title{Test case: links}
 \description{
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{magrittr::subtract(10, 1)
-}\if{html}{\out{</div>}}
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{## [1] 9
+#> [1] 9
 }\if{html}{\out{</div>}}
 }
 \examples{


### PR DESCRIPTION
To solve https://cran.rstudio.org/web/checks/check_results_pkgdown.html

```
Version: 2.0.6
Check: Rd cross-references
Result: NOTE
    Undeclared package ‘usethis’ in Rd xrefs
Flavor: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/pkgdown-00check.html)
```

2 R-hub builds in progress (before - after), I will mark the PR as ready for reviews if that goes well.