### PR TITLE
Rbuildignore `tools/`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,4 @@
 ^\.github$
 ^fake-index.html$
 ^CRAN-SUBMISSION$
+^tools$


### PR DESCRIPTION
This is part of me metaphorically closing all my browser tabs re: the `tools/` folder (https://github.com/r-lib/usethis/issues/1698).

I don't think this is super important. But it also doesn't seem to make sense to ship this script with pkgdown. So we could Rbuildignore it (current PR) or, alternatively, move [`syntax-highlight.R`](https://github.com/r-lib/pkgdown/blob/main/tools/syntax-highlight.R) to `data-raw/`.