### PR TITLE
fix: nested non R code blocks in manual pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* Fix highlighting of nested not R code blocks (for instance, example of R 
+Markdown code with chunks) (@idavydov, #2237).
 * Tweak German translation (@krlmlr, @mgirlich, @lhdjung, #2149, #2236)
 * Remove mention of (defunct) Twitter card validator, provide alternatives (@Bisaloo, #2185)
 * Fix `keywords` typo in `check_missing_topics()` message (@swsoyee, #2178).

--- a/R/tweak-reference.R
+++ b/R/tweak-reference.R
@@ -61,7 +61,7 @@ tweak_highlight_other <- function(div) {
   lang <- sub("sourceCode ", "", xml2::xml_attr(div, "class"))
   # since roxygen 7.2.0 generic code blocks have sourceCode with no lang
   if (!is.na(lang) && lang == "sourceCode") lang <- "r"
-  md <- paste0("```", lang, "\n", xml2::xml_text(code), "\n```")
+  md <- paste0("``````", lang, "\n", xml2::xml_text(code), "\n``````")
   html <- markdown_text(md)
 
   xml_replace_contents(code, xml2::xml_find_first(html, "body/div/pre/code"))

--- a/R/tweak-reference.R
+++ b/R/tweak-reference.R
@@ -61,6 +61,8 @@ tweak_highlight_other <- function(div) {
   lang <- sub("sourceCode ", "", xml2::xml_attr(div, "class"))
   # since roxygen 7.2.0 generic code blocks have sourceCode with no lang
   if (!is.na(lang) && lang == "sourceCode") lang <- "r"
+  # many backticks to account for possible nested code blocks
+  # like a Markdown code block with code chunks inside
   md <- paste0("``````", lang, "\n", xml2::xml_text(code), "\n``````")
   html <- markdown_text(md)
 

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -35,3 +35,21 @@ test_that("tweak_highlight_other() renders generic code blocks for roxygen2 >= 7
     "1+1"
   )
 })
+
+test_that("tweak_highlight_other() renders nested code blocks for roxygen2 >= 7.2.0", {
+  div <- xml2::read_html(
+"<div class='sourceCode markdown'><pre><code>
+blablabla
+
+```{r results='asis'}
+lalala
+```
+
+</code></pre></div>") %>%
+    xml2::xml_find_first("//div")
+  tweak_highlight_other(div)
+  expect_match(
+    xml2::xml_text(xml2::xml_find_first(div, "pre/code")),
+    "```\\n"
+  )
+})

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -50,6 +50,6 @@ lalala
   tweak_highlight_other(div)
   expect_match(
     xml2::xml_text(xml2::xml_find_first(div, "pre/code")),
-    "```\\n"
+    "```.?\\n"
   )
 })


### PR DESCRIPTION
Fix #2237