### PR TITLE
fix: topic selection when one keyword matches and the other not

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* Fix topic match selection when there is an unmatched selection followed by a matched selection (@bundfussr, #2234)
 * Fix highlighting of nested not R code blocks (for instance, example of R 
 Markdown code with chunks) (@idavydov, #2237).
 * Tweak German translation (@krlmlr, @mgirlich, @lhdjung, #2149, #2236)

--- a/R/topics.R
+++ b/R/topics.R
@@ -15,6 +15,7 @@ select_topics <- function(match_strings, topics, check = FALSE) {
     return(integer())
   }
 
+  indexes <- purrr::discard(indexes, is_empty)
   # Combine integer positions; adding if +ve, removing if -ve
   sel <- switch(
     all_sign(indexes[[1]], match_strings[[1]]),
@@ -183,7 +184,7 @@ section_topics <- function(match_strings, topics, src_path) {
   ext_strings <- match_strings[grepl("::", match_strings, fixed = TRUE)]
   topics <- rbind(topics, ext_topics(ext_strings))
 
-  selected <- topics[select_topics(match_strings, topics, check = TRUE), , ]
+  selected <- topics[select_topics(match_strings, topics), , ]
   tibble::tibble(
     name = selected$name,
     path = selected$file_out,

--- a/R/topics.R
+++ b/R/topics.R
@@ -15,6 +15,11 @@ select_topics <- function(match_strings, topics, check = FALSE) {
     return(integer())
   }
 
+  no_match <- match_strings[purrr::map_lgl(indexes, rlang::is_empty)]
+  if (check && length(no_match) > 0) {
+    topic_must("match a function or concept", toString(no_match))
+  }
+
   indexes <- purrr::discard(indexes, is_empty)
   # Combine integer positions; adding if +ve, removing if -ve
   sel <- switch(
@@ -25,10 +30,6 @@ select_topics <- function(match_strings, topics, check = FALSE) {
 
   for (i in seq2(1, length(indexes))) {
     index <- indexes[[i]]
-
-    if (check && length(index) == 0) {
-      topic_must("match a function or concept", match_strings[[i]])
-    }
 
     sel <- switch(all_sign(index, match_strings[[i]]),
       "+" = union(sel, index),

--- a/R/topics.R
+++ b/R/topics.R
@@ -6,10 +6,9 @@ select_topics <- function(match_strings, topics, check = FALSE) {
   }
 
   indexes <- purrr::map(match_strings, match_eval, env = match_env(topics))
-  indexes <- purrr::discard(indexes, is_empty)
 
   # If none of the specified topics have a match, return no topics
-  if (length(indexes) == 0) {
+  if (purrr::every(indexes, is_empty)) {
     if (check) {
       abort("No topics matched in '_pkgdown.yml'. No topics selected.")
     }
@@ -111,6 +110,7 @@ match_env <- function(topics) {
     match <- topics$concepts %>%
       purrr::map(~ str_trim(.) == x) %>%
       purrr::map_lgl(any)
+
     which(match & is_public(internal))
   }
   out$lacks_concepts <- function(x, internal = FALSE) {
@@ -183,7 +183,7 @@ section_topics <- function(match_strings, topics, src_path) {
   ext_strings <- match_strings[grepl("::", match_strings, fixed = TRUE)]
   topics <- rbind(topics, ext_topics(ext_strings))
 
-  selected <- topics[select_topics(match_strings, topics), , ]
+  selected <- topics[select_topics(match_strings, topics, check = TRUE), , ]
   tibble::tibble(
     name = selected$name,
     path = selected$file_out,

--- a/R/topics.R
+++ b/R/topics.R
@@ -6,9 +6,10 @@ select_topics <- function(match_strings, topics, check = FALSE) {
   }
 
   indexes <- purrr::map(match_strings, match_eval, env = match_env(topics))
+  indexes <- purrr::discard(indexes, is_empty)
 
   # If none of the specified topics have a match, return no topics
-  if (purrr::every(indexes, is_empty)) {
+  if (length(indexes) == 0) {
     if (check) {
       abort("No topics matched in '_pkgdown.yml'. No topics selected.")
     }
@@ -110,7 +111,6 @@ match_env <- function(topics) {
     match <- topics$concepts %>%
       purrr::map(~ str_trim(.) == x) %>%
       purrr::map_lgl(any)
-
     which(match & is_public(internal))
   }
   out$lacks_concepts <- function(x, internal = FALSE) {

--- a/tests/testthat/test-topics.R
+++ b/tests/testthat/test-topics.R
@@ -166,7 +166,7 @@ test_that("full topic selection process works", {
   expect_equal(unname(out$name), c("b", "a"))
 })
 
-test_that("an unmatched selection with a match selection does not select everything", {
+test_that("an unmatched selection with a matched selection does not select everything", {
   topics <- tibble::tribble(
     ~name, ~alias,        ~internal,
     "x",   c("a1", "a2"), FALSE,

--- a/tests/testthat/test-topics.R
+++ b/tests/testthat/test-topics.R
@@ -165,3 +165,23 @@ test_that("full topic selection process works", {
   )
   expect_equal(unname(out$name), c("b", "a"))
 })
+
+test_that("an unmatched selection with a match selection does not select everything", {
+  topics <- tibble::tribble(
+    ~name, ~alias,        ~internal,
+    "x",   c("a1", "a2"), FALSE,
+    "a",   c("a3"),       FALSE,
+    "b",   "b1",          FALSE,
+    "d",   "d",           TRUE,
+  )
+
+  expect_equal(
+    select_topics(c("a", "starts_with('unmatched')"), topics, check = FALSE),
+    2
+  )
+
+  expect_equal(
+    select_topics(c("starts_with('unmatched')", "a"), topics, check = FALSE),
+    2
+  )
+})


### PR DESCRIPTION
Fix #2234 

Note that this error depends on the _order_ of match strings inside a section. 
- If the first match string matches nothing, but the second one does match something, all topics are selected; 
- which is not the case when the first match string matches something but the second one does not match anything.
This is why I added two expectations in the new test: with the code in the main branch, only the second expectation fails.

Why is the check argument of `select_topics()` always set to FALSE? When there's a match string that matches nothing, shouldn't there be a warning or error? 