### PR TITLE
Prepare hooks for pkgdown

### DIFF
--- a/R/r-hooks.R
+++ b/R/r-hooks.R
@@ -1,0 +1,13 @@
+#' Call hook
+call_hook <- function(hook_name, ...) {
+  # Get hooks from base::getHook
+  hooks <- getHook(paste0("UserHook::pkgdown::", hook_name))
+  if (!is.list(hooks)) {
+    hooks <- list(hooks)
+  }
+
+  # Evaluate hooks
+  purrr::map(hooks, function(fun) {
+    fun(...)
+  })
+}

--- a/R/r-hooks.R
+++ b/R/r-hooks.R
@@ -9,5 +9,6 @@ call_hook <- function(hook_name, ...) {
   # Evaluate hooks
   purrr::map(hooks, function(fun) {
     fun(...)
-  })
+  }) %>%
+    invisible()
 }

--- a/R/tweak-page.R
+++ b/R/tweak-page.R
@@ -35,6 +35,8 @@ tweak_page <- function(html, name, pkg = list(bs_version = 3)) {
   if (!is.null(pkg$desc) && pkg$desc$has_dep("R6")) {
     tweak_link_R6(html, pkg$package)
   }
+
+  call_hook("tweak_page", html, name, pkg)
 }
 
 tweak_rmarkdown_html <- function(html, input_path, pkg = list(bs_version = 3)) {

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -1,0 +1,41 @@
+test_that("test setting one hook", {
+  html <- xml2::read_html('
+    <a href="local.md"></a>
+    <a href="http://remote.com/remote.md"></a>
+  ')
+
+  setHook("UserHook::pkgdown::test_hook", function(...) {tweak_link_md(..1)}, "replace")
+
+  call_hook("test_hook", html)
+
+  expect_equal(
+    xpath_attr(html, "//a", "href"),
+    c("local.html", "http://remote.com/remote.md")
+  )
+})
+
+test_that("test multi hook for applying execution", {
+  html <- xml2::read_html('
+    <body>
+    <a href="local.md"></a>
+    <a href="http://remote.com/remote.md"></a>
+    <img src="https://raw.githubusercontent.com/OWNER/REPO/main/vignettes/foo" />
+    <img src="https://github.com/OWNER/REPO/raw/main/man/figures/foo" />
+    </body>
+  ')
+  urls_before <- xpath_attr(html, ".//img", "src")
+
+  setHook("UserHook::pkgdown::test_hook", function(...) {tweak_link_md(..1)}, "replace")
+  setHook("UserHook::pkgdown::test_hook", function(...) {tweak_img_src(..1)}, "append")
+
+  call_hook("test_hook", html)
+
+  expect_equal(
+    xpath_attr(html, ".//img", "src"),
+    urls_before
+  )
+  expect_equal(
+    xpath_attr(html, "//a", "href"),
+    c("local.html", "http://remote.com/remote.md")
+  )
+})

--- a/vignettes/hooks.Rmd
+++ b/vignettes/hooks.Rmd
@@ -1,0 +1,39 @@
+---
+title: "Introduction to pkgdown hooks"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{pkdown hooks}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This vignette teaches you how to customise the pkgdown behaviour during generating your site.
+The hooks are functions that are called at specific points during the execution R code. They allow the developer to specify custom behaviour that should occur at these specific points. In the pkgdown case the hooks are used to extend the standard behaviour and allow for custom implementation.
+
+It is important to note that hooks should be used with caution, as they can have unintended consequences if not used properly.
+
+# Supported hooks
+
+- `UserHook::pkgdown::tweak_page`
+This hook is executed in the last step of `tweak_page` and allow for extra modification of html file.
+
+```r
+# Example tweak_page hook
+setHook("UserHook::pkgdown::tweak_page", function(...) {
+  html <- ..1
+
+  links <- xml2::xml_find_all(html, ".//a")
+  if (length(links) == 0)
+    return(invisible())
+
+  # modify links
+  invisible()
+})
+```


### PR DESCRIPTION
This is an idea how to add more customisation to `pkgdown` without prototyping the `pkgdown`.

Using the R hooks concept is not very popular but can be extremely beneficial in package like pkdown. The hooks can be used to perform tasks such as modifying the package's behavior, adding additional functionality, or triggering external events. The most of developer using it only during loading R package but the base R hook functionality allow for much more.

This pr is implementing only one hook but I'm happy to discuss if this concept fits the `pkgdown` and if we can add it across other `pkgdown` functions. 


