### PR TITLE
Fix typo on pkgdown site

### DIFF
--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -9,7 +9,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-The goal of pkgdown is to make it easy to make an elegant and useful package website with a minimum of work.
+The goal of pkgdown is to make it easy to make an elegant and useful package website with a minimum amount of work.
 You can get a basic website up and running in just a couple of minutes:
 
 ```{r, eval = FALSE}


### PR DESCRIPTION
Fix a grammatical typo in the pkgdown site's "Introduction to pkgdown" page, changing "minimum of work" to "minimum amount of work". Feel free to let me know if a different wording is preferred.