### PR TITLE
docs: add alternative text to example of author configuration

### DIFF
--- a/man/rmd-fragments/authors-configuration.Rmd
+++ b/man/rmd-fragments/authors-configuration.Rmd
@@ -58,12 +58,14 @@ and can contain `href` and/or `html` fields:
 * If `html` is provided, it will be shown instead of the author's name.
   This is particularly useful if you want to display the logo of a corporate
   sponsor. Use an absolute URL to an image, not a relative link.
+  Use an empty alternative text rather than no alternative text so a screen-reader
+  would skip over it.
 
 ```yaml
 authors:
   firstname lastname:
     href: "http://name-website.com"
-    html: "<img src='https://website.com/name-picture.png' width=72 alt='Name Website'>"
+    html: "<img src='https://website.com/name-picture.png' width=72 alt=''>"
 ```
 
 

--- a/man/rmd-fragments/authors-configuration.Rmd
+++ b/man/rmd-fragments/authors-configuration.Rmd
@@ -63,7 +63,7 @@ and can contain `href` and/or `html` fields:
 authors:
   firstname lastname:
     href: "http://name-website.com"
-    html: "<img src='https://website.com/name-picture.png' width=72>"
+    html: "<img src='https://website.com/name-picture.png' width=72 alt='Name Website'>"
 ```
 
 


### PR DESCRIPTION
Fix  #2282

Maybe it'd also need a note on empty alternative text in case that's the best solution (reminded of this by #2288)