### PR TITLE
Deduplicate entries in reference index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* Remove redundant entries in the documentation index when multiple explicit `@usage` tags are provided (@klmr, #2302)
 * The article index now sorts vignettes and non-vignette articles alphabetically by their filename (literally, their `basename()`), by default (@jennybc, #2253).
 
 # pkgdown 2.0.7

--- a/R/usage.R
+++ b/R/usage.R
@@ -8,7 +8,8 @@ topic_funs <- function(rd) {
   gens <- name[type == "fun"]
   self_meth <- (name %in% gens) & (type %in% c("s3", "s4"))
 
-  purrr::map_chr(funs[!self_meth], ~ short_name(.$name, .$type, .$signature))
+  funs <- purrr::map_chr(funs[!self_meth], ~ short_name(.$name, .$type, .$signature))
+  unique(funs)
 }
 
 parse_usage <- function(x) {


### PR DESCRIPTION
When a single documentation entry (say, a function) contains multiple `@usage` entries with the same function name, this leads to duplicate entries in the ‘pkgdown’ reference entry.

A concrete use-case can be found [in the ‘box’ package](https://github.com/klmr/box/blob/5ddbc725a873a195cc423a6da4417d05015c58fe/R/file.r#L3-L4):

```r
#' …
#' @usage \special{box::file(\dots)}
#' @usage \special{box::file(\dots, module)}
#' …
#' @export
file = function (..., module) {…}
```

Currently this is rendered as follows:

![Screenshot 2023-05-02 at 22 58 23](https://user-images.githubusercontent.com/38931/235784643-7cf56e5b-9ab4-49d3-ba92-b2470d9f278f.png)

This PR removes redundant entries in the rendered reference index and adds a relevant test case. I have also added a test case for the similar case of an S3 method that is documented on the same page as its generic. This use-case is currently *not* affected by the duplicate-entry behaviour but I found it prudent to proactively add a regression test.

Admittedly this is an extreme niche case. However, there’s *some* precedent for this `\usage` usage in base R, notably [in the documentation of the `:` operator](https://github.com/wch/r-source/blob/trunk/src/library/base/man/Colon.Rd#L13-L16):

```r
\usage{
from:to
   a:b
}
```

… as well as [the documentation of the `[` extract operator](https://github.com/wch/r-source/blob/8705ab789a075adef56f6c8c85d57d306d9e0679/src/library/base/man/Extract.Rd#L28-L40).