### PR TITLE
Record example plots with 'png()' if requested

### DIFF
--- a/R/highlight.R
+++ b/R/highlight.R
@@ -14,8 +14,14 @@ highlight_examples <- function(code, topic, env = globalenv()) {
 
   # some options from testthat::local_reproducible_output()
   # https://github.com/r-lib/testthat/blob/47935141d430e002070a95dd8af6dbf70def0994/R/local.R#L86
+  if (any(fig_settings()$dev %in% c("png", "grDevices::png"))) {
+    type <- fig_settings()$dev.args$type %||% getOption("bitmapType")
+    device <- function(...) grDevices::png(..., bg = bg, type = type)
+  } else {
+    device <- function(...) ragg::agg_png(..., bg = bg)
+  }
   withr::local_options(list(
-    device = function(...) ragg::agg_png(..., bg = bg),
+    device = device,
     rlang_interactive = FALSE,
     cli.num_colors = 256,
     cli.dynamic = FALSE


### PR DESCRIPTION
* If `grDevices::png()` is requested in `_pkgdown.yml` use it to record example plots instead of `ragg::agg_png()`.
* In particular examples with if blocks using `grDevices::dev.capabilities()` to ensure that a required graphics feature is supported by the active graphics device will now work correctly.
* This fixes #2299.  Note here is a list of graphics features which `grDevices::dev.capabilities()` affirms support for `grDevices::png(type = "cairo")` in R 4.3 that is not affirmed in the latest version of `ragg::agg_png()` because it doesn't support that feature yet:

  * Luminance masks
  * Compositing operators
  * Affine transformations
  * Stroking and filling paths
  * Glyphs




