### PR TITLE
Use --no-wrap instead of --wrap=none if pandoc < 1.16

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -115,7 +115,7 @@ convert_markdown_to_html <- function(in_path, out_path, ...) {
       if (rmarkdown::pandoc_available("2.0")) c("-t", "html4"),
       "--indented-code-classes=R",
       "--section-divs",
-      "--wrap=none",
+      if (rmarkdown::pandoc_available("1.16")) "--wrap=none" else "--no-wrap",
       ...
     ))
   )


### PR DESCRIPTION
Closes https://github.com/r-lib/pkgdown/issues/2316

Successfully built the docs for my package that prompted the bug report after installing this fix. I can do more manual testing if required; not sure how I would add an automated test case for old pandoc versions (or if that's even possible/desirable).