### PR TITLE
Indicate that absolute URLs are needed for search

### DIFF
--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -40,7 +40,7 @@ The most important field is `url`, which gives the final location of the site:
 url: https://pkgdown.r-lib.org
 ```
 
-`url` is used throughout the site to generate absolute urls where they are needed.
+`url` is used throughout the site to generate absolute urls where they are needed, such as search, see `vignette("search")`.
 `url` is also part of what enables auto-links to your help topics or vignettes from sites external to your package, such as from other pkgdown sites or from Quarto websites.
 See `vignette("linking")` for more.
 


### PR DESCRIPTION
[Getting started](https://pkgdown.r-lib.org/articles/pkgdown.html) suggests to start with `usethis::use_pkgdown()`. This sets `_pkgdown.yml` to

```yml
url: ~
template:
  bootstrap: 5
```

I thought `~` was the recommended way to set the url: if I change domain name, I don't have to edit this file. I recently discovered however that for a website like `org.github.io/my_package` search results will link to the incorrect page at `org.github.io`, ignoring `my_package`. This issue was reported in #1945, with the suggested fix to provide the domain name in `url`.

Indeed, this is indicated in [Getting started](https://pkgdown.r-lib.org/articles/pkgdown.html#metadata), but I think it might be good to indicate search is one of the functions that requires absolute URLs.

---

The current example in the documentation is:

```yml
url: https://pkgdown.r-lib.org
```

Perhaps it is more useful to provide an non-root domain example, which is typical for users who host their pkgdown site from GitHub Pages (e.g. https://my_org.github.io/my_package). This could then also provide guidance on whether to use an ending slash or not:

```yml
url: https://example.com/mypackage
```