### PR TITLE
Parse S3 methods with non-syntactic names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* Correct parse usage for S3 methods with non-syntactic class names (#2384).
+
 * Deprecated `build_favicon()` was removed (`build_favicons()` remains).
 * Use [cli](https://github.com/r-lib/cli) to provide interactive feedback. 
 * Preserve Markdown code blocks with class rmd from roxygen2 docs (@salim-b, #2298).

--- a/R/usage.R
+++ b/R/usage.R
@@ -199,7 +199,7 @@ usage_code.tag_S3method <- function(x) {
   generic <- paste0(usage_code(x[[1]]), collapse = "")
   class <- paste0(usage_code(x[[2]]), collapse = "")
 
-  paste0("S3method(`", generic, "`, `", class, "`)")
+  paste0("S3method(`", generic, "`, ", class, ")")
 }
 
 #' @export

--- a/tests/testthat/test-usage.R
+++ b/tests/testthat/test-usage.R
@@ -21,6 +21,11 @@ test_that("can parse function/methods", {
   expect_equal(usage$name, "f")
   expect_equal(usage$signature, "bar")
 
+  usage <- parse_usage("\\S3method{f}{`foo bar`}(x)")[[1]]
+  expect_equal(usage$type, "s3")
+  expect_equal(usage$name, "f")
+  expect_equal(usage$signature, "foo bar")
+
   usage <- parse_usage("\\S4method{f}{bar,baz}(x)")[[1]]
   expect_equal(usage$type, "s4")
   expect_equal(usage$name, "f")
@@ -35,6 +40,11 @@ test_that("can parse function/methods", {
   expect_equal(usage$type, "s4")
   expect_equal(usage$name, "f")
   expect_equal(usage$signature, c("function", "function"))
+
+  usage <- parse_usage("\\S4method{f}{function,foo bar}(x, y)")[[1]]
+  expect_equal(usage$type, "s4")
+  expect_equal(usage$name, "f")
+  expect_equal(usage$signature, c("function", "foo bar"))
 
   usage <- parse_usage("pkg::func()")[[1]]
   expect_equal(usage$type, "fun")


### PR DESCRIPTION
`\method{}`, unlike `\S4method{}`, requires non-syntactic names to be escaped with backticks, so we don't need to escape again.

Fixes #2384