### PR TITLE
Fix BS5 navbar template to get `navbar.type: dark` to work with bslib 0.6+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * The article index now sorts vignettes and non-vignette articles alphabetically by their filename (literally, their `basename()`), by default (@jennybc, #2253).
 * Add Catalan translation (@jmaspons, #2333)
 * Set RNG seed for htmlwidgets IDs. This reduces noise in pkgdown reference HTML output when examples generate htmlwidgets (@salim-b, #2294).
+* Fix `navbar.type: dark` in BS5 navbar template to work with bslib 0.6+ / Bootstrap 5.3+ (@tanho63, #2388)
 
 # pkgdown 2.0.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 * The article index now sorts vignettes and non-vignette articles alphabetically by their filename (literally, their `basename()`), by default (@jennybc, #2253).
 * Add Catalan translation (@jmaspons, #2333)
 * Set RNG seed for htmlwidgets IDs. This reduces noise in pkgdown reference HTML output when examples generate htmlwidgets (@salim-b, #2294).
-* Fix `navbar.type: dark` in BS5 navbar template to work with bslib 0.6+ / Bootstrap 5.3+ (@tanho63, #2388)
+* Fix BS5 navbar template to get `navbar.type: dark` to work with bslib 0.6+ / Bootstrap 5.3+ (@tanho63, #2388)
 
 # pkgdown 2.0.7
 

--- a/inst/BS5/templates/navbar.html
+++ b/inst/BS5/templates/navbar.html
@@ -1,5 +1,5 @@
 {{#navbar}}
-<nav class="navbar fixed-top navbar-{{{type}}} navbar-expand-lg bg-{{{bg}}}">
+<nav class="navbar fixed-top navbar-expand-lg bg-{{{bg}}}" data-bs-theme="{{{type}}}">
   <div class="container">
     {{#includes}}{{{before_title}}}{{/includes}}
     <a class="navbar-brand me-2" href="{{#site}}{{root}}{{/site}}index.html">{{#site}}{{title}}{{/site}}</a>

--- a/inst/BS5/templates/navbar.html
+++ b/inst/BS5/templates/navbar.html
@@ -1,5 +1,5 @@
 {{#navbar}}
-<nav class="navbar fixed-top navbar-expand-lg bg-{{{bg}}}" data-bs-theme="{{{type}}}">
+<nav class="navbar fixed-top navbar-{{{type}}} navbar-expand-lg bg-{{{bg}}}" data-bs-theme="{{{type}}}">
   <div class="container">
     {{#includes}}{{{before_title}}}{{/includes}}
     <a class="navbar-brand me-2" href="{{#site}}{{root}}{{/site}}index.html">{{#site}}{{title}}{{/site}}</a>


### PR DESCRIPTION
Fixes #2387 

Bootstrap 5.3 docs [suggest](https://twbs-bootstrap.netlify.app/docs/5.3/components/navbar/#color-schemes) that `.navbar-dark` is now deprecated in favour of using a data attribute `data-bs-theme="dark"`, which seems to facilitate client-side light/dark mode switching. 

In contrast to the proposed fix within the issue, this PR adds the new attribute without removing the old class, so as to maintain backwards compat with bslib <0.6