### PR TITLE
Fix missing class name in "Unknown tag" message

### DIFF
--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -513,7 +513,7 @@ as_html.tag <- function(x, ...) {
   if (identical(class(x), "tag")) {
     flatten_text(x, ...)
   } else {
-    cli::cli_warn("Unknown tag: {.cls {class(x)}}")
+    cli::cli_inform("Unknown tag: {.cls {class(x)}}")
     ""
   }
 }

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -513,8 +513,7 @@ as_html.tag <- function(x, ...) {
   if (identical(class(x), "tag")) {
     flatten_text(x, ...)
   } else {
-    untag <- paste(class(x), collapse = "/")
-    cli::cli_warn("Unknown tag: {.val {untag}}")
+    cli::cli_warn("Unknown tag: {.cls {class(x)}}")
     ""
   }
 }

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -513,7 +513,8 @@ as_html.tag <- function(x, ...) {
   if (identical(class(x), "tag")) {
     flatten_text(x, ...)
   } else {
-    cli::cli_inform("Unknown tag: ", paste(class(x), collapse = "/"))
+    untag <- paste(class(x), collapse = "/")
+    cli::cli_warn("Unknown tag: {.val {untag}}")
     ""
   }
 }


### PR DESCRIPTION
# Problem

Introduced in https://github.com/r-lib/pkgdown/pull/2378, the class of the unknown tags are never shown given that the string of the unknown tags is passed as second argument instead of string interpolation.

## Reprex

``` r
library(pkgdown)
pkgdown:::as_html.tag("test")
#> Message:
#> Unknown tag:
#> [1] ""
```

<sup>Created on 2024-02-15 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

# Solution

Analogue to https://github.com/r-lib/pkgdown/pull/2378/files#diff-7800ebb360a3c28cd33101ef6ea07c562247ec30a029d0a69d527a80f17bff17L158-R164. I also changed the severity to warning.




