### PR TITLE
Update custom footer example

### DIFF
--- a/man/rmd-fragments/footer-configuration.Rmd
+++ b/man/rmd-fragments/footer-configuration.Rmd
@@ -24,7 +24,7 @@ The example below puts the authors' information on the right along with a legal 
 footer:
   structure: 
     left: pkgdown
-    right: [authors, legal]
+    right: [developed_by, legal]
   components:
     legal: Provided without **any warranty**.
 ```


### PR DESCRIPTION
As the default is `developed_by`. Currently, using this template, it prints NULL. Another solution would be to add the component `authors`, like so


```yaml
  components:
    legal: Provided without **any warranty**.
    authors: xyz
```