### PR TITLE
Tweaks in error chaining and path display

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -371,7 +371,8 @@ data_articles_index <- function(pkg = ".") {
 
   if (length(missing) > 0) {
     cli::cli_abort(
-      "{length(missing)} vignette{?s} missing from index: {.file {missing}}.",
+      "{length(missing)} vignette{?s} missing from index in \\
+      {pkgdown_config_href({pkg$src_path})}: {.val {missing}}.",
       call = caller_env()
     )
   }

--- a/R/build-favicons.R
+++ b/R/build-favicons.R
@@ -32,7 +32,7 @@ build_favicons <- function(pkg = ".", overwrite = FALSE) {
   if (has_favicons(pkg) && !overwrite) {
     cli::cli_inform(c(
       "Favicons already exist in {.path pkgdown}",
-      "i" = "Set {.var overwrite = TRUE} to re-create."
+      "i" = "Set {.code overwrite = TRUE} to re-create."
     ))
     return(invisible())
   }
@@ -78,10 +78,7 @@ build_favicons <- function(pkg = ".", overwrite = FALSE) {
   result <- content$favicon_generation_result
 
   if (!identical(result$result$status, "success")) {
-    cli::cli_abort(c(
-        "API request failed.",
-        "i" = "{.href [Please submit a bug report](https://github.com/r-lib/pkgdown/issues)}"
-    ))
+    cli::cli_abort("API request failed.", .internal = TRUE)
   }
 
   tmp <- tempfile()

--- a/R/build.R
+++ b/R/build.R
@@ -27,7 +27,7 @@
 #'    It specifies where the site will be published and is used to allow other
 #'    pkgdown sites to link to your site when needed (`vignette("linking")`),
 #'    generate a `sitemap.xml`, automatically generate a `CNAME` when
-#'    [deploying to github][deploy_site_github], generate the metadata needed
+#'    [deploying to GitHub][deploy_site_github], generate the metadata needed
 #'    rich social "media cards" (`vignette("metadata")`), and more.
 #'
 #' *  `title` overrides the default site title, which is the package name.
@@ -87,7 +87,7 @@
 #' ```md
 #' ::: {.pkgdown-devel}
 #' You can install the development version of pkgdown from GitHub with:
-#' `remotes::install_github("r-lib/pkgdown")`
+#' `pak::pak("r-lib/pkgdown")`
 #' :::
 #' ```
 #'
@@ -222,10 +222,10 @@
 #' ```yaml
 #' repo:
 #'   url:
-#'     home: https://github.com/r-lib/pkgdown/
+#'     home: https://github.com/r-lib/pkgdown
 #'     source: https://github.com/r-lib/pkgdown/blob/HEAD/
-#'     issue: https://github.com/r-lib/pkgdown/issues/
-#'     user: https://github.com/
+#'     issue: https://github.com/r-lib/pkgdown/issues
+#'     user: https://github.com
 #' ```
 #'
 #' * `home`: path to package home on source code repository.
@@ -408,7 +408,7 @@ build_site_external <- function(pkg = ".",
     timeout = getOption('pkgdown.timeout', Inf)
   )
 
-  cli::cli_rule(paste0("Finished building pkgdown site for package ", cli::col_blue(pkg$package)))
+  cli::cli_rule("Finished building pkgdown site for package {.pkg {pkg$package}}")
 
   preview_site(pkg, preview = preview)
   invisible()
@@ -426,7 +426,7 @@ build_site_local <- function(pkg = ".",
 
   pkg <- section_init(pkg, depth = 0, override = override)
 
-  cli::cli_rule(paste0("Building pkgdown site for package ", cli::col_blue(pkg$package)))
+  cli::cli_rule("Building pkgdown site for package {.pkg {pkg$package}}")
   cli::cli_inform("Reading from: {src_path(path_abs(pkg$src_path))}")
   cli::cli_inform("Writing to:   {dst_path(path_abs(pkg$dst_path))}")
 
@@ -453,6 +453,6 @@ build_site_local <- function(pkg = ".",
     build_search(pkg, override = override)
   }
 
-  cli::cli_rule(paste0("Finished building pkgdown site for package ", cli::col_blue(pkg$package)))
+  cli::cli_rule("Finished building pkgdown site for package {.pkg {pkg$package}}")
   preview_site(pkg, preview = preview)
 }

--- a/R/build.R
+++ b/R/build.R
@@ -27,7 +27,7 @@
 #'    It specifies where the site will be published and is used to allow other
 #'    pkgdown sites to link to your site when needed (`vignette("linking")`),
 #'    generate a `sitemap.xml`, automatically generate a `CNAME` when
-#'    [deploying to GitHub][deploy_site_github], generate the metadata needed
+#'    [deploying to github][deploy_site_github], generate the metadata needed
 #'    rich social "media cards" (`vignette("metadata")`), and more.
 #'
 #' *  `title` overrides the default site title, which is the package name.
@@ -87,7 +87,7 @@
 #' ```md
 #' ::: {.pkgdown-devel}
 #' You can install the development version of pkgdown from GitHub with:
-#' `pak::pak("r-lib/pkgdown")`
+#' `remotes::install_github("r-lib/pkgdown")`
 #' :::
 #' ```
 #'
@@ -222,10 +222,10 @@
 #' ```yaml
 #' repo:
 #'   url:
-#'     home: https://github.com/r-lib/pkgdown
+#'     home: https://github.com/r-lib/pkgdown/
 #'     source: https://github.com/r-lib/pkgdown/blob/HEAD/
-#'     issue: https://github.com/r-lib/pkgdown/issues
-#'     user: https://github.com
+#'     issue: https://github.com/r-lib/pkgdown/issues/
+#'     user: https://github.com/
 #' ```
 #'
 #' * `home`: path to package home on source code repository.

--- a/R/check.R
+++ b/R/check.R
@@ -12,6 +12,7 @@ check_pkgdown <- function(pkg = ".") {
   data_articles_index(pkg)
   data_reference_index(pkg)
 
-  cli::cli_alert_success("No problems found in {pkgdown_config_href({pkg$src_path})}")
+  cli::cli_inform(c(
+    "v" = "No problems found in {pkgdown_config_href({pkg$src_path})}"
+  ))
 }
-

--- a/R/check.R
+++ b/R/check.R
@@ -12,6 +12,6 @@ check_pkgdown <- function(pkg = ".") {
   data_articles_index(pkg)
   data_reference_index(pkg)
 
-  cli::cli_alert_success("No problems found in {.file {pkgdown_config_relpath(pkg)}}")
+  cli::cli_alert_success("No problems found in {pkgdown_config_href({pkg$src_path})}")
 }
 

--- a/R/package.R
+++ b/R/package.R
@@ -129,6 +129,12 @@ pkgdown_config_path <- function(path) {
     )
   )
 }
+pkgdown_config_href <- function(path) {
+  cli::style_hyperlink(
+    text = "_pkgdown.yml",
+    url = paste0("file://", pkgdown_config_path(path))
+  )
+}
 
 read_meta <- function(path) {
   path <- pkgdown_config_path(path)

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -88,7 +88,7 @@ whole site.
 It specifies where the site will be published and is used to allow other
 pkgdown sites to link to your site when needed (\code{vignette("linking")}),
 generate a \code{sitemap.xml}, automatically generate a \code{CNAME} when
-\link[=deploy_site_github]{deploying to GitHub}, generate the metadata needed
+\link[=deploy_site_github]{deploying to github}, generate the metadata needed
 rich social "media cards" (\code{vignette("metadata")}), and more.
 \item \code{title} overrides the default site title, which is the package name.
 It's used in the page title and default navbar.
@@ -147,7 +147,7 @@ on the development version of your site:
 
 \if{html}{\out{<div class="sourceCode md">}}\preformatted{::: \{.pkgdown-devel\}
 You can install the development version of pkgdown from GitHub with:
-`pak::pak("r-lib/pkgdown")`
+`remotes::install_github("r-lib/pkgdown")`
 :::
 }\if{html}{\out{</div>}}
 
@@ -282,10 +282,10 @@ Otherwise, you can supply your own in the \code{repo} field:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{repo:
   url:
-    home: https://github.com/r-lib/pkgdown
+    home: https://github.com/r-lib/pkgdown/
     source: https://github.com/r-lib/pkgdown/blob/HEAD/
-    issue: https://github.com/r-lib/pkgdown/issues
-    user: https://github.com
+    issue: https://github.com/r-lib/pkgdown/issues/
+    user: https://github.com/
 }\if{html}{\out{</div>}}
 \itemize{
 \item \code{home}: path to package home on source code repository.

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -147,7 +147,7 @@ on the development version of your site:
 
 \if{html}{\out{<div class="sourceCode md">}}\preformatted{::: \{.pkgdown-devel\}
 You can install the development version of pkgdown from GitHub with:
-`remotes::install_github("r-lib/pkgdown")`
+`pak::pak("r-lib/pkgdown")`
 :::
 }\if{html}{\out{</div>}}
 
@@ -282,10 +282,10 @@ Otherwise, you can supply your own in the \code{repo} field:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{repo:
   url:
-    home: https://github.com/r-lib/pkgdown/
+    home: https://github.com/r-lib/pkgdown
     source: https://github.com/r-lib/pkgdown/blob/HEAD/
-    issue: https://github.com/r-lib/pkgdown/issues/
-    user: https://github.com/
+    issue: https://github.com/r-lib/pkgdown/issues
+    user: https://github.com
 }\if{html}{\out{</div>}}
 \itemize{
 \item \code{home}: path to package home on source code repository.

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -88,7 +88,7 @@ whole site.
 It specifies where the site will be published and is used to allow other
 pkgdown sites to link to your site when needed (\code{vignette("linking")}),
 generate a \code{sitemap.xml}, automatically generate a \code{CNAME} when
-\link[=deploy_site_github]{deploying to github}, generate the metadata needed
+\link[=deploy_site_github]{deploying to GitHub}, generate the metadata needed
 rich social "media cards" (\code{vignette("metadata")}), and more.
 \item \code{title} overrides the default site title, which is the package name.
 It's used in the page title and default navbar.

--- a/tests/testthat/_snaps/build-reference-index.md
+++ b/tests/testthat/_snaps/build-reference-index.md
@@ -50,9 +50,9 @@
     Code
       data_reference_index(pkg)
     Condition
-      Error in `check_missing_topics()`:
+      Error:
       ! All topics must be included in reference index
-      x Missing topics: c, e, ?
+      x Missing topics: c, e, and ?
       i Either add to _pkgdown.yml or use @keywords internal
 
 # errors well when a content entry is empty

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -20,4 +20,6 @@
 
     Code
       check_pkgdown(pkg)
+    Message
+      v No problems found in _pkgdown.yml
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -3,7 +3,7 @@
     Code
       check_pkgdown(pkg)
     Condition
-      Error in `check_missing_topics()`:
+      Error in `check_pkgdown()`:
       ! All topics must be included in reference index
       x Missing topics: ?
       i Either add to _pkgdown.yml or use @keywords internal
@@ -14,7 +14,7 @@
       check_pkgdown(pkg)
     Condition
       Error in `check_pkgdown()`:
-      ! 2 vignettes missing from index: 'articles/nested' and 'width'.
+      ! 2 vignettes missing from index in _pkgdown.yml: "articles/nested" and "width".
 
 # informs if everything is ok
 


### PR DESCRIPTION
In current dev, the link created by `check_pkgdown()` if success was invalid if using `check_pkgdown("C:/users/path/to/package/")`. This PR fixes it as well as doing some touchups on the cli conversion.

Tweaks to output of `check_pkgdown()`. I used a new helper function to ensure that `check_pkgdown()` works if you provide `pkg`. 

Currently, it didn't work as expected. Also added some chaining, so that it would display Error in `check_pkgdown()` instead of Error in `check_missing_topics()`.

Also took advantage of cli inline markup for `{.pkg}`

FWIW, I am testing this with r-lib/devtools#2561 and it is working pretty well!