### PR TITLE
fix override when included in `as_pkgdown`

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -9,7 +9,11 @@
 #' @export
 as_pkgdown <- function(pkg = ".", override = list()) {
   if (is_pkgdown(pkg)) {
-    pkg$meta <- utils::modifyList(pkg$meta, override)
+    if (is.list(pkg$meta)) {
+      pkg$meta <- utils::modifyList(pkg$meta, override)
+    } else if (is.null(pkg$meta)) {
+      pkg$meta <- override
+    }
     return(pkg)
   }
 

--- a/R/package.R
+++ b/R/package.R
@@ -9,11 +9,7 @@
 #' @export
 as_pkgdown <- function(pkg = ".", override = list()) {
   if (is_pkgdown(pkg)) {
-    if (is.list(pkg$meta)) {
-      pkg$meta <- utils::modifyList(pkg$meta, override)
-    } else if (is.null(pkg$meta)) {
-      pkg$meta <- override
-    }
+    pkg$meta <- modify_list(pkg$meta, override)
     return(pkg)
   }
 
@@ -26,7 +22,7 @@ as_pkgdown <- function(pkg = ".", override = list()) {
 
   desc <- read_desc(pkg)
   meta <- read_meta(pkg)
-  meta <- utils::modifyList(meta, override)
+  meta <- modify_list(meta, override)
 
   template_config <- find_template_config(
     package = meta$template$package,

--- a/R/package.R
+++ b/R/package.R
@@ -9,6 +9,7 @@
 #' @export
 as_pkgdown <- function(pkg = ".", override = list()) {
   if (is_pkgdown(pkg)) {
+    pkg$meta <- utils::modifyList(pkg$meta, override)
     return(pkg)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,7 +86,7 @@ isFALSE <- function(x) {
 }
 
 modify_list <- function(x, y) {
-  if (is.null(y)) {
+  if (is.null(x) || is.null(y)) {
     return(x)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,7 +86,9 @@ isFALSE <- function(x) {
 }
 
 modify_list <- function(x, y) {
-  if (is.null(x) || is.null(y)) {
+  if (is.null(x)) {
+    return(y)
+  } else if (is.null(y)) {
     return(x)
   }
 

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -46,13 +46,3 @@ test_that("site meta doesn't break unexpectedly", {
 
   expect_snapshot(yaml)
 })
-
-test_that("override works correctly for as_pkgdown", {
-  pkgdown <- as_pkgdown("assets/man-figures")
-  expected_list <- list(figures = list(dev = "jpeg", fig.ext = "jpg", fig.width = 3, fig.asp = 1))
-  expect_equal(pkgdown$meta, expected_list)
-  modified_pkgdown <- as_pkgdown(pkgdown, override = list(figures = list(dev = "png")))
-  modified_list <- list(figures = list(dev = "png", fig.ext = "jpg", fig.width = 3, fig.asp = 1))
-  modified_pkgdown$meta
-  expect_equal(modified_pkgdown$meta, modified_list)
-})

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -46,3 +46,13 @@ test_that("site meta doesn't break unexpectedly", {
 
   expect_snapshot(yaml)
 })
+
+test_that("override works correctly for as_pkgdown", {
+  pkgdown <- as_pkgdown("assets/man-figures")
+  expected_list <- list(figures = list(dev = "jpeg", fig.ext = "jpg", fig.width = 3, fig.asp = 1))
+  expect_equal(pkgdown$meta, expected_list)
+  modified_pkgdown <- as_pkgdown(pkgdown, override = list(figures = list(dev = "png")))
+  modified_list <- list(figures = list(dev = "png", fig.ext = "jpg", fig.width = 3, fig.asp = 1))
+  modified_pkgdown$meta
+  expect_equal(modified_pkgdown$meta, modified_list)
+})

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -48,6 +48,15 @@ test_that("package_vignettes() sorts articles alphabetically by file name", {
   )
 })
 
+test_that("override works correctly for as_pkgdown", {
+  pkgdown <- as_pkgdown("assets/man-figures")
+  expected_list <- list(figures = list(dev = "jpeg", fig.ext = "jpg", fig.width = 3, fig.asp = 1))
+  expect_equal(pkgdown$meta, expected_list)
+  modified_pkgdown <- as_pkgdown(pkgdown, override = list(figures = list(dev = "png")))
+  modified_list <- list(figures = list(dev = "png", fig.ext = "jpg", fig.width = 3, fig.asp = 1))
+  modified_pkgdown$meta
+  expect_equal(modified_pkgdown$meta, modified_list)
+})
 # titles ------------------------------------------------------------------
 
 test_that("multiline titles are collapsed", {


### PR DESCRIPTION
Fixes #2257. I wasn't exactly sure where to put the test, but figured it was better to include a brief test somewhere.

As with the other issue, I actually ran into this doing `build_site_github_pages()`, but figured it was better to fix at the root