### PR TITLE
Prevent creation of faulty site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* `build_reference_index()` and friends give a better error message if the site was not initialized (@olivroy, #2329).
 * Fix parsing of github profiles and issues into links when present at the beginning of list items (@pearsonca, #2122)
 * Correct parse usage for S3 methods with non-syntactic class names (#2384).
 * Deprecated `build_favicon()` was removed (`build_favicons()` remains).

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -247,6 +247,7 @@ examples_env <- function(pkg, seed = 1014, devel = TRUE, envir = parent.frame())
 #' @rdname build_reference
 build_reference_index <- function(pkg = ".") {
   pkg <- section_init(pkg, depth = 1L)
+  check_dst_path_exists(pkg$dst_path)
   dir_create(path(pkg$dst_path, "reference"))
 
   # Copy icons, if needed

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -113,12 +113,13 @@ pkgdown_config_relpath <- function(pkg) {
 
 # Will error if parent path doesn't exist.
 # https://github.com/r-lib/pkgdown/issues/2329
-check_dst_path_exists <- function(path, call = caller_env()) {
-  if (!dir_exists(path)) {
+check_dst_path_exists <- function(path, call = caller_env(), check = is_interactive()) {
+  if (check && !dir_exists(path)) {
     cli::cli_abort(c(
       "Can't create a site",
       i = "Do you need to run {.run pkgdown::init_site()}?"
     ),
     call = call)
   }
+  invisible()
 }

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -110,3 +110,15 @@ pkgdown_config_relpath <- function(pkg) {
 
   fs::path_rel(config_path, pkg$src_path)
 }
+
+# Will error if parent path doesn't exist.
+# https://github.com/r-lib/pkgdown/issues/2329
+check_dst_path_exists <- function(path, call = caller_env()) {
+  if (!dir_exists(path)) {
+    cli::cli_abort(c(
+      "Can't create a site",
+      i = "Do you need to run {.run pkgdown::init_site()}?"
+    ),
+    call = call)
+  }
+}


### PR DESCRIPTION
Fix #2329

If you think the approach is reasonable, I could add this check in some strategic places.

For me, I'd see these as good candidates:
* `build_reference()`
* `build_home()`
* `build_articles()`
* `build_news()`

Add earlier message to prevent the creation of a faulty pkgdown site in `build_reference_index()`.

I tested this interactively with no docs folder initialized and this works as expected.

Edit: the CI failure of no-pandoc appears genuine Maybe I could make the message conditional on the presence of pandoc? I added a condition on interactivity, but that seems a bit clunky.
