### PR TITLE
Add back preview page runnable link

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -225,7 +225,8 @@ write_if_different <- function(pkg, contents, path, quiet = FALSE, check = TRUE)
   }
 
   if (!quiet) {
-    cli::cli_inform("Writing {dst_path(path)}")
+    href <- paste0("ide:run:pkgdown::preview_page('", path_rel(full_path, pkg$dst_path), "')")
+    cli::cli_inform("Writing {cli::style_hyperlink(dst_path(path), href)}")
   }
 
   write_lines(contents, path = full_path)


### PR DESCRIPTION
fix regression introduced in #2378 

For example, after `init_site()` + `build_reference_index()`

2.0.7:

![image](https://github.com/r-lib/pkgdown/assets/52606734/f41f638d-c3e0-41c8-ad94-75a5b9fa96ea)

Current dev:

![image](https://github.com/r-lib/pkgdown/assets/52606734/0aeac350-5457-4fee-b150-076fd26a65b5)

This PR brings back the old behavior.

![image](https://github.com/r-lib/pkgdown/assets/52606734/ba1aa1de-ef36-43ec-877b-1231ec412b43)


Very useful for previewing easily.