### PR TITLE
Fix `build_site_external()`

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -380,6 +380,7 @@ build_site_external <- function(pkg = ".",
                                 override = list(),
                                 preview = NA,
                                 devel = TRUE) {
+  pkg <- as_pkgdown(pkg, override = override)
   args <- list(
     pkg = pkg,
     examples = examples,


### PR DESCRIPTION
Before, directly calling `pkgdown:::build_site_external()` failed with

```
Error in `cli::cli_rule("Finished building pkgdown site for package {.pkg {pkg$package}}")`:
! Could not evaluate cli `{}` expression: `pkg$package`.
Caused by error in `pkg$package`:
! $ operator is invalid for atomic vectors
```

since `pkg = "." wasn't resolved to an actual `pkgdown` object`.