### PR TITLE
Avoid creation of faulty site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Preview links now work once again (#2435).
 * `build_home()` no longer renders Github issue and pull request templates (@hsloot, #2362)
+* It is now easier to preview parts of the website locally interactively. `build_reference_index()` and friends will call `init_site()` internally instead of erroring (@olivroy, #2329).
 
 # pkgdown 2.0.8
 

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -351,7 +351,7 @@ rmarkdown_template <- function(pkg, name, data, depth) {
 build_articles_index <- function(pkg = ".") {
   pkg <- as_pkgdown(pkg)
 
-  create_subdir(pkg$dst_path, "articles", pkg)
+  create_subdir(pkg, "articles")
   render_page(
     pkg,
     "article-index",

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -351,7 +351,7 @@ rmarkdown_template <- function(pkg, name, data, depth) {
 build_articles_index <- function(pkg = ".") {
   pkg <- as_pkgdown(pkg)
 
-  dir_create(path(pkg$dst_path, "articles"))
+  create_subdir(pkg$dst_path, "articles")
   render_page(
     pkg,
     "article-index",

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -351,7 +351,7 @@ rmarkdown_template <- function(pkg, name, data, depth) {
 build_articles_index <- function(pkg = ".") {
   pkg <- as_pkgdown(pkg)
 
-  create_subdir(pkg$dst_path, "articles")
+  create_subdir(pkg$dst_path, "articles", pkg)
   render_page(
     pkg,
     "article-index",

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -79,7 +79,7 @@ build_news <- function(pkg = ".",
     return()
 
   cli::cli_rule("Building news")
-  create_subdir(pkg$dst_path, "news", pkg)
+  create_subdir(pkg, "news")
 
   switch(news_style(pkg$meta),
     single = build_news_single(pkg),

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -79,7 +79,7 @@ build_news <- function(pkg = ".",
     return()
 
   cli::cli_rule("Building news")
-  dir_create(path(pkg$dst_path, "news"))
+  create_subdir(pkg$dst_path, "news")
 
   switch(news_style(pkg$meta),
     single = build_news_single(pkg),

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -79,7 +79,7 @@ build_news <- function(pkg = ".",
     return()
 
   cli::cli_rule("Building news")
-  create_subdir(pkg$dst_path, "news")
+  create_subdir(pkg$dst_path, "news", pkg)
 
   switch(news_style(pkg$meta),
     single = build_news_single(pkg),

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -245,7 +245,7 @@ examples_env <- function(pkg, seed = 1014L, devel = TRUE, envir = parent.frame()
 #' @rdname build_reference
 build_reference_index <- function(pkg = ".") {
   pkg <- section_init(pkg, depth = 1L)
-  dir_create(path(pkg$dst_path, "reference"))
+  create_subdir(pkg$dst_path, "reference")
 
   # Copy icons, if needed
   src_icons <- path(pkg$src_path, "icons")

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -245,7 +245,7 @@ examples_env <- function(pkg, seed = 1014L, devel = TRUE, envir = parent.frame()
 #' @rdname build_reference
 build_reference_index <- function(pkg = ".") {
   pkg <- section_init(pkg, depth = 1L)
-  create_subdir(pkg$dst_path, "reference")
+  create_subdir(pkg$dst_path, "reference", pkg)
 
   # Copy icons, if needed
   src_icons <- path(pkg$src_path, "icons")

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -245,7 +245,7 @@ examples_env <- function(pkg, seed = 1014L, devel = TRUE, envir = parent.frame()
 #' @rdname build_reference
 build_reference_index <- function(pkg = ".") {
   pkg <- section_init(pkg, depth = 1L)
-  create_subdir(pkg$dst_path, "reference", pkg)
+  create_subdir(pkg, "reference")
 
   # Copy icons, if needed
   src_icons <- path(pkg$src_path, "icons")

--- a/R/build-tutorials.R
+++ b/R/build-tutorials.R
@@ -36,7 +36,7 @@ build_tutorials <- function(pkg = ".", override = list(), preview = NA) {
   }
 
   cli::cli_rule("Building tutorials")
-  create_subdir(pkg$dst_path, "tutorials")
+  create_subdir(pkg$dst_path, "tutorials", pkg)
 
   data <- purrr::transpose(tutorials)
 

--- a/R/build-tutorials.R
+++ b/R/build-tutorials.R
@@ -36,7 +36,7 @@ build_tutorials <- function(pkg = ".", override = list(), preview = NA) {
   }
 
   cli::cli_rule("Building tutorials")
-  dir_create(path(pkg$dst_path, "tutorials"))
+  create_subdir(pkg$dst_path, "tutorials")
 
   data <- purrr::transpose(tutorials)
 

--- a/R/build-tutorials.R
+++ b/R/build-tutorials.R
@@ -36,7 +36,7 @@ build_tutorials <- function(pkg = ".", override = list(), preview = NA) {
   }
 
   cli::cli_rule("Building tutorials")
-  create_subdir(pkg$dst_path, "tutorials", pkg)
+  create_subdir(pkg, "tutorials")
 
   data <- purrr::transpose(tutorials)
 

--- a/R/init.R
+++ b/R/init.R
@@ -26,7 +26,8 @@ init_site <- function(pkg = ".") {
   if (is_non_pkgdown_site(pkg$dst_path)) {
     cli::cli_abort(c(
       "{.file {pkg$dst_path}} is non-empty and not built by pkgdown",
-      i = "Make sure no important information, and use {.run pkgdown::clean_site()} to clear"
+      "!" = "Make sure it contains no important information \\
+             and use {.run pkgdown::clean_site()} to delete its contents."
       ),
       call = caller_env()
     )

--- a/R/init.R
+++ b/R/init.R
@@ -24,8 +24,10 @@ init_site <- function(pkg = ".") {
   pkg <- as_pkgdown(pkg)
 
   if (is_non_pkgdown_site(pkg$dst_path)) {
-    cli::cli_abort(
+    cli::cli_abort(c(
       "{.file {pkg$dst_path}} is non-empty and not built by pkgdown",
+      i = "Make sure no important information, and use {.run pkgdown::clean_site()} to clear"
+      ),
       call = caller_env()
     )
   }

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -51,9 +51,9 @@ file_copy_to <- function(pkg,
 }
 
 # Checks init_site() first.
-create_subdir <- function(dest_base, subdir) {
+create_subdir <- function(dest_base, subdir, pkg = pkg) {
   if (!fs::dir_exists(dest_base)) {
-    init_site()
+    init_site(pkg)
   }
   dir_create(path(dest_base, subdir))
 

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -50,6 +50,15 @@ file_copy_to <- function(pkg,
   file_copy(from_paths[!eq], to_paths[!eq], overwrite = overwrite)
 }
 
+# Checks init_site() first.
+create_subdir <- function(dest_base, subdir) {
+  if (!fs::dir_exists(dest_base)) {
+    init_site()
+  }
+  dir_create(path(dest_base, subdir))
+
+}
+
 out_of_date <- function(source, target) {
   if (!file_exists(target))
     return(TRUE)

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -51,11 +51,11 @@ file_copy_to <- function(pkg,
 }
 
 # Checks init_site() first.
-create_subdir <- function(dest_base, subdir, pkg) {
-  if (!fs::dir_exists(dest_base)) {
+create_subdir <- function(pkg, subdir) {
+  if (!fs::dir_exists(pkg$dst_path)) {
     init_site(pkg)
   }
-  dir_create(path(dest_base, subdir))
+  dir_create(path(pkg$dst_path, subdir))
 
 }
 

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -51,7 +51,7 @@ file_copy_to <- function(pkg,
 }
 
 # Checks init_site() first.
-create_subdir <- function(dest_base, subdir, pkg = pkg) {
+create_subdir <- function(dest_base, subdir, pkg) {
   if (!fs::dir_exists(dest_base)) {
     init_site(pkg)
   }


### PR DESCRIPTION
Fixes #2329.

Supersedes #2411 

Applies the suggestions to call `init_site()` earlier.

Will be interesting to see the codecov patch, maybe some messages are no longer reached?

Errors are caused by the fact that `init_site()` is called earlier, which triggers a message.