### PR TITLE
fix: use BS version from template package again

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -32,6 +32,9 @@ as_pkgdown <- function(pkg = ".", override = list()) {
   )
   meta <- modify_list(template_config, meta)
 
+  # BS version can also be set by template package itself
+  bs_version <- get_bootstrap_version(list(meta = meta))
+
   # Ensure the URL has no trailing slash
   if (!is.null(meta[["url"]])) {
     meta[["url"]] <- sub("/$", "", meta[["url"]])
@@ -99,8 +102,10 @@ read_desc <- function(path = ".") {
 }
 
 get_bootstrap_version <- function(pkg) {
-  template_bootstrap <- pkg$meta[["template"]]$bootstrap
-  template_bslib <- pkg$meta[["template"]]$bslib$version
+  template_bootstrap <- pkg[["template"]]$bootstrap %||%
+    pkg$meta[["template"]]$bootstrap
+  template_bslib <- pkg[["template"]]$bootstrap %||%
+    pkg$meta[["template"]]$bslib$version
 
   if (!is.null(template_bootstrap) && !is.null(template_bslib)) {
     cli::cli_abort(


### PR DESCRIPTION
Fix #2440 cc @gadenbuie 

@Bisaloo could you please confirm it also works for you?

This is not an elegant fix because of getting the BS version twice. I can also imagine it'd make sense to ask maintainers of template packages to ask their users to set the BS version? But it means more work if updating the BS version in the template package so I would not appreciate this outcome as a template package maintainer. :joy_cat: 