### PR TITLE
tweaks to detection of intro vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * `build_home()` no longer renders Github issue and pull request templates (@hsloot, #2362)
 * It is now easier to preview parts of the website locally interactively. `build_reference_index()` and friends will call `init_site()` internally instead of erroring (@olivroy, #2329).
 * Fixed an issue introduced in 2.0.8 where pkgdown was not using the Bootstrap version specified in a template package (@gadenbuie, #2443).
-* `check_pkgdown()` no longer errors if your intro vignette is an article (@olivroy #2150).
+* `check_pkgdown()` no longer errors if your intro vignette is an article is not listed in `_pkgdown.yml` (@olivroy #2150).
 
 # pkgdown 2.0.8
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `build_home()` no longer renders Github issue and pull request templates (@hsloot, #2362)
 * It is now easier to preview parts of the website locally interactively. `build_reference_index()` and friends will call `init_site()` internally instead of erroring (@olivroy, #2329).
 * Fixed an issue introduced in 2.0.8 where pkgdown was not using the Bootstrap version specified in a template package (@gadenbuie, #2443).
+* `check_pkgdown()` no longer errors if your intro vignette is an article (@olivroy #2150).
 
 # pkgdown 2.0.8
 

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -380,7 +380,9 @@ data_articles_index <- function(pkg = ".") {
     purrr::flatten_chr() %>%
     unique()
 
-  missing <- setdiff(pkg$vignettes$name, c(listed, pkg$package))
+  missing <- setdiff(pkg$vignettes$name, listed)
+  # Exclude get started vignette or article #2150
+  missing <- missing[!article_is_intro(missing, package = pkg$package)]
 
   if (length(missing) > 0) {
     cli::cli_abort(

--- a/man/rmd-fragments/navbar-configuration.Rmd
+++ b/man/rmd-fragments/navbar-configuration.Rmd
@@ -13,7 +13,7 @@ navbar:
 
 It makes use of the the six built-in components:
 
--   `intro`: "Get Started", which links to a vignette with the same name as the package[^dots].
+-   `intro`: "Get Started", which links to a vignette or article with the same name as the package[^dots].
 -   `reference`, if there are any `.Rd` files.
 -   `articles`, if there are any vignettes or articles.
 -   `tutorials`, if there any tutorials.


### PR DESCRIPTION
Addresses https://github.com/r-lib/pkgdown/issues/2150#issuecomment-2053756994 + amends #2161

Basically, this allows to omit `articles/packagename` from articles reference index.

I did some manual testing switching pkgdown.Rmd to articles/pkgdown.Rmd

The goal of this PR is to remove this line from `_pkgdown.yml` for leaflet.

https://github.com/rstudio/leaflet/blob/92bc272caa9a268140e75ede1966bcdc7d585636/pkgdown/_pkgdown.yml#L57

I didn't understand why I had to do this in leaflet when I created its pkgdown site, but after reading #2150, I understood that pkgdown could handle this more intuitively !

The advantage of this PR is also that possibly, packages with `.` in them will be better off (although I didn't test this)

With:
```r
article_is_intro
function(name, package) {
  package <- gsub(".", "-", package, fixed = TRUE)
  name %in% c(package, paste0("articles/", package))
}
```

and 

> Note that dots (`.`) in the package name need to be replaced by hyphens (`-`) in the vignette filename to be recognized as the intro. That means for a
    package `foo.bar` the intro needs to be named `foo-bar.Rmd`.
