### PR TITLE
Remove `<p>` from template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* The left and right footers no longer contain an extra empty paragraph tag and the footer gains additional padding-top to keep the whitespace constant (#2381).
 * `build_article_index()` and `build_reference_index()` use an improved BS5 template that correctly wraps each section description in a `<div>`, rather than a `<p>`. This eliminates an empty pargraph tag that preceded each section description (#2352).
 * `build_news()` now warns if it doesn't find any version headings, suggesting that that `NEWS.md` is structured incorrectly (#2213).
 * `build_article()` gains a new `new_process` argument which allows to build a vignette in the current process for debugging purposes. We've also improved the error messages and tracebacks if an article fails to build, hopefully also making debugging easier (#2438).

--- a/inst/BS5/assets/pkgdown.scss
+++ b/inst/BS5/assets/pkgdown.scss
@@ -165,6 +165,7 @@ $pkgdown-footer-border-width: $border-width !default;
 
 footer {
   margin: 1rem 0 1rem 0;
+  padding-top: 1rem;
   font-size: .875em;
   border-top: $pkgdown-footer-border-width solid $pkgdown-footer-border-color;
   background: $pkgdown-footer-bg;

--- a/inst/BS5/templates/footer.html
+++ b/inst/BS5/templates/footer.html
@@ -1,9 +1,9 @@
 {{#footer}}
 <div class="pkgdown-footer-left">
-  <p>{{#left}}{{{.}}}{{/left}}</p>
+  {{#left}}{{{.}}}{{/left}}
 </div>
 
 <div class="pkgdown-footer-right">
-  <p>{{#right}}{{{.}}}{{/right}}</p>
+  {{#right}}{{{.}}}{{/right}}
 </div>
 {{/footer}}


### PR DESCRIPTION
The footer markdown is processed with `markdown_text_block()` so it always produces a block tag, rendering the wrapping `<p>` in the footer unnecessary. The empty paragraph tag ends up at the top of the footer, due to xml2 round trip.

Fixes #2381

@gadenbuie: do you mind taking a quick look at this since it's related to the PR you just reviewed?