### PR TITLE
Work with empty markdown files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* `build_home()` no longer errors when you have an empty `.md` file (#2309).
 * The skip link now becomes visible when focussed (#2138). Thanks to @glin for the styles!
 * `build_reference_index()` gives more informative errors if your `contents` field is malformed (#2323).
 * The left and right footers no longer contain an extra empty paragraph tag and the footer gains additional padding-top to keep the whitespace constant (#2381).

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -38,6 +38,10 @@ markdown_text_block <- function(text, ...) {
 markdown_body <- function(path, strip_header = FALSE) {
   xml <- markdown_path_html(path, strip_header = strip_header)
 
+  if (is.null(xml)) {
+    return(NULL)
+  }
+
   # Extract body of html - as.character renders as xml which adds
   # significant whitespace in tags like pre
   transformed_path <- withr::local_tempfile()

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -4,6 +4,10 @@ test_that("handles empty inputs", {
 
   expect_equal(markdown_text_block(NULL), NULL)
   expect_equal(markdown_text_block(""), NULL)
+
+  path <- withr::local_tempfile()
+  file.create(path)
+  expect_equal(markdown_body(path), NULL)
 })
 
 test_that("header attributes are parsed", {


### PR DESCRIPTION
Fixes #2309

Rather than erroring, I just made it return nothing, which seems most consistent with the other ways we process markdown.