### PR TITLE
Don't globally change cli.default_handler for tests

### DIFF
--- a/tests/testthat/_snaps/build-articles.md
+++ b/tests/testthat/_snaps/build-articles.md
@@ -11,6 +11,7 @@
     Code
       build_articles(pkg, lazy = FALSE)
     Message
+      -- Building articles -----------------------------------------------------------
       Writing `articles/index.html`
       Reading vignettes/kitten.Rmd
       Writing `articles/kitten.html`
@@ -20,6 +21,7 @@
     Code
       build_articles(pkg)
     Message
+      -- Building articles -----------------------------------------------------------
       Writing `articles/index.html`
       Reading vignettes/html-vignette.Rmd
       Writing `articles/html-vignette.html`
@@ -112,6 +114,8 @@
 
     Code
       build_redirects(pkg)
+    Message
+      -- Building redirects ----------------------------------------------------------
 
 # pkgdown deps are included only once in articles
 

--- a/tests/testthat/_snaps/build-favicons.md
+++ b/tests/testthat/_snaps/build-favicons.md
@@ -2,6 +2,8 @@
 
     Code
       expect_output(build_favicons(pkg), "Building favicons")
+    Message
+      -- Building favicons -----------------------------------------------------------
     Condition
       Error in `build_favicons()`:
       ! Can't find package logo PNG or SVG to build favicons.
@@ -12,6 +14,7 @@
     Code
       build_favicons(pkg)
     Message
+      -- Building favicons -----------------------------------------------------------
       Favicons already exist in 'pkgdown'
       i Set `overwrite = TRUE` to re-create.
 

--- a/tests/testthat/_snaps/build-github.md
+++ b/tests/testthat/_snaps/build-github.md
@@ -3,6 +3,7 @@
     Code
       build_github_pages(pkg)
     Message
+      -- Extra files for GitHub pages ------------------------------------------------
       Writing `.nojekyll`
       Writing `CNAME`
 

--- a/tests/testthat/_snaps/build-home-citation.md
+++ b/tests/testthat/_snaps/build-home-citation.md
@@ -3,6 +3,7 @@
     Code
       build_home(pkg)
     Message
+      -- Building home ---------------------------------------------------------------
       Writing `authors.html`
       Writing `404.html`
 

--- a/tests/testthat/_snaps/build-home.md
+++ b/tests/testthat/_snaps/build-home.md
@@ -3,6 +3,7 @@
     Code
       build_home(pkg)
     Message
+      -- Building home ---------------------------------------------------------------
       Writing `authors.html`
       Writing `404.html`
 
@@ -11,6 +12,7 @@
     Code
       build_home(pkg)
     Message
+      -- Building home ---------------------------------------------------------------
       Writing `authors.html`
       Writing `404.html`
 
@@ -19,6 +21,7 @@
     Code
       build_home(pkg)
     Message
+      -- Building home ---------------------------------------------------------------
       Writing `authors.html`
     Condition
       Warning:
@@ -32,6 +35,7 @@
     Code
       build_home(pkg)
     Message
+      -- Building home ---------------------------------------------------------------
       Writing `authors.html`
       Writing `404.html`
 
@@ -40,6 +44,7 @@
     Code
       build_home(pkg)
     Message
+      -- Building home ---------------------------------------------------------------
       Writing `authors.html`
       Reading .github/404.md
       Writing `404.html`

--- a/tests/testthat/_snaps/build-news.md
+++ b/tests/testthat/_snaps/build-news.md
@@ -32,6 +32,7 @@
     Code
       build_news(pkg)
     Message
+      -- Building news ---------------------------------------------------------------
       Writing `news/news-2.0.html`
       Writing `news/news-1.1.html`
       Writing `news/news-1.0.html`

--- a/tests/testthat/_snaps/build-reference.md
+++ b/tests/testthat/_snaps/build-reference.md
@@ -3,6 +3,7 @@
     Code
       build_reference(pkg)
     Message
+      -- Building function reference -------------------------------------------------
       Writing `reference/index.html`
       Reading man/f.Rd
     Condition
@@ -17,6 +18,7 @@
     Code
       build_reference(pkg, topics = "e")
     Message
+      -- Building function reference -------------------------------------------------
       Writing `reference/index.html`
       Reading man/e.Rd
       Writing `reference/e.html`
@@ -26,6 +28,7 @@
     Code
       build_reference(pkg, topics = "e")
     Message
+      -- Building function reference -------------------------------------------------
       Writing `reference/index.html`
       Reading man/e.Rd
       Writing `reference/e.html`
@@ -35,6 +38,7 @@
     Code
       build_reference(pkg, topics = "a")
     Message
+      -- Building function reference -------------------------------------------------
       Writing `reference/index.html`
       Reading man/a.Rd
       Writing `reference/a.html`

--- a/tests/testthat/_snaps/figure.md
+++ b/tests/testthat/_snaps/figure.md
@@ -3,6 +3,7 @@
     Code
       build_reference(pkg, devel = FALSE)
     Message
+      -- Building function reference -------------------------------------------------
       Writing `reference/index.html`
       Reading man/figure.Rd
       Writing `reference/figure.html`
@@ -12,6 +13,7 @@
     Code
       build_articles(pkg)
     Message
+      -- Building articles -----------------------------------------------------------
       Writing `articles/index.html`
       Reading vignettes/figures.Rmd
       Writing `articles/figures.html`

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,0 @@
-# suppress cli messages in interactive testthat output
-# https://github.com/r-lib/cli/issues/434
-options(cli.default_handler = function(...) { })


### PR DESCRIPTION
I removed this primarily because it globally suppresses cli output after you run any test file interactively, but IMO it also increases the fidelity of the snapshots.