### PR TITLE
fix(template.bslib): Support bootswatch item

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,85 +13,85 @@
 * Fixes for regressions in 2.0.8:
 
   * Output links generated when building the site work once again (#2435).
-
-  * pkgdown once again uses Bootstrap version specified in a template
+  
+  * pkgdown once again uses Bootstrap version specified in a template 
     package (@gadenbuie, #2443).
 
 * Front-end improvements:
 
-  * The skip link now becomes visible when focussed (#2138). Thanks to @glin
+  * The skip link now becomes visible when focussed (#2138). Thanks to @glin 
     for the styles!
 
-  * The left and right footers no longer contain an extra empty paragraph tag
-    and the footer gains additional padding-top to keep the whitespace constant
+  * The left and right footers no longer contain an extra empty paragraph tag 
+    and the footer gains additional padding-top to keep the whitespace constant 
     (#2381).
 
   * Clipboard buttons report their action again ("Copied!") (#2462)
 
-* It is now easier to preview parts of the website locally interactively.
+* It is now easier to preview parts of the website locally interactively. 
   `build_reference_index()` and friends will call `init_site()` automatically
   instead of erroring (@olivroy, #2329).
 
 * `build_article()` gains a new `new_process` argument which allows to build a
-   vignette in the current process for debugging purposes. We've also improved
-   the error messages and tracebacks if an article fails to build, hopefully
+   vignette in the current process for debugging purposes. We've also improved 
+   the error messages and tracebacks if an article fails to build, hopefully 
    also making debugging easier (#2438).
 
-* `build_article_index()` and `build_reference_index()` use an improved BS5
-  template that correctly wraps each section description in a `<div>`, rather
-  than a `<p>`. This eliminates an empty pargraph tag that preceded each section
+* `build_article_index()` and `build_reference_index()` use an improved BS5 
+  template that correctly wraps each section description in a `<div>`, rather 
+  than a `<p>`. This eliminates an empty pargraph tag that preceded each section 
   description (#2352).
 
 * `build_home()` no longer errors when you have an empty `.md` file (#2309).
-  It alos no longer renders Github issue and pull request templates
+  It alos no longer renders Github issue and pull request templates 
   (@hsloot, #2362)
 
-* `build_news()` now warns if it doesn't find any version headings, suggesting
+* `build_news()` now warns if it doesn't find any version headings, suggesting 
   that that `NEWS.md` is structured incorrectly (#2213).
 
-* `build_readme()` now correctly tweaks links to markdown files that use an
+* `build_readme()` now correctly tweaks links to markdown files that use an 
   anchor, e.g. `foo.md#heading-name` (#2313).
 
-* `build_reference_index()` gives more informative errors if your `contents`
+* `build_reference_index()` gives more informative errors if your `contents` 
   field is malformed (#2323).
 
-* `check_pkgdown()` no longer errors if your intro vignette is an article is
+* `check_pkgdown()` no longer errors if your intro vignette is an article is 
   not listed in `_pkgdown.yml` (@olivroy #2150).
 
 * `data_template()` gives a more informative error if you've misspecified the navbar (#2312).
 
 # pkgdown 2.0.8
 
-* pkgdown is now compatible with (and requires) bslib >= 0.5.1
-  (@gadenbuie, #2395), including a fix to BS5 navbar template to get
+* pkgdown is now compatible with (and requires) bslib >= 0.5.1 
+  (@gadenbuie, #2395), including a fix to BS5 navbar template to get 
   `navbar.type: dark` to work with Bootstrap 5.3+ (@tanho63, #2388)
 
-* Now uses [cli](https://github.com/r-lib/cli) to provide interactive feedback.
+* Now uses [cli](https://github.com/r-lib/cli) to provide interactive feedback. 
 
 * Avoid unwanted linebreaks from parsing `DESCRIPTION` (@salim-b, #2247).
 
-* Translations
-  * New Catalan translation (@jmaspons, #2333).
+* Translations  
+  * New Catalan translation (@jmaspons, #2333). 
   * Citation sections are correctly translated (@eliocamp, #2410).
 
-* `build_article_index()` now sorts vignettes and non-vignette articles
-   alphabetically by their filename (literally, their `basename()`), by default
+* `build_article_index()` now sorts vignettes and non-vignette articles 
+   alphabetically by their filename (literally, their `basename()`), by default 
    (@jennybc, #2253).
 
 * Deprecated `build_favicon()` was removed (`build_favicons()` remains).
 
-* `build_articles()` now sets RNG seed by default. Use
-  `build_articles(seed = NULL)` for the old (unreproducible) behaviour.
+* `build_articles()` now sets RNG seed by default. Use 
+  `build_articles(seed = NULL)` for the old (unreproducible) behaviour. 
   (@salim-b, #2354).
 
 * `build_articles()` will process `.qmd` articles with the quarto vignette
   builder (@rcannood, #2404).
 
-* `build_articles()` and `build_reference()` now set RNG seed for htmlwidgets
-  IDs. This reduces noise in final HTML output, both for articles and examples
+* `build_articles()` and `build_reference()` now set RNG seed for htmlwidgets 
+  IDs. This reduces noise in final HTML output, both for articles and examples 
   that contain htmlwidgets (@salim-b, #2294, #2354).
 
-* `build_news()` correctly parses  of github profiles and issues into links
+* `build_news()` correctly parses  of github profiles and issues into links 
   when present at the beginning of list items (@pearsonca, #2122)
 
 * `build_reference()` sets `seed` correctly; it was previously reset too early
@@ -102,16 +102,16 @@
   * Correct usage for S3 methods with non-syntactic class names (#2384).
   * Preserve Markdown code blocks with class rmd from roxygen2 docs (@salim-b, #2298).
 
-* `build_reference_index()` no longer generates redundant entries when multiple
+* `build_reference_index()` no longer generates redundant entries when multiple 
   explicit `@usage` tags are provided (@klmr, #2302)
 
-* `build_reference_index()` correctly handles topic names that conflict with
+* `build_reference_index()` correctly handles topic names that conflict with 
   selector functions (@dmurdoch, #2397).
 
 # pkgdown 2.0.7
 
 * Fix topic match selection when there is an unmatched selection followed by a matched selection (@bundfussr, #2234)
-* Fix highlighting of nested not R code blocks (for instance, example of R
+* Fix highlighting of nested not R code blocks (for instance, example of R 
 Markdown code with chunks) (@idavydov, #2237).
 * Tweak German translation (@krlmlr, @mgirlich, @lhdjung, #2149, #2236)
 * Remove mention of (defunct) Twitter card validator, provide alternatives (@Bisaloo, #2185)
@@ -127,23 +127,23 @@ Markdown code with chunks) (@idavydov, #2237).
   (#2150).
 
 * If there aren't any functions in the `\usage{}` block, then pkgdown will
-  now shows all aliases on the reference index, rather than just the topic
+  now shows all aliases on the reference index, rather than just the topic 
   name (#1624).
 
 # pkgdown 2.0.5
 
-* Correctly generate downlit link targets for topics that have a file name
+* Correctly generate downlit link targets for topics that have a file name 
   ending in `.` (#2128).
 
 * `build_articles()`: if build fails because the index doesn't include all
   articles, you're now told what articles are missing (@zkamvar, #2121).
 
 * `build_home()` now escapes angle brackets in author comments(#2127).
-
+  
 * `build_home()` will automatically render and link `.github/SUPPORT.md`
   (@IndrajeetPatil, #2124).
 
-* `build_news()` once again fails to link `@username` at start of
+* `build_news()` once again fails to link `@username` at start of 
   bullet. I had to reverted #2030 because of #2122.
 
 * `build_reference()`: restore accidentally nerfed `has_keyword()` and
@@ -151,25 +151,25 @@ Markdown code with chunks) (@idavydov, #2237).
 
 # pkgdown 2.0.4
 
-* New `check_pkgdown()` provides a lightweight way to check that your
-  `_pkgdown.yml` is valid without building the site (#2056). Invalid
+* New `check_pkgdown()` provides a lightweight way to check that your 
+  `_pkgdown.yml` is valid without building the site (#2056). Invalid 
   `_pkgdown.yml` now consistently generates errors both locally and on
   CI (#2055).
 
 * `build_article()` now supports inline markdown in the `title` (#2039).
 
-* `build_home()` no longer shows development status badges on the released
+* `build_home()` no longer shows development status badges on the released 
   version of the site (#2054).
 
 * `build_news()` support automated `@username` links in more places (#2030).
 
-* `build_reference()`:
+* `build_reference()`: 
 
-    * You can once again exclude topics from the reference index with `-` (#2040).
+    * You can once again exclude topics from the reference index with `-` (#2040). 
 
-    * Inline markdown in `title`s and `subtitle`s is now supported(#2039).
+    * Inline markdown in `title`s and `subtitle`s is now supported(#2039). 
 
-    * Package logos will be automatically stripped from the `.Rd` you don't end
+    * Package logos will be automatically stripped from the `.Rd` you don't end 
       up with two on one page. (#2083).
 
     * `\figure{file}{alternative text}` with multiline alt text is now parsed
@@ -192,7 +192,7 @@ Markdown code with chunks) (@idavydov, #2237).
 
     * Navbar components now accept `target` argument (#2089, @JSchoenbachler).
 
-* New syntax highlighting themes a11y-light, a11y-dark, monochrome-light,
+* New syntax highlighting themes a11y-light, a11y-dark, monochrome-light, 
   monochrome-dark, and solarized
 
 # pkgdown 2.0.3
@@ -204,8 +204,8 @@ Markdown code with chunks) (@idavydov, #2237).
 * New Korean (`ko`) translation thanks to @mrchypark and @peremen (#1944).
   New Danish (`dk`) translation thanks to @LDalby.
 
-* `build_articles()` now adjusts the heading levels of vignettes/articles that
-  use `<h1>` as section headings to ensure that there's one top-level heading
+* `build_articles()` now adjusts the heading levels of vignettes/articles that 
+  use `<h1>` as section headings to ensure that there's one top-level heading 
   (#2004). This ensures that there's one `<h1>`, the title, on each page,
   and makes the TOC in the sidebar work correctly.
 
@@ -215,11 +215,11 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * `build_news()` once again works if `NEWS.md` uses `<h1>` headings (#1947).
 
-* `build_reference()` now correctly interprets `title: internal`: it removes
-  the section from the reference index _and_ it doesn't list the topics in that
+* `build_reference()` now correctly interprets `title: internal`: it removes 
+  the section from the reference index _and_ it doesn't list the topics in that 
   section as missing (#1958).
 
-* `build_reference()` now gives a correct hint when the reference index YAML
+* `build_reference()` now gives a correct hint when the reference index YAML 
   is not formatted correctly (e.g. empty item, or item such as "n" that needs
   to be escaped with quotes to not be interpreted as Boolean) (#1995).
 
@@ -231,16 +231,16 @@ Markdown code with chunks) (@idavydov, #2237).
     * The navbar gets a little more space after the version number, and aligns
       the baseline with rest of the navbar (#1989).
 
-    * Long lines in code output once again scroll, rather than being wrapped.
+    * Long lines in code output once again scroll, rather than being wrapped. 
       While this is different to what you'll see in the console, it's a better
-      fit for web pages where the available code width varies based on the
+      fit for web pages where the available code width varies based on the 
       browser width (#1940).
-
-    * scrollspy (which highlights the "active" heading in the sidebar) now
-      computes the offset dynamically which makes it work better on sites with
+    
+    * scrollspy (which highlights the "active" heading in the sidebar) now 
+      computes the offset dynamically which makes it work better on sites with 
       taller navbars (#1993).
 
-    * Fixed js issues that occurred on pages without a table of contents
+    * Fixed js issues that occurred on pages without a table of contents 
       (@gadenbuie, #1998).
 
     * When htmlwidgets with jQuery or Bootstrap dependencies are used in examples or
@@ -248,7 +248,7 @@ Markdown code with chunks) (@idavydov, #2237).
       the versions used by the htmlwidget (@gadenbuie, #1997).
 
 * pkgdown no longer includes bundled author metadata for Hadley Wickham,
-  RStudio, or the RConsortium, since there are now ways to include this
+  RStudio, or the RConsortium, since there are now ways to include this 
   meta data in template packages, and special casing these three entities
   feels increasingly weird (#1952).
 
@@ -272,111 +272,111 @@ Markdown code with chunks) (@idavydov, #2237).
 ## Bootstrap 5
 
 * pkgdown can style your site with Bootstrap 5 (with help from @jayhesselberth,
-  @apreshill, @cpsievert). Opt-in by setting `boostrap` version in your
+  @apreshill, @cpsievert). Opt-in by setting `boostrap` version in your 
   `_pkgdown.yml`:
-
+  
     ```yaml
     template:
       bootstrap: 5
     ```
 
-* We reviewed site accessibility and made a number of small improvements:
+* We reviewed site accessibility and made a number of small improvements: 
   (#782, #1553):
 
     * Default font is larger and links are always underlined.
     * Heading anchors use `aria-hidden` to reduce noise for screenreader users.
     * Navbar dropdowns has improved `aria-labelledby`.
-    * The default GitHub/GitLab links gain an `aria-label`; use for other
+    * The default GitHub/GitLab links gain an `aria-label`; use for other 
       icons is now supported, and encouraged in the docs.
     * Syntax highlighting uses a new more
-      [accessible colour scheme](https://apreshill.github.io/rmda11y/arrow.html),
+      [accessible colour scheme](https://apreshill.github.io/rmda11y/arrow.html), 
       designed by Alison Hill (#1536)
     * A skip link makes it easier to get directly to the page contents (#1827).
 
-* In-line footnotes mean you can read asides next to the text they refer to.
+* In-line footnotes mean you can read asides next to the text they refer to. 
 
 * Articles support tabsets,
   [as in R Markdown](https://bookdown.org/yihui/rmarkdown-cookbook/html-tabs.html).
   (@JamesHWade, #1667).
 
 * Other minor styling improvements:
-
+    
     * The active item in TOC is indicated with background colour, rather than
       a border.
     * If present, the package logo is shown on all pages near the header.
-    * Section anchors now appear on the right (making them usable on mobile
+    * Section anchors now appear on the right (making them usable on mobile 
       phones) (#1782).
     * The TOC is scrollable independently of the main content. This makes it
       more useful on long pages with many headings (#1610).
     * The sidebar is shown at the bottom of the page on narrow screens.
-    * Function arguments and the reference index (#1822) use definition lists
-      (`<dl>`) instead of tables. This gives more room for long argument
-      names/lists of function and detailed descriptions, and displays better
+    * Function arguments and the reference index (#1822) use definition lists 
+      (`<dl>`) instead of tables. This gives more room for long argument 
+      names/lists of function and detailed descriptions, and displays better 
       on mobile.
     * Links on the homepage no longer show the full url in the text.
-    * The default navbar no longer includes a home icon - this took up
-      precious horizontal space and wasn't very useful since there was already
+    * The default navbar no longer includes a home icon - this took up 
+      precious horizontal space and wasn't very useful since there was already 
       a link to the home page immediately to its left (#1383).
 
 ## Local search
 
-* pkgdown now supports local searching (i.e. searching without an external
-  service), and is enabled by default for Bootstrap 5 sites since no set-up is
-  needed (#1629, with help from @gustavdelius in #1655 and @dieghernan &
+* pkgdown now supports local searching (i.e. searching without an external 
+  service), and is enabled by default for Bootstrap 5 sites since no set-up is 
+  needed (#1629, with help from @gustavdelius in #1655 and @dieghernan & 
   @GregorDeCillia in #1770).
 
-* pkgdown builds a more exhaustive `sitemap.xml` even for websites built with
-  Bootstrap 3. This might change Algolia results if you use Algolia for search
+* pkgdown builds a more exhaustive `sitemap.xml` even for websites built with 
+  Bootstrap 3. This might change Algolia results if you use Algolia for search 
   (#1629).
 
 ## Customisation
 
-* New `vignette("customise")` documents all the ways you can customise your
+* New `vignette("customise")` documents all the ways you can customise your 
   site, including the new options described below (#1573).
 
 * Sites can be easily themed with either bootswatch themes or by selectively
-  overriding the `bslib` variables used to generate the CSS. pkgdown now uses
-  scss for its own Bootstrap css tweaks, which means that you can customise
+  overriding the `bslib` variables used to generate the CSS. pkgdown now uses 
+  scss for its own Bootstrap css tweaks, which means that you can customise 
   more of the site from within `_pkgdown.yml`.
 
 * You can pick from a variety of built-in syntax highlighting themes (#1823).
   These control the colours (and background) of code in `<pre>` tags.
 
-* pkgdown can now translate all the text that it generates (#1446): this means
-  that if you have a package where the docs are written in another language, you
+* pkgdown can now translate all the text that it generates (#1446): this means 
+  that if you have a package where the docs are written in another language, you 
   can match all the pkgdown UI to provide a seamless experience to non-English
   speakers. Activate the translations by setting the `lang` in `_pkgdown.yml`:
-
+   
     ```yaml
     lang: fr
     ```
-
+    
     pkgdown includes translations for:
-
+    
     * `es`, Spanish, thanks to @edgararuiz-zz, @dieghernan, @rivaquiroga.
     * `de`, German, thanks to @hfrick.
     * `fr`, French, thanks to @romainfrancois, @lionel-, @jplecavalier, and @maelle.
     * `pt`, Portuguese, thanks to @rich-iannone.
     * `tr`, Turkish, thanks to @mine-cetinkaya-rundel.
     * `zh_CN`, simplified Chinese, thanks to @yitao.
-
+  
     If you're interested in adding translations for your language please file
     an issue and we'll help you get started.
-
+  
 * Template packages can now provide `inst/pkgdown/_pkgdown.yml` which is used
-  as a set of defaults for `_pkgdown.yml`. It can be used to (e.g.) provide
-  author definitions, select Bootstrap version and define bslib variables,
+  as a set of defaults for `_pkgdown.yml`. It can be used to (e.g.) provide 
+  author definitions, select Bootstrap version and define bslib variables, 
   and customise the sidebar, footer, navbar, etc. (#1499).
 
-* New `includes` parameters `in-header`, `before-body`, and `after-body`
-  make it easy to add arbitrary HTML to every page. Their content will be
-  placed at the end of the `<head>` tag, right below the opening `<body>` tag,
-  and before the closing tag `</body>` respectively (#1487). They match the
+* New `includes` parameters `in-header`, `before-body`, and `after-body` 
+  make it easy to add arbitrary HTML to every page. Their content will be 
+  placed at the end of the `<head>` tag, right below the opening `<body>` tag, 
+  and before the closing tag `</body>` respectively (#1487). They match the 
   bookdown options `in_header`, `before_body` and `after_body`.
-
+  
     Additionally, you can use `before_title`, `before_navbar`, and
     `after_navbar` to add arbitrary HTML into the navbar/page header; they
-    will appear to the left of the package name/version, and to the left and
+    will appear to the left of the package name/version, and to the left and 
     right of the navigation links respectively (#1882).
 
 * Authors configuration is more flexible (#1516). You can now:
@@ -392,14 +392,14 @@ Markdown code with chunks) (@idavydov, #2237).
     * Add custom sidebar sections (with Markdown/HTML `text`).
     * Add a table of contents to the home page.
     * Completely suppress the sidebar.
-    * Provide your own HTML for the navbar.
+    * Provide your own HTML for the navbar. 
 
 * Footer specification is more flexible (#1502). You can now:
-
+    
     * Change the placement of elements on the left and right.
     * Add text to the left and right (or even remove/replace default text)
-
-* You can now exclude all default components from the navbar (#1517).
+    
+* You can now exclude all default components from the navbar (#1517). 
 
 * Expert users can now override layout templates provided by pkgdown or template
   packages by placing template files in `pkgdown/templates` (@gadenbuie, #1897).
@@ -407,7 +407,7 @@ Markdown code with chunks) (@idavydov, #2237).
 ## New features
 
 * pkgdown now supports redirects (#1259, @lorenzwalthert). The following yaml
-  demonstrates the syntax, with old paths on the left and new paths/URLs on
+  demonstrates the syntax, with old paths on the left and new paths/URLs on 
   the right.
 
   ```yaml
@@ -417,9 +417,9 @@ Markdown code with chunks) (@idavydov, #2237).
     - ["articles/yet-another-old-vignette-name.html", "https://pkgdown.r-lib.org/dev"]
   ```
 
-* Use HTML classes `pkgdown-devel` or `pkgdown-release` to declare that certain
+* Use HTML classes `pkgdown-devel` or `pkgdown-release` to declare that certain 
   content should appear only on the devel or release site. Use the class
-  `pkgdown-hide` for content that should only appear only on GitHub/CRAN
+  `pkgdown-hide` for content that should only appear only on GitHub/CRAN 
   (#1299).
 
 * New `pkgdown_sitrep()` function reports whether the site is set up correctly;
@@ -427,34 +427,34 @@ Markdown code with chunks) (@idavydov, #2237).
 
 ## Code
 
-* Styling for errors, warnings, and messages has been tweaked. Messages
+* Styling for errors, warnings, and messages has been tweaked. Messages 
   are now displayed the same way as output, and warnings and errors are
   bolded, not coloured. This is part of a suite of changes that aim to
-  give package authors greater control over the appearance of messages,
-  warnings, and errors.
+  give package authors greater control over the appearance of messages, 
+  warnings, and errors. 
 
 * Long lines in code output are now wrapped, rather than requiring scrolling.
-  This better matches `rmarkdown::html_document()` and what you see in the
+  This better matches `rmarkdown::html_document()` and what you see in the 
   console.
-
-* `build_reference()` now allows linking to topics from other packages (either
-  function names e.g. `rlang::is_installed` or topic names e.g.
+  
+* `build_reference()` now allows linking to topics from other packages (either 
+  function names e.g. `rlang::is_installed` or topic names e.g. 
   `sass::font_face`). (#1664)
 
-* `build_reference()` now runs examples with
-  `options(rlang_interactive = FALSE)` (ensuring non-interactive behaviour in
-  functions that use `rlang::is_interactive()`), `options(cli.dynamic = FALSE)`,
+* `build_reference()` now runs examples with 
+  `options(rlang_interactive = FALSE)` (ensuring non-interactive behaviour in 
+  functions that use `rlang::is_interactive()`), `options(cli.dynamic = FALSE)`, 
   `Sys.setenv(RSTUDIO = NA)` and `Sys.setLocale("LC_COLLATE", "C")` (#1693).
-  It also runs `pkgdown/pre-reference.R` before and `pkgdown/post-reference.R`
-  after examples. These allow you to do any setup or teardown operations you
+  It also runs `pkgdown/pre-reference.R` before and `pkgdown/post-reference.R` 
+  after examples. These allow you to do any setup or teardown operations you 
   might need (#1602).
 
 * A reference index section with `title: internal` is now silently dropped,
   allowing you to suppress warnings about topics that are not listed in the
   index (#1716).
 
-* Code blocks are now highlighted according to their declared language
-  (e.g. `yaml`) if the documentation was built with roxygen2 7.1.2 or later
+* Code blocks are now highlighted according to their declared language 
+  (e.g. `yaml`) if the documentation was built with roxygen2 7.1.2 or later 
   (#1690, #1692).
 
 * New `pkgdown_print()` allows you to control how your objects are rendered in
@@ -465,7 +465,7 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * You can globally set the `width` of code output (in reference and articles)
   with
-
+    
     ```yaml
     code:
       width: 50
@@ -478,18 +478,18 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * Auto-linking improvements:
 
-  * Links to inherited R6 methods now work correctly for both internal
+  * Links to inherited R6 methods now work correctly for both internal 
     (#1173, @vandenman) and external (#1476) parent classes.
-
+    
   * Linking no longer fails if a package contains duplicated Rd aliases.
-
+  
   * Correctly link to reference pages when the `\name{}` entry doesn't match
     the file name (@dmurdoch, #1586; #1676).
 
 ## Articles
 
-* Article subtitle, author and date (specified in the YAML frontmatter) are now
-  correctly omitted from the article table of contents in the sidebar
+* Article subtitle, author and date (specified in the YAML frontmatter) are now 
+  correctly omitted from the article table of contents in the sidebar 
   (@maxheld83, #1428).
 
 * Support for `as_is: true` and non-default output formats for vignettes/
@@ -498,18 +498,18 @@ Markdown code with chunks) (@idavydov, #2237).
   know about, but it should be a little more reliable and a little better
   documented (#1757, #1764).
 
-* `build_articles()` no longer fails if you have a directory underneath
+* `build_articles()` no longer fails if you have a directory underneath 
   vignettes with a `.Rmd` extension (#1425).
 
 * `build_articles()` now correctly handles links to images in `man/figures`
   (which have the form `../man/figures`) (#1472).
 
-* `build_articles()` again sets the `theme` argument of the document format
+* `build_articles()` again sets the `theme` argument of the document format 
   to `NULL` when `as_is: true` but lets users override this via the `theme`
   argument of the output format.
 
-* `build_articles()` and `build_home()` now warn if you have images that
-  won't render on the website because they're in unsupported directories
+* `build_articles()` and `build_home()` now warn if you have images that 
+  won't render on the website because they're in unsupported directories 
   (#1810). Generally, it's only safe to refer to figures in `man/figures`
   and `vignettes`.
 
@@ -520,14 +520,14 @@ Markdown code with chunks) (@idavydov, #2237).
 
 ## HTML, CSS and JS
 
-* New `template` option `trailing_slash_redirect` that allows adding a script to
-  redirect `your-package-url.com` to `your-package-url.com/` (#1439, @cderv,
+* New `template` option `trailing_slash_redirect` that allows adding a script to 
+  redirect `your-package-url.com` to `your-package-url.com/` (#1439, @cderv, 
   @apreshill).
 
-* External links now get the class `external-link`. This makes them easier to
+* External links now get the class `external-link`. This makes them easier to 
   style with CSS (#881, #1491).
 
-* Duplicated section ids are now de-duplicated; this makes pkgdown work better
+* Duplicated section ids are now de-duplicated; this makes pkgdown work better 
   with the documentation of R6 classes.
 
 * Updated CSS styles from pandoc to improve styling of reference lists (#1469).
@@ -540,60 +540,60 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * `deploy_to_branch()` now calls `git remote set-branches` with `--add` to avoid
   overwriting the existing `remote.{remote}.fetch` value (@kyleam, #1382).
-  It also now cleans out the website directory by default; revert to previous
+  It also now cleans out the website directory by default; revert to previous 
   behaviour with `clean = FALSE` (#1394).
 
 * `build_reference()` will error if envar `CI` is `true` and there are missing
   topics (@ThierryO, #1378).
 
-* You can override the `auto` development mode detected from the package
+* You can override the `auto` development mode detected from the package 
   version by setting env var `PKGDOWN_DEV_MODE` to `release` or `devel`.
   This is useful if your package uses a different convention to indicate
   development and release versions (#1081).
 
-## Other minor improvements and bug fixes
+## Other minor improvements and bug fixes 
 
 * `\special{}` tags with complex contents are rendered correctly (@klmr, #1744).
 
-* `\arguments{}` and `\value{}` do a better job of handling mingled items and
-  text (#1479). The contents of `\value{}` are now shown immediately after
+* `\arguments{}` and `\value{}` do a better job of handling mingled items and 
+  text (#1479). The contents of `\value{}` are now shown immediately after 
   `\arguments{}`.
 
-* The default "branch" for linking to the file sources is `HEAD`, which will
+* The default "branch" for linking to the file sources is `HEAD`, which will 
   work regardless of whether your default branch is called "main" or "master".
 
-* Non-ORCID comments in `Authors@R` are now more usable: if such comments
-  exist, the sidebar gains a link to the authors page, where they are displayed
+* Non-ORCID comments in `Authors@R` are now more usable: if such comments 
+  exist, the sidebar gains a link to the authors page, where they are displayed 
   (#1516).
 
-* Citations with and without text versions are better handled, and text
+* Citations with and without text versions are better handled, and text 
   citations are correctly escaped for HTML (@bastistician, #1507).
 
-* README badges in a single paragraph placed between `<!-- badges: end -->`and
-  `<!-- badges: end -->` comments are again detected (#1603).
+* README badges in a single paragraph placed between `<!-- badges: end -->`and 
+  `<!-- badges: end -->` comments are again detected (#1603). 
 
-* The 404 page (default or from `.github/404.md`) is no longer built in the
-  development mode (see `?build_site`) as e.g. GitHub pages only uses the
+* The 404 page (default or from `.github/404.md`) is no longer built in the 
+  development mode (see `?build_site`) as e.g. GitHub pages only uses the 
   `404.html` in the site root (#1622).
 
-* All links on the 404 pages (navbar, scripts, CSS) are now absolute if there
+* All links on the 404 pages (navbar, scripts, CSS) are now absolute if there 
   is an URL in the configuration file (#1622).
 
-* The version tooltip showed in the top navbar is now only set if you've
+* The version tooltip showed in the top navbar is now only set if you've 
   explicitly set the `development.mode` in `_pkgdown.yml` (#1768).
 
-* All heading (e.g. headings on the reference index page, and the arguments
+* All heading (e.g. headings on the reference index page, and the arguments 
   heading on the reference pages) now get anchors (#1747).
 
 * Use `autolink_bare_uris` for Pandoc above version 2.0 (@marcosmolla, #1618).
 
-* pkgdown now recognizes GitLab URLs to the source repository and adds the
-  corresponding icon to the navbar (#1493). It also supports
+* pkgdown now recognizes GitLab URLs to the source repository and adds the 
+  corresponding icon to the navbar (#1493). It also supports 
   [GitLab subgroups](https://docs.gitlab.com/ee/user/group/subgroups/)
   (@salim-b, #1532).
 
-* Links for GitHub Enterprise and GitLab Enterprise repositories are detected
-  by assuming such host address begin with `github.` or `gitlab.`
+* Links for GitHub Enterprise and GitLab Enterprise repositories are detected 
+  by assuming such host address begin with `github.` or `gitlab.` 
   (@ijlyttle, #1452).
 
 * The rules drawn by the CLI (as for example, in `build_site()`) are protected
@@ -602,7 +602,7 @@ Markdown code with chunks) (@idavydov, #2237).
 * Google Site Verification (https://support.google.com/webmasters/answer/9008080?hl=en)
   can now be configured for pkgdown sites.
 
-* `build_rmarkdown_format` sets `html_document(anchor_sections = FALSE)`
+* `build_rmarkdown_format` sets `html_document(anchor_sections = FALSE)` 
    to avoid needless dependencies (@atusy, #1426).
 
 * Jira issues in NEWS can be automatically linked by setting your project name
@@ -610,27 +610,27 @@ Markdown code with chunks) (@idavydov, #2237).
   `repo: url: issue: ...` in `_pkgdown.yml` (@jonkeane, #1466).
 
 * `build_home()` always creates citation information for the authors page,
-  using metadata from `DESCRIPTION` when there is no `inst/CITATION` file,
+  using metadata from `DESCRIPTION` when there is no `inst/CITATION` file, 
   and links to this from the sidebar (#1904).
 
-* `build_news()` no longer breaks with URLs containing numeric fragments
+* `build_news()` no longer breaks with URLs containing numeric fragments 
   (@krassowski, #1456), recognises more styles of release heading (#1437),
-  and generate stable IDs using a the combination of the heading slug and
+  and generate stable IDs using a the combination of the heading slug and 
   package number. (@Bisaloo, #1015)
 
 # pkgdown 1.6.1
 
-* The article index (used for autolinking vignettes across packages)
+* The article index (used for autolinking vignettes across packages) 
   once again works (#1401).
 
 # pkgdown 1.6.0
 
 ## Major changes
 
-* pkgdown now uses the new [downlit](https://downlit.r-lib.org/) package for all
-  syntax highlighting and autolinking (in both reference topics and vignettes).
-  There should be very little change in behaviour because the code in downlit
-  was extracted from pkgdown, but this makes it easier to use pkgdown's nice
+* pkgdown now uses the new [downlit](https://downlit.r-lib.org/) package for all 
+  syntax highlighting and autolinking (in both reference topics and vignettes). 
+  There should be very little change in behaviour because the code in downlit 
+  was extracted from pkgdown, but this makes it easier to use pkgdown's nice 
   linking/highlighting in more places (#1234).
 
 * pkgdown now uses the `ragg::agg_png()` device to generate example figures.
@@ -645,19 +645,19 @@ Markdown code with chunks) (@idavydov, #2237).
   syntax (@klmr, #1345).
 
 * `#ifdef` and `#ifndef` are now supported; the "current" OS is hard coded to
-  "unix" to ensure reproducible output regardless of where you build the
+  "unix" to ensure reproducible output regardless of where you build the 
   website (#1384).
 
-* Nested `\subsection{}`s now generate appropriate heading levels
+* Nested `\subsection{}`s now generate appropriate heading levels 
   (h3, h4, h5 etc) (#1377), and get anchor links (#1389).
 
 * `\preformatted{}` no longer double escapes its contents (#1311).
 
 ### Articles and vignettes
 
-* `build_articles()` no longer sets the `theme` argument of the document format
+* `build_articles()` no longer sets the `theme` argument of the document format 
   to `NULL` when `as_is: true`. This should allow it to work with a wider
-  range of output formats including `bookdown::html_vignette2()` and
+  range of output formats including `bookdown::html_vignette2()` and 
   friends (@GegznaV, #955, #1352).
 
 * When `build_article()` fails, it gives the complete failure message (#1379).
@@ -666,7 +666,7 @@ Markdown code with chunks) (@idavydov, #2237).
 
 ### Auto-linking and syntax highlighting
 
-* The branch used for source linking can be configured by setting
+* The branch used for source linking can be configured by setting 
   `repo: branch: branch_name` in `_pkgdown.yml` (@jonkeane, #1355):
 
     ```yaml
@@ -674,17 +674,17 @@ Markdown code with chunks) (@idavydov, #2237).
       branch: main
     ```
 
-* `autolink_html()` is (soft) deprecated. Please use
+* `autolink_html()` is (soft) deprecated. Please use 
   `downlit::downlit_html_path()` instead.
 
 * Highlighting of empty expressions works once more (#1310).
 
 * New `deploy$install_metadata` option in `_pkgdown.yml`. Setting it to
   `true` will store site metadata in the package itself, allowing offline
-  access for packages that to autolink to the package's website
+  access for packages that to autolink to the package's website 
   (@mstr3336, #1336).
 
-### Other
+### Other    
 
 * You can now control the background colour of plots with the `figures.bg`
   option (it is transparent by default, and given a white background by
@@ -696,22 +696,22 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * All HTTP requests are now retried upon failure (@jameslamb, #1305).
 
-* Setting `clean = TRUE` in `deploy_site_github()` removes old files from the
+* Setting `clean = TRUE` in `deploy_site_github()` removes old files from the 
   deployed site before building a new one (#1297).
 
 # pkgdown 1.5.1
 
 * Syntax highlighting works on Windows once more (#1282).
 
-* pkgdown no longer fails if your `.Rd` files have duplicated `\aliases`
+* pkgdown no longer fails if your `.Rd` files have duplicated `\aliases` 
   as were produced by an older version of roxygen2 (#1290).
 
 * Rendering empty `.md` file now returns empty string (#1285).
 
 * `build_articles_index()` is now exported to rapidly rebuild the index (#1281)
 
-* `deploy_site_github()` now accepts a `host` argument to specify alternate
-  hosts (e.g., Github enterprise) (@dimagor, #1165) and once again works as
+* `deploy_site_github()` now accepts a `host` argument to specify alternate 
+  hosts (e.g., Github enterprise) (@dimagor, #1165) and once again works as 
   intended on Travis-CI (@jimhester, #1276).
 
 # pkgdown 1.5.0
@@ -722,8 +722,8 @@ Markdown code with chunks) (@idavydov, #2237).
   major new features in this release:
 
     * The articles index page now displays article `description`s,
-      taken from YAML metadata belonging to each article. This lets you provide
-      more context about each article and describe why one might want to read
+      taken from YAML metadata belonging to each article. This lets you provide 
+      more context about each article and describe why one might want to read 
       it (#1227).
 
     * The articles navbar is now also controlled by the `articles` section
@@ -739,7 +739,7 @@ Markdown code with chunks) (@idavydov, #2237).
   [bootstrap-toc](https://afeld.github.io/bootstrap-toc/); this considerably
   improves navigation for long articles and reference pages.
 
-* You can now control the links to source files (in reference pages and
+* You can now control the links to source files (in reference pages and 
   articles) and issues and users (in the NEWS) with new `repo$url` config
   option (#1238). This makes it easier to use pkgdown with GitHub enterprise,
   packages in subdirectories, and other source hosts (like bitbucket).
@@ -753,25 +753,25 @@ Markdown code with chunks) (@idavydov, #2237).
         user: https://github.com/
     ```
 
-    The individual components (e.g. path, issue number, username) are pasted on
+    The individual components (e.g. path, issue number, username) are pasted on 
     the end of these urls so they should have trailing `/`s.
 
-    You don't need to set these links for GitLab, as pkgdown now detects
+    You don't need to set these links for GitLab, as pkgdown now detects 
     GitLab urls automatically (since they use the same structure as GitHub)
-    (#1045).
+    (#1045). 
 
-* There's much richer control over Open Graph and Twitter metadata for the
-  whole site and for individual articles. See new `vignette("metadata")` for
+* There's much richer control over Open Graph and Twitter metadata for the 
+  whole site and for individual articles. See new `vignette("metadata")` for 
   details (@gadenbuie, #936).
 
 * New `deploy_to_branch()` function to build and deploy a site to a branch,
-  defaulting to `gh-pages` for use with GitHub Pages. This is used in our
+  defaulting to `gh-pages` for use with GitHub Pages. This is used in our 
   recommended GitHub action workflow for automatically building and deploying
   pkgdown sites for packages on GitHub (@jimhester, #1221).
 
 * Updated JS libraries: jquery 3.3.1 -> 3.4.1; bootswatch 3.3.7 -> 3.4.0;
   bootstrap 3.3.7 -> bootstrap 3.4.1; docsearch 2.6.1 -> 2.6.3;
-  fontawesome 5.11.1 -> 5.12.1; headroom.js 0.9.44 -> 0.11.0;
+  fontawesome 5.11.1 -> 5.12.1; headroom.js 0.9.44 -> 0.11.0; 
   clipboard.js 2.0.4 -> 2.0.6 (@jayhesselberth).
 
 ## Auto-linking improvements
@@ -784,7 +784,7 @@ Markdown code with chunks) (@idavydov, #2237).
 * `\preformatted{}` blocks are now highlighted and linked if they parse
   as R code (#1180).
 
-* `library(pkgdown)` is now automatically linked to the reference index for
+* `library(pkgdown)` is now automatically linked to the reference index for 
   "pkgdown" not the documentation for `library()` (#1161).
 
 * `help("topic")` is now automatically linked to the documentation for "topic",
@@ -800,10 +800,10 @@ Markdown code with chunks) (@idavydov, #2237).
 * `build_article()` failures now print more information to help you debug
   the problem (#952).
 
-* The name of the vignette mapped to the "Get started" entry in the navbar
-  is now more flexible. You can use an article (e.g `articles/{pkgname}`)
-  and if your package has a `.` in its name you can replace it with `-` to
-  generate a valid article name (e.g. the get started vignette for
+* The name of the vignette mapped to the "Get started" entry in the navbar 
+  is now more flexible. You can use an article (e.g `articles/{pkgname}`) 
+  and if your package has a `.` in its name you can replace it with `-` to 
+  generate a valid article name (e.g. the get started vignette for 
   `pack.down` would be `pack-down`) (#1166).
 
 ### Deployment
@@ -814,27 +814,27 @@ Markdown code with chunks) (@idavydov, #2237).
 * `deploy_to_branch(github_pages = TRUE)` generates a `.nojekyll` to prevent
   jekyll ever executing (#1242).
 
-* `CNAME` is no longer generated by `init_site()`, but is instead conditionally
-  by `deploy_to_branch()` when `github_pages = TRUE`. This is a better a fit
+* `CNAME` is no longer generated by `init_site()`, but is instead conditionally 
+  by `deploy_to_branch()` when `github_pages = TRUE`. This is a better a fit 
   because the `CNAME` file is only needed by GitHub pages (#969).
 
 * `deploy_site_github()` argument `repo_slug` has been deprecated and is no
   longer needed or used. (@jimhester, #1221)
 
-### News
+### News 
 See additional details in `?build_news`:
 
-* You can optionally suppress the CRAN release dates added to the news
+* You can optionally suppress the CRAN release dates added to the news 
   page (#1118).
 
-* Multi-page news style gets a better yaml specification (the old style
+* Multi-page news style gets a better yaml specification (the old style 
   will continue to work so no need to change existing YAML).
 
 ### Reference
 
 * A topic named `index` will not longer clobber the reference index (#1110).
 
-* Topic names/aliases on reference index are now escaped (#1216).
+* Topic names/aliases on reference index are now escaped (#1216). 
 
 * `build_reference()` gives better warnings if your `_pkgdown.yml` is
   constructed incorrectly (#1025).
@@ -842,22 +842,22 @@ See additional details in `?build_news`:
 * New `has_keyword()` topic selector for `reference`. `has_keyword("datasets")`
   is particularly useful for selecting all data documentation (#760).
 
-* New `lacks_concepts()` can select topics that do not contain any of
+* New `lacks_concepts()` can select topics that do not contain any of 
   a number of specified concepts. (@mikldk, #1232)
 
 ### Home, authors, and citation
 
-* pkgdown now escapes html and linkifies links in comments in author info
+* pkgdown now escapes html and linkifies links in comments in author info 
   from DESCRIPTION (@maelle, #1204)
 
-* pkgdown now uses the ORCiD logo included in Font Awesome 5.11 instead of
+* pkgdown now uses the ORCiD logo included in Font Awesome 5.11 instead of 
   querying it from members.orcid.org (@bisaloo, #1153)
 
 * badges are now extracted from everything between `<!--badges: start-->`
   and `<!--badges: end-->`. They used to be extracted only if they were
   direct children of the first `<p>` after `<!--badges: start-->`.
 
-* `build_home()` now looks for `pkgdown/index.md` in addition to the top-level
+* `build_home()` now looks for `pkgdown/index.md` in addition to the top-level 
   `index` or `README` files (@nteetor, #1031)
 
 ### Navbar
@@ -866,13 +866,13 @@ See additional details in `?build_news`:
   as it has been specified in the DESCRIPTION file. In particular, version
   separators (e.g. `.` and `-`) are preserved. (#1170, @kevinushey)
 
-* add support for navbar submenus: you can create submenus following the
+* add support for navbar submenus: you can create submenus following the 
   convention established in [rstudio/rmarkdown#721](https://github.com/rstudio/rmarkdown/issues/721) (@ijlyttle, @wendtke, #1213)
 
 ### Other
 
 * Updated JS libraries: jquery 3.3.1 -> 3.4.1; bootswatch 3.3.7 -> 3.4.0;
-  bootstrap 3.3.7 -> bootstrap 3.4.1; docsearch 2.6.1 -> 2.6.3
+  bootstrap 3.3.7 -> bootstrap 3.4.1; docsearch 2.6.1 -> 2.6.3 
   (@jayhesselberth).
 
 * Markdown conversion now explicitly allows markdown inside of HTML blocks;
@@ -891,9 +891,9 @@ See additional details in `?build_news`:
 * build citation as specified by the `textVersion` argument of `citEntry` in the
   `CITATION` file (#1096, @yiluheihei)
 
-* `build_site()`, `build_reference()` and `build_home()` gain a parameter
+* `build_site()`, `build_reference()` and `build_home()` gain a parameter 
   `devel` which controls whether you're in deployment or development mode.
-  It generalises and replaces (with deprecation) the existing `document`
+  It generalises and replaces (with deprecation) the existing `document` 
   argument.
 
     Development mode is optimised for rapid iteration and is the default
@@ -905,13 +905,13 @@ See additional details in `?build_news`:
     library, and runs examples/articles in a new process.
 
 * `build_reference()` no longer runs `devtools::document()` (#1079) and
-  `build_home()` no longer re-builds `README.Rmd` or `index.Rmd`. This makes
-  the scope of responsibility of pkgdown more clear: it now only
+  `build_home()` no longer re-builds `README.Rmd` or `index.Rmd`. This makes 
+  the scope of responsibility of pkgdown more clear: it now only 
   creates/modifies files in `doc/`.
 
-* `build_home()` now strips quotes from `Title` and `Description` fields
-  when generating page metadata. Additionally, you can now override the
-  defaults via the `title` and `description` fields in the `home` section of
+* `build_home()` now strips quotes from `Title` and `Description` fields 
+  when generating page metadata. Additionally, you can now override the 
+  defaults via the `title` and `description` fields in the `home` section of 
   `_pkgdown.yml` (#957, @maelle).
 
 * `vignette("linking")` describes how pkgdown's automatic linking works, and
@@ -921,9 +921,9 @@ See additional details in `?build_news`:
 
 ### Rd translation
 
-* `\examples{}` rendering has been completely overhauled so it now first
+* `\examples{}` rendering has been completely overhauled so it now first 
   converts the entire mixed Rd-R block to R prior, and then evaluates the
-  whole thing. This considerably improves the fidelity of the translation
+  whole thing. This considerably improves the fidelity of the translation 
   at a small cost of no longer being able to remove `\donttest{}` and
   friends (#1087).
 
@@ -935,14 +935,14 @@ See additional details in `?build_news`:
 
 * `\tabular{}` translation handles code better (@mitchelloharawild, #978).
 
-* `\subsection{}` contents are now treated as paragraphs, not inline text
+* `\subsection{}` contents are now treated as paragraphs, not inline text 
   (#991).
 
 * `\preformatted{}` blocks preserve important whitespace (#951).
 
 ### Front end
 
-* Links to online documentation for functions in code chunks are no longer
+* Links to online documentation for functions in code chunks are no longer 
   displayed when printing (#1135, @bisaloo).
 
 * Updated fontawesome to v5.7.1. fontawesome 5 [deprecated the `fa` prefix](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#changes).
@@ -950,56 +950,56 @@ See additional details in `?build_news`:
   (e.g.) `fa fa-home` to `fas fa-home`. Brands now have a separate prefix so
   `fa fa-github` becomes `fab fa-github` (#953).
 
-* The navbar is now automatically hidden with
+* The navbar is now automatically hidden with 
   [headroom.js](https://wicky.nillia.ms/headroom.js/).
 
-* The sticky behaviour of the navbar is now implemented in pure CSS instead of
+* The sticky behaviour of the navbar is now implemented in pure CSS instead of 
   relying a the 3rd party javascript library (#1016, @bisaloo)
 
 * Favicons are now automatically built from a package logo (#949).
 
 ### Linking
 
-* Infix operators (e.g., `%in%` and `%*%`) are now linked to their
+* Infix operators (e.g., `%in%` and `%*%`) are now linked to their 
   documentation (#1082).
 
-* Function names can now be included in headers without spurious auto-linking
+* Function names can now be included in headers without spurious auto-linking 
   (#948).
 
-* Links to external documentation now point to [rdrr.io](https://rdrr.io)
+* Links to external documentation now point to [rdrr.io](https://rdrr.io) 
   (#998).
 
 ### Other
 
-* News page recognises more version specifications (including the
+* News page recognises more version specifications (including the  
   "(development version)" now used by usethis) (#980).
 
 * Subdirectories are supported for assets (#939, @ijlyttle).
 
-* A default 404 page (`404.html`) is built, unless a custom `.github/404.md`
+* A default 404 page (`404.html`) is built, unless a custom `.github/404.md` 
   is provided (#947).
 
-* `build_article()` now uses the raw vignette title as page `<title>`
+* `build_article()` now uses the raw vignette title as page `<title>` 
   and `og:title` (@maelle, #1037).
 
-* `build_home()` now looks for license files spelled either as LICENSE or
+* `build_home()` now looks for license files spelled either as LICENSE or 
   LICENCE (#972).
 
-* `build_home()` can find badges in paragraph coming after the comment
+* `build_home()` can find badges in paragraph coming after the comment 
   `<!-- badges: start -->` (#670, @gaborcsardi, @maelle).
 
-* `build_home()` will add a community section to the sidebar if there is either
-  a code of  conduct (`.github/CODE_OF_CONDUCT.md`) or a contributing guide
+* `build_home()` will add a community section to the sidebar if there is either 
+  a code of  conduct (`.github/CODE_OF_CONDUCT.md`) or a contributing guide 
   (`.github/CONTRIBUTING.md`) (#1044, @maelle).
 
 * `build_reference()` gains a `topics` argument which allows you to re-build
   only specified topics.
 
-* `build_site(new_process = TRUE)` gains a timeout,
-  `options(pkgdown.timeout = 10)`, that can be used to prevent stalled
-  builds.
+* `build_site(new_process = TRUE)` gains a timeout, 
+  `options(pkgdown.timeout = 10)`, that can be used to prevent stalled 
+  builds. 
 
-* `deploy_site_github(install = FALSE)` makes it possible to opt out of
+* `deploy_site_github(install = FALSE)` makes it possible to opt out of 
   installation.
 
 * `dev_mode()` now recognises `0.1.9000` as a development version of a package
@@ -1016,7 +1016,7 @@ See additional details in `?build_news`:
 * `content-home.html` template is no longer used when the homepage
   is an `.Rmd` (Reverts #834. Fixes #927, #929)
 
-* `deploy_site_github()` now passes parameters to `build_site()`
+* `deploy_site_github()` now passes parameters to `build_site()` 
   (@noamross, #922), and the documentation gives slightly better advice.
 
 * Correct off-by-one error in navbar highlighting javascript; now no navbar
@@ -1035,9 +1035,9 @@ See additional details in `?build_news`:
   See documentation for how to set up details (@jimhester).
 
 * `build_favicon()` creates high resolution favicons from the package logo,
-  and saves them in `pkgdown/`. They are created using the
-  <https://realfavicongenerator.net/> API, and are better suited for modern web
-  usage (e.g. retina display screens, desktop shortcuts, etc.). This also
+  and saves them in `pkgdown/`. They are created using the 
+  <https://realfavicongenerator.net/> API, and are better suited for modern web 
+  usage (e.g. retina display screens, desktop shortcuts, etc.). This also 
   removes the dependency on the magick package, making automated deployment
   a little easier (@bisaloo, #883).
 
@@ -1048,25 +1048,25 @@ See additional details in `?build_news`:
 
 * `rd2html()` is now exported to facilitate creation of translation reprexes.
 
-* `\Sexpr{}` conversion supports multiple arguments, eliminating
+* `\Sexpr{}` conversion supports multiple arguments, eliminating 
   `x must be a string or a R connection` errors when using `\doi{}` (#738).
 
 * `\tabular{}` conversion better handles empty cells (#780).
 
-* `\usage{}` now supports qualified functions eliminating
+* `\usage{}` now supports qualified functions eliminating  
   `Error in fun_info(x) : Unknown call: ::` errors (#795).
 
 * Invalid tags now generate more informative errors (@BarkleyBG, #771, #891)
 
 ## Front end
 
-* The default footer now displays the version of pkgdown used to build
-  the site (#876).
+* The default footer now displays the version of pkgdown used to build 
+  the site (#876). 
 
 * All third party resources are now fetched from a single CDN and are
   give a SRI hash (@bisaloo, #893).
 
-* The navbar version now has class "version" so you can more easily control
+* The navbar version now has class "version" so you can more easily control 
   its display (#680).
 
 * The default css has been tweaked to ensure that icons are visible on all
@@ -1076,14 +1076,14 @@ See additional details in `?build_news`:
 
 ### Home page
 
-* Can now build sites for older packages that don't have a `Authors@R` field
+* Can now build sites for older packages that don't have a `Authors@R` field 
   (#727).
 
 * Remote urls ending in `.md` are no longer tweaked to end in `.html` (#763).
 
 * Bug report link is only shown if there's a "BugReports" field (#855).
 
-* `content-home.html` template is now used when the homepage is an `.Rmd`
+* `content-home.html` template is now used when the homepage is an `.Rmd` 
   (@goldingn, #787).
 
 * A link to the source `inst/CITATION` was added to the authors page (#714).
@@ -1096,12 +1096,12 @@ See additional details in `?build_news`:
 
 * Unexported functions and test helpers are no longer loaded (#789).
 
-* Selectors that do not match topics now generate a warning. If none of the
+* Selectors that do not match topics now generate a warning. If none of the 
   specified selectors have a match, no topics are selected (#728).
 
 ### Articles
 
-* The display depth of vignette tables of contents can be configured by
+* The display depth of vignette tables of contents can be configured by 
   setting `toc: depth` in `_pkgdown.yml` (#821):
 
   ```yaml
@@ -1114,7 +1114,7 @@ See additional details in `?build_news`:
 * `init_site()` now creates a CNAME file if one doesn't already exist and the
   site's metadata includes a `url` field.
 
-* `build_site()` loses vestigal `mathjax` parameter. This didn't appear to do
+* `build_site()` loses vestigal `mathjax` parameter. This didn't appear to do 
   anything and  no one could remember why it existed (#785).
 
 * `build_site()` now uses colours even if `new_process = TRUE` (@jimhester).
@@ -1123,40 +1123,40 @@ See additional details in `?build_news`:
 
 ## New features
 
-* `build_reference()` and `build_site()` get new `document` argument. When
-  `TRUE`, the default, will automatically run `devtools::document()` to
+* `build_reference()` and `build_site()` get new `document` argument. When 
+  `TRUE`, the default, will automatically run `devtools::document()` to 
   ensure that your documentation is up to date.
 
 * `build_site()` gains a `new_process` argument, which defaults to `TRUE`.
   This will run pkgdown in a separate process, and is recommended practice
   because it improves reproducibility (#647).
 
-* Improved display for icons: icons must be 30px and stored in top-level
-  `icons/` directory. They are embedded in a separate column of reference
+* Improved display for icons: icons must be 30px and stored in top-level 
+  `icons/` directory. They are embedded in a separate column of reference 
   index table, instead of being inside a comment (!) (#607).
 
 ## Front end
 
-* Added a keyboard shortcut for searching. Press `shift` + `/` (`?`) to move
-  focus to the search bar (#642).
+* Added a keyboard shortcut for searching. Press `shift` + `/` (`?`) to move 
+  focus to the search bar (#642). 
 
 * The Algolia logo is correctly shown in the search results (#673).
 
-* Navbar active tab highlighting uses a superior approach (suggested by
+* Navbar active tab highlighting uses a superior approach (suggested by 
   @jcheng5) which should mean that the active page is correctly highlighted
   in all scenarios (#660).
 
-* `pkgdown.js` is better isolated so it should still work even if you
+* `pkgdown.js` is better isolated so it should still work even if you 
   load html widgets that import a different version of jquery (#655).
 
 ## Improvements to Rd translation
 
-* `vignette()` calls that don't link to existing vignettes silently fail
-  to link instead of generating an uninformative error messages (#652).
-  Automatic linking works for re-exported objects that are not functions
+* `vignette()` calls that don't link to existing vignettes silently fail 
+  to link instead of generating an uninformative error messages (#652). 
+  Automatic linking works for re-exported objects that are not functions 
   (@gaborcsardi, #666).
 
-* Empty `\section{}`s are ignored (#656). Previously, empty sections caused
+* Empty `\section{}`s are ignored (#656). Previously, empty sections caused 
   error `Error in rep(TRUE, length(x) - 1)`.
 
 * `\Sexpr{}` supports `results=text`, `results=Rd` and `results=hide` (#651).
@@ -1165,13 +1165,13 @@ See additional details in `?build_news`:
 
 ## Minor bug fixes and improvements
 
-* Add `inst/pkgdown.yml` as a possible site configuration file so that packages
+* Add `inst/pkgdown.yml` as a possible site configuration file so that packages 
   on CRAN can be built without needing the development version (#662).
 
-* Default navbar template now uses site title, not package name (the package
+* Default navbar template now uses site title, not package name (the package 
   name is the default title, so this will not affect most sites) (#654).
 
-* You can suppress indexing by search engines by setting `noindex: true`
+* You can suppress indexing by search engines by setting `noindex: true` 
   `pkgdown.yml` (#686)
 
     ```yaml
@@ -1180,29 +1180,29 @@ See additional details in `?build_news`:
         noindex: true
     ```
 
-* `build_article()` sets `IN_PKGDOWN` env var so `in_pkgdown()` works
+* `build_article()` sets `IN_PKGDOWN` env var so `in_pkgdown()` works 
   (#650).
 
 * `build_home()`: CITATION files with non-UTF-8 encodings (latin1) work
-  correctly, instead of generating an error. For non-UTF-8 locales, ensure you
-  have e.g. `Encoding: latin1` in your `DESCRIPTION`; but best practice is to
+  correctly, instead of generating an error. For non-UTF-8 locales, ensure you 
+  have e.g. `Encoding: latin1` in your `DESCRIPTION`; but best practice is to 
   re-enode your CITATION file to UTF-8 (#689).
 
-* `build_home()`: Markdown files (e.g., `CODE_OF_CONDUCT.md`) stored in
+* `build_home()`: Markdown files (e.g., `CODE_OF_CONDUCT.md`) stored in 
   `.github/` are copied and linked correctly (#682).
 
 * `build_news()`: Multi-page changelogs (generated from `NEWS.md` with
   `news: one_page: false` in `_pkgdown.yml`) are rendered correctly.
 
-* `build_reference()`: reference index shows infix functions (like `%+%`) as
+* `build_reference()`: reference index shows infix functions (like `%+%`) as 
   `` `%+%` ``, not `` `%+%`() `` on  (#659).
 
 # pkgdown 1.0.0
 
 * Major refactoring of path handling. `build_` functions no longer take
-  `path` or `depth` arguments. Instead, set the `destination` directory
+  `path` or `depth` arguments. Instead, set the `destination` directory 
   at the top level of `pkgdown.yml`.
 
 * Similarly, `build_news()` no longer takes a `one_page` argument;
-  this should now be specified in the `_pkgdown.yml` instead. See the
+  this should now be specified in the `_pkgdown.yml` instead. See the 
   documentation for an example.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,91 +6,92 @@
 * New translation for "Search site", the label applied to the search box for screenreaders. This was previously incorrectly labelled as "Toggle navigation" (#2320).
 * You can now choose where the search box is placed with the "search" navbar component. This has been documented for a very long time, but as far as I can tell, never worked (#2320). If you have made your own template with a custom `navbar`, you will need to remove the `<form>` with `role="search"` to avoid getting two search boxes.
 * The mobile version of pkgdown sites no longer has a scrollburglar (a small amount of horizontal scroll) (#2179, @netique).
+* The `template.bslib` item now also accepts a `bootswatch` key (@gadenbuie, #2483).
 
 # pkgdown 2.0.9
 
 * Fixes for regressions in 2.0.8:
 
   * Output links generated when building the site work once again (#2435).
-  
-  * pkgdown once again uses Bootstrap version specified in a template 
+
+  * pkgdown once again uses Bootstrap version specified in a template
     package (@gadenbuie, #2443).
 
 * Front-end improvements:
 
-  * The skip link now becomes visible when focussed (#2138). Thanks to @glin 
+  * The skip link now becomes visible when focussed (#2138). Thanks to @glin
     for the styles!
 
-  * The left and right footers no longer contain an extra empty paragraph tag 
-    and the footer gains additional padding-top to keep the whitespace constant 
+  * The left and right footers no longer contain an extra empty paragraph tag
+    and the footer gains additional padding-top to keep the whitespace constant
     (#2381).
 
   * Clipboard buttons report their action again ("Copied!") (#2462)
 
-* It is now easier to preview parts of the website locally interactively. 
+* It is now easier to preview parts of the website locally interactively.
   `build_reference_index()` and friends will call `init_site()` automatically
   instead of erroring (@olivroy, #2329).
 
 * `build_article()` gains a new `new_process` argument which allows to build a
-   vignette in the current process for debugging purposes. We've also improved 
-   the error messages and tracebacks if an article fails to build, hopefully 
+   vignette in the current process for debugging purposes. We've also improved
+   the error messages and tracebacks if an article fails to build, hopefully
    also making debugging easier (#2438).
 
-* `build_article_index()` and `build_reference_index()` use an improved BS5 
-  template that correctly wraps each section description in a `<div>`, rather 
-  than a `<p>`. This eliminates an empty pargraph tag that preceded each section 
+* `build_article_index()` and `build_reference_index()` use an improved BS5
+  template that correctly wraps each section description in a `<div>`, rather
+  than a `<p>`. This eliminates an empty pargraph tag that preceded each section
   description (#2352).
 
 * `build_home()` no longer errors when you have an empty `.md` file (#2309).
-  It alos no longer renders Github issue and pull request templates 
+  It alos no longer renders Github issue and pull request templates
   (@hsloot, #2362)
 
-* `build_news()` now warns if it doesn't find any version headings, suggesting 
+* `build_news()` now warns if it doesn't find any version headings, suggesting
   that that `NEWS.md` is structured incorrectly (#2213).
 
-* `build_readme()` now correctly tweaks links to markdown files that use an 
+* `build_readme()` now correctly tweaks links to markdown files that use an
   anchor, e.g. `foo.md#heading-name` (#2313).
 
-* `build_reference_index()` gives more informative errors if your `contents` 
+* `build_reference_index()` gives more informative errors if your `contents`
   field is malformed (#2323).
 
-* `check_pkgdown()` no longer errors if your intro vignette is an article is 
+* `check_pkgdown()` no longer errors if your intro vignette is an article is
   not listed in `_pkgdown.yml` (@olivroy #2150).
 
 * `data_template()` gives a more informative error if you've misspecified the navbar (#2312).
 
 # pkgdown 2.0.8
 
-* pkgdown is now compatible with (and requires) bslib >= 0.5.1 
-  (@gadenbuie, #2395), including a fix to BS5 navbar template to get 
+* pkgdown is now compatible with (and requires) bslib >= 0.5.1
+  (@gadenbuie, #2395), including a fix to BS5 navbar template to get
   `navbar.type: dark` to work with Bootstrap 5.3+ (@tanho63, #2388)
 
-* Now uses [cli](https://github.com/r-lib/cli) to provide interactive feedback. 
+* Now uses [cli](https://github.com/r-lib/cli) to provide interactive feedback.
 
 * Avoid unwanted linebreaks from parsing `DESCRIPTION` (@salim-b, #2247).
 
-* Translations  
-  * New Catalan translation (@jmaspons, #2333). 
+* Translations
+  * New Catalan translation (@jmaspons, #2333).
   * Citation sections are correctly translated (@eliocamp, #2410).
 
-* `build_article_index()` now sorts vignettes and non-vignette articles 
-   alphabetically by their filename (literally, their `basename()`), by default 
+* `build_article_index()` now sorts vignettes and non-vignette articles
+   alphabetically by their filename (literally, their `basename()`), by default
    (@jennybc, #2253).
 
 * Deprecated `build_favicon()` was removed (`build_favicons()` remains).
 
-* `build_articles()` now sets RNG seed by default. Use 
-  `build_articles(seed = NULL)` for the old (unreproducible) behaviour. 
+* `build_articles()` now sets RNG seed by default. Use
+  `build_articles(seed = NULL)` for the old (unreproducible) behaviour.
   (@salim-b, #2354).
 
 * `build_articles()` will process `.qmd` articles with the quarto vignette
   builder (@rcannood, #2404).
 
-* `build_articles()` and `build_reference()` now set RNG seed for htmlwidgets 
-  IDs. This reduces noise in final HTML output, both for articles and examples 
+* `build_articles()` and `build_reference()` now set RNG seed for htmlwidgets
+  IDs. This reduces noise in final HTML output, both for articles and examples
   that contain htmlwidgets (@salim-b, #2294, #2354).
 
-* `build_news()` correctly parses  of github profiles and issues into links 
+* `build_news()` correctly parses  of github profiles and issues into links
   when present at the beginning of list items (@pearsonca, #2122)
 
 * `build_reference()` sets `seed` correctly; it was previously reset too early
@@ -101,16 +102,16 @@
   * Correct usage for S3 methods with non-syntactic class names (#2384).
   * Preserve Markdown code blocks with class rmd from roxygen2 docs (@salim-b, #2298).
 
-* `build_reference_index()` no longer generates redundant entries when multiple 
+* `build_reference_index()` no longer generates redundant entries when multiple
   explicit `@usage` tags are provided (@klmr, #2302)
 
-* `build_reference_index()` correctly handles topic names that conflict with 
+* `build_reference_index()` correctly handles topic names that conflict with
   selector functions (@dmurdoch, #2397).
 
 # pkgdown 2.0.7
 
 * Fix topic match selection when there is an unmatched selection followed by a matched selection (@bundfussr, #2234)
-* Fix highlighting of nested not R code blocks (for instance, example of R 
+* Fix highlighting of nested not R code blocks (for instance, example of R
 Markdown code with chunks) (@idavydov, #2237).
 * Tweak German translation (@krlmlr, @mgirlich, @lhdjung, #2149, #2236)
 * Remove mention of (defunct) Twitter card validator, provide alternatives (@Bisaloo, #2185)
@@ -126,23 +127,23 @@ Markdown code with chunks) (@idavydov, #2237).
   (#2150).
 
 * If there aren't any functions in the `\usage{}` block, then pkgdown will
-  now shows all aliases on the reference index, rather than just the topic 
+  now shows all aliases on the reference index, rather than just the topic
   name (#1624).
 
 # pkgdown 2.0.5
 
-* Correctly generate downlit link targets for topics that have a file name 
+* Correctly generate downlit link targets for topics that have a file name
   ending in `.` (#2128).
 
 * `build_articles()`: if build fails because the index doesn't include all
   articles, you're now told what articles are missing (@zkamvar, #2121).
 
 * `build_home()` now escapes angle brackets in author comments(#2127).
-  
+
 * `build_home()` will automatically render and link `.github/SUPPORT.md`
   (@IndrajeetPatil, #2124).
 
-* `build_news()` once again fails to link `@username` at start of 
+* `build_news()` once again fails to link `@username` at start of
   bullet. I had to reverted #2030 because of #2122.
 
 * `build_reference()`: restore accidentally nerfed `has_keyword()` and
@@ -150,25 +151,25 @@ Markdown code with chunks) (@idavydov, #2237).
 
 # pkgdown 2.0.4
 
-* New `check_pkgdown()` provides a lightweight way to check that your 
-  `_pkgdown.yml` is valid without building the site (#2056). Invalid 
+* New `check_pkgdown()` provides a lightweight way to check that your
+  `_pkgdown.yml` is valid without building the site (#2056). Invalid
   `_pkgdown.yml` now consistently generates errors both locally and on
   CI (#2055).
 
 * `build_article()` now supports inline markdown in the `title` (#2039).
 
-* `build_home()` no longer shows development status badges on the released 
+* `build_home()` no longer shows development status badges on the released
   version of the site (#2054).
 
 * `build_news()` support automated `@username` links in more places (#2030).
 
-* `build_reference()`: 
+* `build_reference()`:
 
-    * You can once again exclude topics from the reference index with `-` (#2040). 
+    * You can once again exclude topics from the reference index with `-` (#2040).
 
-    * Inline markdown in `title`s and `subtitle`s is now supported(#2039). 
+    * Inline markdown in `title`s and `subtitle`s is now supported(#2039).
 
-    * Package logos will be automatically stripped from the `.Rd` you don't end 
+    * Package logos will be automatically stripped from the `.Rd` you don't end
       up with two on one page. (#2083).
 
     * `\figure{file}{alternative text}` with multiline alt text is now parsed
@@ -191,7 +192,7 @@ Markdown code with chunks) (@idavydov, #2237).
 
     * Navbar components now accept `target` argument (#2089, @JSchoenbachler).
 
-* New syntax highlighting themes a11y-light, a11y-dark, monochrome-light, 
+* New syntax highlighting themes a11y-light, a11y-dark, monochrome-light,
   monochrome-dark, and solarized
 
 # pkgdown 2.0.3
@@ -203,8 +204,8 @@ Markdown code with chunks) (@idavydov, #2237).
 * New Korean (`ko`) translation thanks to @mrchypark and @peremen (#1944).
   New Danish (`dk`) translation thanks to @LDalby.
 
-* `build_articles()` now adjusts the heading levels of vignettes/articles that 
-  use `<h1>` as section headings to ensure that there's one top-level heading 
+* `build_articles()` now adjusts the heading levels of vignettes/articles that
+  use `<h1>` as section headings to ensure that there's one top-level heading
   (#2004). This ensures that there's one `<h1>`, the title, on each page,
   and makes the TOC in the sidebar work correctly.
 
@@ -214,11 +215,11 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * `build_news()` once again works if `NEWS.md` uses `<h1>` headings (#1947).
 
-* `build_reference()` now correctly interprets `title: internal`: it removes 
-  the section from the reference index _and_ it doesn't list the topics in that 
+* `build_reference()` now correctly interprets `title: internal`: it removes
+  the section from the reference index _and_ it doesn't list the topics in that
   section as missing (#1958).
 
-* `build_reference()` now gives a correct hint when the reference index YAML 
+* `build_reference()` now gives a correct hint when the reference index YAML
   is not formatted correctly (e.g. empty item, or item such as "n" that needs
   to be escaped with quotes to not be interpreted as Boolean) (#1995).
 
@@ -230,16 +231,16 @@ Markdown code with chunks) (@idavydov, #2237).
     * The navbar gets a little more space after the version number, and aligns
       the baseline with rest of the navbar (#1989).
 
-    * Long lines in code output once again scroll, rather than being wrapped. 
+    * Long lines in code output once again scroll, rather than being wrapped.
       While this is different to what you'll see in the console, it's a better
-      fit for web pages where the available code width varies based on the 
+      fit for web pages where the available code width varies based on the
       browser width (#1940).
-    
-    * scrollspy (which highlights the "active" heading in the sidebar) now 
-      computes the offset dynamically which makes it work better on sites with 
+
+    * scrollspy (which highlights the "active" heading in the sidebar) now
+      computes the offset dynamically which makes it work better on sites with
       taller navbars (#1993).
 
-    * Fixed js issues that occurred on pages without a table of contents 
+    * Fixed js issues that occurred on pages without a table of contents
       (@gadenbuie, #1998).
 
     * When htmlwidgets with jQuery or Bootstrap dependencies are used in examples or
@@ -247,7 +248,7 @@ Markdown code with chunks) (@idavydov, #2237).
       the versions used by the htmlwidget (@gadenbuie, #1997).
 
 * pkgdown no longer includes bundled author metadata for Hadley Wickham,
-  RStudio, or the RConsortium, since there are now ways to include this 
+  RStudio, or the RConsortium, since there are now ways to include this
   meta data in template packages, and special casing these three entities
   feels increasingly weird (#1952).
 
@@ -271,111 +272,111 @@ Markdown code with chunks) (@idavydov, #2237).
 ## Bootstrap 5
 
 * pkgdown can style your site with Bootstrap 5 (with help from @jayhesselberth,
-  @apreshill, @cpsievert). Opt-in by setting `boostrap` version in your 
+  @apreshill, @cpsievert). Opt-in by setting `boostrap` version in your
   `_pkgdown.yml`:
-  
+
     ```yaml
     template:
       bootstrap: 5
     ```
 
-* We reviewed site accessibility and made a number of small improvements: 
+* We reviewed site accessibility and made a number of small improvements:
   (#782, #1553):
 
     * Default font is larger and links are always underlined.
     * Heading anchors use `aria-hidden` to reduce noise for screenreader users.
     * Navbar dropdowns has improved `aria-labelledby`.
-    * The default GitHub/GitLab links gain an `aria-label`; use for other 
+    * The default GitHub/GitLab links gain an `aria-label`; use for other
       icons is now supported, and encouraged in the docs.
     * Syntax highlighting uses a new more
-      [accessible colour scheme](https://apreshill.github.io/rmda11y/arrow.html), 
+      [accessible colour scheme](https://apreshill.github.io/rmda11y/arrow.html),
       designed by Alison Hill (#1536)
     * A skip link makes it easier to get directly to the page contents (#1827).
 
-* In-line footnotes mean you can read asides next to the text they refer to. 
+* In-line footnotes mean you can read asides next to the text they refer to.
 
 * Articles support tabsets,
   [as in R Markdown](https://bookdown.org/yihui/rmarkdown-cookbook/html-tabs.html).
   (@JamesHWade, #1667).
 
 * Other minor styling improvements:
-    
+
     * The active item in TOC is indicated with background colour, rather than
       a border.
     * If present, the package logo is shown on all pages near the header.
-    * Section anchors now appear on the right (making them usable on mobile 
+    * Section anchors now appear on the right (making them usable on mobile
       phones) (#1782).
     * The TOC is scrollable independently of the main content. This makes it
       more useful on long pages with many headings (#1610).
     * The sidebar is shown at the bottom of the page on narrow screens.
-    * Function arguments and the reference index (#1822) use definition lists 
-      (`<dl>`) instead of tables. This gives more room for long argument 
-      names/lists of function and detailed descriptions, and displays better 
+    * Function arguments and the reference index (#1822) use definition lists
+      (`<dl>`) instead of tables. This gives more room for long argument
+      names/lists of function and detailed descriptions, and displays better
       on mobile.
     * Links on the homepage no longer show the full url in the text.
-    * The default navbar no longer includes a home icon - this took up 
-      precious horizontal space and wasn't very useful since there was already 
+    * The default navbar no longer includes a home icon - this took up
+      precious horizontal space and wasn't very useful since there was already
       a link to the home page immediately to its left (#1383).
 
 ## Local search
 
-* pkgdown now supports local searching (i.e. searching without an external 
-  service), and is enabled by default for Bootstrap 5 sites since no set-up is 
-  needed (#1629, with help from @gustavdelius in #1655 and @dieghernan & 
+* pkgdown now supports local searching (i.e. searching without an external
+  service), and is enabled by default for Bootstrap 5 sites since no set-up is
+  needed (#1629, with help from @gustavdelius in #1655 and @dieghernan &
   @GregorDeCillia in #1770).
 
-* pkgdown builds a more exhaustive `sitemap.xml` even for websites built with 
-  Bootstrap 3. This might change Algolia results if you use Algolia for search 
+* pkgdown builds a more exhaustive `sitemap.xml` even for websites built with
+  Bootstrap 3. This might change Algolia results if you use Algolia for search
   (#1629).
 
 ## Customisation
 
-* New `vignette("customise")` documents all the ways you can customise your 
+* New `vignette("customise")` documents all the ways you can customise your
   site, including the new options described below (#1573).
 
 * Sites can be easily themed with either bootswatch themes or by selectively
-  overriding the `bslib` variables used to generate the CSS. pkgdown now uses 
-  scss for its own Bootstrap css tweaks, which means that you can customise 
+  overriding the `bslib` variables used to generate the CSS. pkgdown now uses
+  scss for its own Bootstrap css tweaks, which means that you can customise
   more of the site from within `_pkgdown.yml`.
 
 * You can pick from a variety of built-in syntax highlighting themes (#1823).
   These control the colours (and background) of code in `<pre>` tags.
 
-* pkgdown can now translate all the text that it generates (#1446): this means 
-  that if you have a package where the docs are written in another language, you 
+* pkgdown can now translate all the text that it generates (#1446): this means
+  that if you have a package where the docs are written in another language, you
   can match all the pkgdown UI to provide a seamless experience to non-English
   speakers. Activate the translations by setting the `lang` in `_pkgdown.yml`:
-   
+
     ```yaml
     lang: fr
     ```
-    
+
     pkgdown includes translations for:
-    
+
     * `es`, Spanish, thanks to @edgararuiz-zz, @dieghernan, @rivaquiroga.
     * `de`, German, thanks to @hfrick.
     * `fr`, French, thanks to @romainfrancois, @lionel-, @jplecavalier, and @maelle.
     * `pt`, Portuguese, thanks to @rich-iannone.
     * `tr`, Turkish, thanks to @mine-cetinkaya-rundel.
     * `zh_CN`, simplified Chinese, thanks to @yitao.
-  
+
     If you're interested in adding translations for your language please file
     an issue and we'll help you get started.
-  
+
 * Template packages can now provide `inst/pkgdown/_pkgdown.yml` which is used
-  as a set of defaults for `_pkgdown.yml`. It can be used to (e.g.) provide 
-  author definitions, select Bootstrap version and define bslib variables, 
+  as a set of defaults for `_pkgdown.yml`. It can be used to (e.g.) provide
+  author definitions, select Bootstrap version and define bslib variables,
   and customise the sidebar, footer, navbar, etc. (#1499).
 
-* New `includes` parameters `in-header`, `before-body`, and `after-body` 
-  make it easy to add arbitrary HTML to every page. Their content will be 
-  placed at the end of the `<head>` tag, right below the opening `<body>` tag, 
-  and before the closing tag `</body>` respectively (#1487). They match the 
+* New `includes` parameters `in-header`, `before-body`, and `after-body`
+  make it easy to add arbitrary HTML to every page. Their content will be
+  placed at the end of the `<head>` tag, right below the opening `<body>` tag,
+  and before the closing tag `</body>` respectively (#1487). They match the
   bookdown options `in_header`, `before_body` and `after_body`.
-  
+
     Additionally, you can use `before_title`, `before_navbar`, and
     `after_navbar` to add arbitrary HTML into the navbar/page header; they
-    will appear to the left of the package name/version, and to the left and 
+    will appear to the left of the package name/version, and to the left and
     right of the navigation links respectively (#1882).
 
 * Authors configuration is more flexible (#1516). You can now:
@@ -391,14 +392,14 @@ Markdown code with chunks) (@idavydov, #2237).
     * Add custom sidebar sections (with Markdown/HTML `text`).
     * Add a table of contents to the home page.
     * Completely suppress the sidebar.
-    * Provide your own HTML for the navbar. 
+    * Provide your own HTML for the navbar.
 
 * Footer specification is more flexible (#1502). You can now:
-    
+
     * Change the placement of elements on the left and right.
     * Add text to the left and right (or even remove/replace default text)
-    
-* You can now exclude all default components from the navbar (#1517). 
+
+* You can now exclude all default components from the navbar (#1517).
 
 * Expert users can now override layout templates provided by pkgdown or template
   packages by placing template files in `pkgdown/templates` (@gadenbuie, #1897).
@@ -406,7 +407,7 @@ Markdown code with chunks) (@idavydov, #2237).
 ## New features
 
 * pkgdown now supports redirects (#1259, @lorenzwalthert). The following yaml
-  demonstrates the syntax, with old paths on the left and new paths/URLs on 
+  demonstrates the syntax, with old paths on the left and new paths/URLs on
   the right.
 
   ```yaml
@@ -416,9 +417,9 @@ Markdown code with chunks) (@idavydov, #2237).
     - ["articles/yet-another-old-vignette-name.html", "https://pkgdown.r-lib.org/dev"]
   ```
 
-* Use HTML classes `pkgdown-devel` or `pkgdown-release` to declare that certain 
+* Use HTML classes `pkgdown-devel` or `pkgdown-release` to declare that certain
   content should appear only on the devel or release site. Use the class
-  `pkgdown-hide` for content that should only appear only on GitHub/CRAN 
+  `pkgdown-hide` for content that should only appear only on GitHub/CRAN
   (#1299).
 
 * New `pkgdown_sitrep()` function reports whether the site is set up correctly;
@@ -426,34 +427,34 @@ Markdown code with chunks) (@idavydov, #2237).
 
 ## Code
 
-* Styling for errors, warnings, and messages has been tweaked. Messages 
+* Styling for errors, warnings, and messages has been tweaked. Messages
   are now displayed the same way as output, and warnings and errors are
   bolded, not coloured. This is part of a suite of changes that aim to
-  give package authors greater control over the appearance of messages, 
-  warnings, and errors. 
+  give package authors greater control over the appearance of messages,
+  warnings, and errors.
 
 * Long lines in code output are now wrapped, rather than requiring scrolling.
-  This better matches `rmarkdown::html_document()` and what you see in the 
+  This better matches `rmarkdown::html_document()` and what you see in the
   console.
-  
-* `build_reference()` now allows linking to topics from other packages (either 
-  function names e.g. `rlang::is_installed` or topic names e.g. 
+
+* `build_reference()` now allows linking to topics from other packages (either
+  function names e.g. `rlang::is_installed` or topic names e.g.
   `sass::font_face`). (#1664)
 
-* `build_reference()` now runs examples with 
-  `options(rlang_interactive = FALSE)` (ensuring non-interactive behaviour in 
-  functions that use `rlang::is_interactive()`), `options(cli.dynamic = FALSE)`, 
+* `build_reference()` now runs examples with
+  `options(rlang_interactive = FALSE)` (ensuring non-interactive behaviour in
+  functions that use `rlang::is_interactive()`), `options(cli.dynamic = FALSE)`,
   `Sys.setenv(RSTUDIO = NA)` and `Sys.setLocale("LC_COLLATE", "C")` (#1693).
-  It also runs `pkgdown/pre-reference.R` before and `pkgdown/post-reference.R` 
-  after examples. These allow you to do any setup or teardown operations you 
+  It also runs `pkgdown/pre-reference.R` before and `pkgdown/post-reference.R`
+  after examples. These allow you to do any setup or teardown operations you
   might need (#1602).
 
 * A reference index section with `title: internal` is now silently dropped,
   allowing you to suppress warnings about topics that are not listed in the
   index (#1716).
 
-* Code blocks are now highlighted according to their declared language 
-  (e.g. `yaml`) if the documentation was built with roxygen2 7.1.2 or later 
+* Code blocks are now highlighted according to their declared language
+  (e.g. `yaml`) if the documentation was built with roxygen2 7.1.2 or later
   (#1690, #1692).
 
 * New `pkgdown_print()` allows you to control how your objects are rendered in
@@ -464,7 +465,7 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * You can globally set the `width` of code output (in reference and articles)
   with
-    
+
     ```yaml
     code:
       width: 50
@@ -477,18 +478,18 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * Auto-linking improvements:
 
-  * Links to inherited R6 methods now work correctly for both internal 
+  * Links to inherited R6 methods now work correctly for both internal
     (#1173, @vandenman) and external (#1476) parent classes.
-    
+
   * Linking no longer fails if a package contains duplicated Rd aliases.
-  
+
   * Correctly link to reference pages when the `\name{}` entry doesn't match
     the file name (@dmurdoch, #1586; #1676).
 
 ## Articles
 
-* Article subtitle, author and date (specified in the YAML frontmatter) are now 
-  correctly omitted from the article table of contents in the sidebar 
+* Article subtitle, author and date (specified in the YAML frontmatter) are now
+  correctly omitted from the article table of contents in the sidebar
   (@maxheld83, #1428).
 
 * Support for `as_is: true` and non-default output formats for vignettes/
@@ -497,18 +498,18 @@ Markdown code with chunks) (@idavydov, #2237).
   know about, but it should be a little more reliable and a little better
   documented (#1757, #1764).
 
-* `build_articles()` no longer fails if you have a directory underneath 
+* `build_articles()` no longer fails if you have a directory underneath
   vignettes with a `.Rmd` extension (#1425).
 
 * `build_articles()` now correctly handles links to images in `man/figures`
   (which have the form `../man/figures`) (#1472).
 
-* `build_articles()` again sets the `theme` argument of the document format 
+* `build_articles()` again sets the `theme` argument of the document format
   to `NULL` when `as_is: true` but lets users override this via the `theme`
   argument of the output format.
 
-* `build_articles()` and `build_home()` now warn if you have images that 
-  won't render on the website because they're in unsupported directories 
+* `build_articles()` and `build_home()` now warn if you have images that
+  won't render on the website because they're in unsupported directories
   (#1810). Generally, it's only safe to refer to figures in `man/figures`
   and `vignettes`.
 
@@ -519,14 +520,14 @@ Markdown code with chunks) (@idavydov, #2237).
 
 ## HTML, CSS and JS
 
-* New `template` option `trailing_slash_redirect` that allows adding a script to 
-  redirect `your-package-url.com` to `your-package-url.com/` (#1439, @cderv, 
+* New `template` option `trailing_slash_redirect` that allows adding a script to
+  redirect `your-package-url.com` to `your-package-url.com/` (#1439, @cderv,
   @apreshill).
 
-* External links now get the class `external-link`. This makes them easier to 
+* External links now get the class `external-link`. This makes them easier to
   style with CSS (#881, #1491).
 
-* Duplicated section ids are now de-duplicated; this makes pkgdown work better 
+* Duplicated section ids are now de-duplicated; this makes pkgdown work better
   with the documentation of R6 classes.
 
 * Updated CSS styles from pandoc to improve styling of reference lists (#1469).
@@ -539,60 +540,60 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * `deploy_to_branch()` now calls `git remote set-branches` with `--add` to avoid
   overwriting the existing `remote.{remote}.fetch` value (@kyleam, #1382).
-  It also now cleans out the website directory by default; revert to previous 
+  It also now cleans out the website directory by default; revert to previous
   behaviour with `clean = FALSE` (#1394).
 
 * `build_reference()` will error if envar `CI` is `true` and there are missing
   topics (@ThierryO, #1378).
 
-* You can override the `auto` development mode detected from the package 
+* You can override the `auto` development mode detected from the package
   version by setting env var `PKGDOWN_DEV_MODE` to `release` or `devel`.
   This is useful if your package uses a different convention to indicate
   development and release versions (#1081).
 
-## Other minor improvements and bug fixes 
+## Other minor improvements and bug fixes
 
 * `\special{}` tags with complex contents are rendered correctly (@klmr, #1744).
 
-* `\arguments{}` and `\value{}` do a better job of handling mingled items and 
-  text (#1479). The contents of `\value{}` are now shown immediately after 
+* `\arguments{}` and `\value{}` do a better job of handling mingled items and
+  text (#1479). The contents of `\value{}` are now shown immediately after
   `\arguments{}`.
 
-* The default "branch" for linking to the file sources is `HEAD`, which will 
+* The default "branch" for linking to the file sources is `HEAD`, which will
   work regardless of whether your default branch is called "main" or "master".
 
-* Non-ORCID comments in `Authors@R` are now more usable: if such comments 
-  exist, the sidebar gains a link to the authors page, where they are displayed 
+* Non-ORCID comments in `Authors@R` are now more usable: if such comments
+  exist, the sidebar gains a link to the authors page, where they are displayed
   (#1516).
 
-* Citations with and without text versions are better handled, and text 
+* Citations with and without text versions are better handled, and text
   citations are correctly escaped for HTML (@bastistician, #1507).
 
-* README badges in a single paragraph placed between `<!-- badges: end -->`and 
-  `<!-- badges: end -->` comments are again detected (#1603). 
+* README badges in a single paragraph placed between `<!-- badges: end -->`and
+  `<!-- badges: end -->` comments are again detected (#1603).
 
-* The 404 page (default or from `.github/404.md`) is no longer built in the 
-  development mode (see `?build_site`) as e.g. GitHub pages only uses the 
+* The 404 page (default or from `.github/404.md`) is no longer built in the
+  development mode (see `?build_site`) as e.g. GitHub pages only uses the
   `404.html` in the site root (#1622).
 
-* All links on the 404 pages (navbar, scripts, CSS) are now absolute if there 
+* All links on the 404 pages (navbar, scripts, CSS) are now absolute if there
   is an URL in the configuration file (#1622).
 
-* The version tooltip showed in the top navbar is now only set if you've 
+* The version tooltip showed in the top navbar is now only set if you've
   explicitly set the `development.mode` in `_pkgdown.yml` (#1768).
 
-* All heading (e.g. headings on the reference index page, and the arguments 
+* All heading (e.g. headings on the reference index page, and the arguments
   heading on the reference pages) now get anchors (#1747).
 
 * Use `autolink_bare_uris` for Pandoc above version 2.0 (@marcosmolla, #1618).
 
-* pkgdown now recognizes GitLab URLs to the source repository and adds the 
-  corresponding icon to the navbar (#1493). It also supports 
+* pkgdown now recognizes GitLab URLs to the source repository and adds the
+  corresponding icon to the navbar (#1493). It also supports
   [GitLab subgroups](https://docs.gitlab.com/ee/user/group/subgroups/)
   (@salim-b, #1532).
 
-* Links for GitHub Enterprise and GitLab Enterprise repositories are detected 
-  by assuming such host address begin with `github.` or `gitlab.` 
+* Links for GitHub Enterprise and GitLab Enterprise repositories are detected
+  by assuming such host address begin with `github.` or `gitlab.`
   (@ijlyttle, #1452).
 
 * The rules drawn by the CLI (as for example, in `build_site()`) are protected
@@ -601,7 +602,7 @@ Markdown code with chunks) (@idavydov, #2237).
 * Google Site Verification (https://support.google.com/webmasters/answer/9008080?hl=en)
   can now be configured for pkgdown sites.
 
-* `build_rmarkdown_format` sets `html_document(anchor_sections = FALSE)` 
+* `build_rmarkdown_format` sets `html_document(anchor_sections = FALSE)`
    to avoid needless dependencies (@atusy, #1426).
 
 * Jira issues in NEWS can be automatically linked by setting your project name
@@ -609,27 +610,27 @@ Markdown code with chunks) (@idavydov, #2237).
   `repo: url: issue: ...` in `_pkgdown.yml` (@jonkeane, #1466).
 
 * `build_home()` always creates citation information for the authors page,
-  using metadata from `DESCRIPTION` when there is no `inst/CITATION` file, 
+  using metadata from `DESCRIPTION` when there is no `inst/CITATION` file,
   and links to this from the sidebar (#1904).
 
-* `build_news()` no longer breaks with URLs containing numeric fragments 
+* `build_news()` no longer breaks with URLs containing numeric fragments
   (@krassowski, #1456), recognises more styles of release heading (#1437),
-  and generate stable IDs using a the combination of the heading slug and 
+  and generate stable IDs using a the combination of the heading slug and
   package number. (@Bisaloo, #1015)
 
 # pkgdown 1.6.1
 
-* The article index (used for autolinking vignettes across packages) 
+* The article index (used for autolinking vignettes across packages)
   once again works (#1401).
 
 # pkgdown 1.6.0
 
 ## Major changes
 
-* pkgdown now uses the new [downlit](https://downlit.r-lib.org/) package for all 
-  syntax highlighting and autolinking (in both reference topics and vignettes). 
-  There should be very little change in behaviour because the code in downlit 
-  was extracted from pkgdown, but this makes it easier to use pkgdown's nice 
+* pkgdown now uses the new [downlit](https://downlit.r-lib.org/) package for all
+  syntax highlighting and autolinking (in both reference topics and vignettes).
+  There should be very little change in behaviour because the code in downlit
+  was extracted from pkgdown, but this makes it easier to use pkgdown's nice
   linking/highlighting in more places (#1234).
 
 * pkgdown now uses the `ragg::agg_png()` device to generate example figures.
@@ -644,19 +645,19 @@ Markdown code with chunks) (@idavydov, #2237).
   syntax (@klmr, #1345).
 
 * `#ifdef` and `#ifndef` are now supported; the "current" OS is hard coded to
-  "unix" to ensure reproducible output regardless of where you build the 
+  "unix" to ensure reproducible output regardless of where you build the
   website (#1384).
 
-* Nested `\subsection{}`s now generate appropriate heading levels 
+* Nested `\subsection{}`s now generate appropriate heading levels
   (h3, h4, h5 etc) (#1377), and get anchor links (#1389).
 
 * `\preformatted{}` no longer double escapes its contents (#1311).
 
 ### Articles and vignettes
 
-* `build_articles()` no longer sets the `theme` argument of the document format 
+* `build_articles()` no longer sets the `theme` argument of the document format
   to `NULL` when `as_is: true`. This should allow it to work with a wider
-  range of output formats including `bookdown::html_vignette2()` and 
+  range of output formats including `bookdown::html_vignette2()` and
   friends (@GegznaV, #955, #1352).
 
 * When `build_article()` fails, it gives the complete failure message (#1379).
@@ -665,7 +666,7 @@ Markdown code with chunks) (@idavydov, #2237).
 
 ### Auto-linking and syntax highlighting
 
-* The branch used for source linking can be configured by setting 
+* The branch used for source linking can be configured by setting
   `repo: branch: branch_name` in `_pkgdown.yml` (@jonkeane, #1355):
 
     ```yaml
@@ -673,17 +674,17 @@ Markdown code with chunks) (@idavydov, #2237).
       branch: main
     ```
 
-* `autolink_html()` is (soft) deprecated. Please use 
+* `autolink_html()` is (soft) deprecated. Please use
   `downlit::downlit_html_path()` instead.
 
 * Highlighting of empty expressions works once more (#1310).
 
 * New `deploy$install_metadata` option in `_pkgdown.yml`. Setting it to
   `true` will store site metadata in the package itself, allowing offline
-  access for packages that to autolink to the package's website 
+  access for packages that to autolink to the package's website
   (@mstr3336, #1336).
 
-### Other    
+### Other
 
 * You can now control the background colour of plots with the `figures.bg`
   option (it is transparent by default, and given a white background by
@@ -695,22 +696,22 @@ Markdown code with chunks) (@idavydov, #2237).
 
 * All HTTP requests are now retried upon failure (@jameslamb, #1305).
 
-* Setting `clean = TRUE` in `deploy_site_github()` removes old files from the 
+* Setting `clean = TRUE` in `deploy_site_github()` removes old files from the
   deployed site before building a new one (#1297).
 
 # pkgdown 1.5.1
 
 * Syntax highlighting works on Windows once more (#1282).
 
-* pkgdown no longer fails if your `.Rd` files have duplicated `\aliases` 
+* pkgdown no longer fails if your `.Rd` files have duplicated `\aliases`
   as were produced by an older version of roxygen2 (#1290).
 
 * Rendering empty `.md` file now returns empty string (#1285).
 
 * `build_articles_index()` is now exported to rapidly rebuild the index (#1281)
 
-* `deploy_site_github()` now accepts a `host` argument to specify alternate 
-  hosts (e.g., Github enterprise) (@dimagor, #1165) and once again works as 
+* `deploy_site_github()` now accepts a `host` argument to specify alternate
+  hosts (e.g., Github enterprise) (@dimagor, #1165) and once again works as
   intended on Travis-CI (@jimhester, #1276).
 
 # pkgdown 1.5.0
@@ -721,8 +722,8 @@ Markdown code with chunks) (@idavydov, #2237).
   major new features in this release:
 
     * The articles index page now displays article `description`s,
-      taken from YAML metadata belonging to each article. This lets you provide 
-      more context about each article and describe why one might want to read 
+      taken from YAML metadata belonging to each article. This lets you provide
+      more context about each article and describe why one might want to read
       it (#1227).
 
     * The articles navbar is now also controlled by the `articles` section
@@ -738,7 +739,7 @@ Markdown code with chunks) (@idavydov, #2237).
   [bootstrap-toc](https://afeld.github.io/bootstrap-toc/); this considerably
   improves navigation for long articles and reference pages.
 
-* You can now control the links to source files (in reference pages and 
+* You can now control the links to source files (in reference pages and
   articles) and issues and users (in the NEWS) with new `repo$url` config
   option (#1238). This makes it easier to use pkgdown with GitHub enterprise,
   packages in subdirectories, and other source hosts (like bitbucket).
@@ -752,25 +753,25 @@ Markdown code with chunks) (@idavydov, #2237).
         user: https://github.com/
     ```
 
-    The individual components (e.g. path, issue number, username) are pasted on 
+    The individual components (e.g. path, issue number, username) are pasted on
     the end of these urls so they should have trailing `/`s.
 
-    You don't need to set these links for GitLab, as pkgdown now detects 
+    You don't need to set these links for GitLab, as pkgdown now detects
     GitLab urls automatically (since they use the same structure as GitHub)
-    (#1045). 
+    (#1045).
 
-* There's much richer control over Open Graph and Twitter metadata for the 
-  whole site and for individual articles. See new `vignette("metadata")` for 
+* There's much richer control over Open Graph and Twitter metadata for the
+  whole site and for individual articles. See new `vignette("metadata")` for
   details (@gadenbuie, #936).
 
 * New `deploy_to_branch()` function to build and deploy a site to a branch,
-  defaulting to `gh-pages` for use with GitHub Pages. This is used in our 
+  defaulting to `gh-pages` for use with GitHub Pages. This is used in our
   recommended GitHub action workflow for automatically building and deploying
   pkgdown sites for packages on GitHub (@jimhester, #1221).
 
 * Updated JS libraries: jquery 3.3.1 -> 3.4.1; bootswatch 3.3.7 -> 3.4.0;
   bootstrap 3.3.7 -> bootstrap 3.4.1; docsearch 2.6.1 -> 2.6.3;
-  fontawesome 5.11.1 -> 5.12.1; headroom.js 0.9.44 -> 0.11.0; 
+  fontawesome 5.11.1 -> 5.12.1; headroom.js 0.9.44 -> 0.11.0;
   clipboard.js 2.0.4 -> 2.0.6 (@jayhesselberth).
 
 ## Auto-linking improvements
@@ -783,7 +784,7 @@ Markdown code with chunks) (@idavydov, #2237).
 * `\preformatted{}` blocks are now highlighted and linked if they parse
   as R code (#1180).
 
-* `library(pkgdown)` is now automatically linked to the reference index for 
+* `library(pkgdown)` is now automatically linked to the reference index for
   "pkgdown" not the documentation for `library()` (#1161).
 
 * `help("topic")` is now automatically linked to the documentation for "topic",
@@ -799,10 +800,10 @@ Markdown code with chunks) (@idavydov, #2237).
 * `build_article()` failures now print more information to help you debug
   the problem (#952).
 
-* The name of the vignette mapped to the "Get started" entry in the navbar 
-  is now more flexible. You can use an article (e.g `articles/{pkgname}`) 
-  and if your package has a `.` in its name you can replace it with `-` to 
-  generate a valid article name (e.g. the get started vignette for 
+* The name of the vignette mapped to the "Get started" entry in the navbar
+  is now more flexible. You can use an article (e.g `articles/{pkgname}`)
+  and if your package has a `.` in its name you can replace it with `-` to
+  generate a valid article name (e.g. the get started vignette for
   `pack.down` would be `pack-down`) (#1166).
 
 ### Deployment
@@ -813,27 +814,27 @@ Markdown code with chunks) (@idavydov, #2237).
 * `deploy_to_branch(github_pages = TRUE)` generates a `.nojekyll` to prevent
   jekyll ever executing (#1242).
 
-* `CNAME` is no longer generated by `init_site()`, but is instead conditionally 
-  by `deploy_to_branch()` when `github_pages = TRUE`. This is a better a fit 
+* `CNAME` is no longer generated by `init_site()`, but is instead conditionally
+  by `deploy_to_branch()` when `github_pages = TRUE`. This is a better a fit
   because the `CNAME` file is only needed by GitHub pages (#969).
 
 * `deploy_site_github()` argument `repo_slug` has been deprecated and is no
   longer needed or used. (@jimhester, #1221)
 
-### News 
+### News
 See additional details in `?build_news`:
 
-* You can optionally suppress the CRAN release dates added to the news 
+* You can optionally suppress the CRAN release dates added to the news
   page (#1118).
 
-* Multi-page news style gets a better yaml specification (the old style 
+* Multi-page news style gets a better yaml specification (the old style
   will continue to work so no need to change existing YAML).
 
 ### Reference
 
 * A topic named `index` will not longer clobber the reference index (#1110).
 
-* Topic names/aliases on reference index are now escaped (#1216). 
+* Topic names/aliases on reference index are now escaped (#1216).
 
 * `build_reference()` gives better warnings if your `_pkgdown.yml` is
   constructed incorrectly (#1025).
@@ -841,22 +842,22 @@ See additional details in `?build_news`:
 * New `has_keyword()` topic selector for `reference`. `has_keyword("datasets")`
   is particularly useful for selecting all data documentation (#760).
 
-* New `lacks_concepts()` can select topics that do not contain any of 
+* New `lacks_concepts()` can select topics that do not contain any of
   a number of specified concepts. (@mikldk, #1232)
 
 ### Home, authors, and citation
 
-* pkgdown now escapes html and linkifies links in comments in author info 
+* pkgdown now escapes html and linkifies links in comments in author info
   from DESCRIPTION (@maelle, #1204)
 
-* pkgdown now uses the ORCiD logo included in Font Awesome 5.11 instead of 
+* pkgdown now uses the ORCiD logo included in Font Awesome 5.11 instead of
   querying it from members.orcid.org (@bisaloo, #1153)
 
 * badges are now extracted from everything between `<!--badges: start-->`
   and `<!--badges: end-->`. They used to be extracted only if they were
   direct children of the first `<p>` after `<!--badges: start-->`.
 
-* `build_home()` now looks for `pkgdown/index.md` in addition to the top-level 
+* `build_home()` now looks for `pkgdown/index.md` in addition to the top-level
   `index` or `README` files (@nteetor, #1031)
 
 ### Navbar
@@ -865,13 +866,13 @@ See additional details in `?build_news`:
   as it has been specified in the DESCRIPTION file. In particular, version
   separators (e.g. `.` and `-`) are preserved. (#1170, @kevinushey)
 
-* add support for navbar submenus: you can create submenus following the 
+* add support for navbar submenus: you can create submenus following the
   convention established in [rstudio/rmarkdown#721](https://github.com/rstudio/rmarkdown/issues/721) (@ijlyttle, @wendtke, #1213)
 
 ### Other
 
 * Updated JS libraries: jquery 3.3.1 -> 3.4.1; bootswatch 3.3.7 -> 3.4.0;
-  bootstrap 3.3.7 -> bootstrap 3.4.1; docsearch 2.6.1 -> 2.6.3 
+  bootstrap 3.3.7 -> bootstrap 3.4.1; docsearch 2.6.1 -> 2.6.3
   (@jayhesselberth).
 
 * Markdown conversion now explicitly allows markdown inside of HTML blocks;
@@ -890,9 +891,9 @@ See additional details in `?build_news`:
 * build citation as specified by the `textVersion` argument of `citEntry` in the
   `CITATION` file (#1096, @yiluheihei)
 
-* `build_site()`, `build_reference()` and `build_home()` gain a parameter 
+* `build_site()`, `build_reference()` and `build_home()` gain a parameter
   `devel` which controls whether you're in deployment or development mode.
-  It generalises and replaces (with deprecation) the existing `document` 
+  It generalises and replaces (with deprecation) the existing `document`
   argument.
 
     Development mode is optimised for rapid iteration and is the default
@@ -904,13 +905,13 @@ See additional details in `?build_news`:
     library, and runs examples/articles in a new process.
 
 * `build_reference()` no longer runs `devtools::document()` (#1079) and
-  `build_home()` no longer re-builds `README.Rmd` or `index.Rmd`. This makes 
-  the scope of responsibility of pkgdown more clear: it now only 
+  `build_home()` no longer re-builds `README.Rmd` or `index.Rmd`. This makes
+  the scope of responsibility of pkgdown more clear: it now only
   creates/modifies files in `doc/`.
 
-* `build_home()` now strips quotes from `Title` and `Description` fields 
-  when generating page metadata. Additionally, you can now override the 
-  defaults via the `title` and `description` fields in the `home` section of 
+* `build_home()` now strips quotes from `Title` and `Description` fields
+  when generating page metadata. Additionally, you can now override the
+  defaults via the `title` and `description` fields in the `home` section of
   `_pkgdown.yml` (#957, @maelle).
 
 * `vignette("linking")` describes how pkgdown's automatic linking works, and
@@ -920,9 +921,9 @@ See additional details in `?build_news`:
 
 ### Rd translation
 
-* `\examples{}` rendering has been completely overhauled so it now first 
+* `\examples{}` rendering has been completely overhauled so it now first
   converts the entire mixed Rd-R block to R prior, and then evaluates the
-  whole thing. This considerably improves the fidelity of the translation 
+  whole thing. This considerably improves the fidelity of the translation
   at a small cost of no longer being able to remove `\donttest{}` and
   friends (#1087).
 
@@ -934,14 +935,14 @@ See additional details in `?build_news`:
 
 * `\tabular{}` translation handles code better (@mitchelloharawild, #978).
 
-* `\subsection{}` contents are now treated as paragraphs, not inline text 
+* `\subsection{}` contents are now treated as paragraphs, not inline text
   (#991).
 
 * `\preformatted{}` blocks preserve important whitespace (#951).
 
 ### Front end
 
-* Links to online documentation for functions in code chunks are no longer 
+* Links to online documentation for functions in code chunks are no longer
   displayed when printing (#1135, @bisaloo).
 
 * Updated fontawesome to v5.7.1. fontawesome 5 [deprecated the `fa` prefix](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#changes).
@@ -949,56 +950,56 @@ See additional details in `?build_news`:
   (e.g.) `fa fa-home` to `fas fa-home`. Brands now have a separate prefix so
   `fa fa-github` becomes `fab fa-github` (#953).
 
-* The navbar is now automatically hidden with 
+* The navbar is now automatically hidden with
   [headroom.js](https://wicky.nillia.ms/headroom.js/).
 
-* The sticky behaviour of the navbar is now implemented in pure CSS instead of 
+* The sticky behaviour of the navbar is now implemented in pure CSS instead of
   relying a the 3rd party javascript library (#1016, @bisaloo)
 
 * Favicons are now automatically built from a package logo (#949).
 
 ### Linking
 
-* Infix operators (e.g., `%in%` and `%*%`) are now linked to their 
+* Infix operators (e.g., `%in%` and `%*%`) are now linked to their
   documentation (#1082).
 
-* Function names can now be included in headers without spurious auto-linking 
+* Function names can now be included in headers without spurious auto-linking
   (#948).
 
-* Links to external documentation now point to [rdrr.io](https://rdrr.io) 
+* Links to external documentation now point to [rdrr.io](https://rdrr.io)
   (#998).
 
 ### Other
 
-* News page recognises more version specifications (including the  
+* News page recognises more version specifications (including the
   "(development version)" now used by usethis) (#980).
 
 * Subdirectories are supported for assets (#939, @ijlyttle).
 
-* A default 404 page (`404.html`) is built, unless a custom `.github/404.md` 
+* A default 404 page (`404.html`) is built, unless a custom `.github/404.md`
   is provided (#947).
 
-* `build_article()` now uses the raw vignette title as page `<title>` 
+* `build_article()` now uses the raw vignette title as page `<title>`
   and `og:title` (@maelle, #1037).
 
-* `build_home()` now looks for license files spelled either as LICENSE or 
+* `build_home()` now looks for license files spelled either as LICENSE or
   LICENCE (#972).
 
-* `build_home()` can find badges in paragraph coming after the comment 
+* `build_home()` can find badges in paragraph coming after the comment
   `<!-- badges: start -->` (#670, @gaborcsardi, @maelle).
 
-* `build_home()` will add a community section to the sidebar if there is either 
-  a code of  conduct (`.github/CODE_OF_CONDUCT.md`) or a contributing guide 
+* `build_home()` will add a community section to the sidebar if there is either
+  a code of  conduct (`.github/CODE_OF_CONDUCT.md`) or a contributing guide
   (`.github/CONTRIBUTING.md`) (#1044, @maelle).
 
 * `build_reference()` gains a `topics` argument which allows you to re-build
   only specified topics.
 
-* `build_site(new_process = TRUE)` gains a timeout, 
-  `options(pkgdown.timeout = 10)`, that can be used to prevent stalled 
-  builds. 
+* `build_site(new_process = TRUE)` gains a timeout,
+  `options(pkgdown.timeout = 10)`, that can be used to prevent stalled
+  builds.
 
-* `deploy_site_github(install = FALSE)` makes it possible to opt out of 
+* `deploy_site_github(install = FALSE)` makes it possible to opt out of
   installation.
 
 * `dev_mode()` now recognises `0.1.9000` as a development version of a package
@@ -1015,7 +1016,7 @@ See additional details in `?build_news`:
 * `content-home.html` template is no longer used when the homepage
   is an `.Rmd` (Reverts #834. Fixes #927, #929)
 
-* `deploy_site_github()` now passes parameters to `build_site()` 
+* `deploy_site_github()` now passes parameters to `build_site()`
   (@noamross, #922), and the documentation gives slightly better advice.
 
 * Correct off-by-one error in navbar highlighting javascript; now no navbar
@@ -1034,9 +1035,9 @@ See additional details in `?build_news`:
   See documentation for how to set up details (@jimhester).
 
 * `build_favicon()` creates high resolution favicons from the package logo,
-  and saves them in `pkgdown/`. They are created using the 
-  <https://realfavicongenerator.net/> API, and are better suited for modern web 
-  usage (e.g. retina display screens, desktop shortcuts, etc.). This also 
+  and saves them in `pkgdown/`. They are created using the
+  <https://realfavicongenerator.net/> API, and are better suited for modern web
+  usage (e.g. retina display screens, desktop shortcuts, etc.). This also
   removes the dependency on the magick package, making automated deployment
   a little easier (@bisaloo, #883).
 
@@ -1047,25 +1048,25 @@ See additional details in `?build_news`:
 
 * `rd2html()` is now exported to facilitate creation of translation reprexes.
 
-* `\Sexpr{}` conversion supports multiple arguments, eliminating 
+* `\Sexpr{}` conversion supports multiple arguments, eliminating
   `x must be a string or a R connection` errors when using `\doi{}` (#738).
 
 * `\tabular{}` conversion better handles empty cells (#780).
 
-* `\usage{}` now supports qualified functions eliminating  
+* `\usage{}` now supports qualified functions eliminating
   `Error in fun_info(x) : Unknown call: ::` errors (#795).
 
 * Invalid tags now generate more informative errors (@BarkleyBG, #771, #891)
 
 ## Front end
 
-* The default footer now displays the version of pkgdown used to build 
-  the site (#876). 
+* The default footer now displays the version of pkgdown used to build
+  the site (#876).
 
 * All third party resources are now fetched from a single CDN and are
   give a SRI hash (@bisaloo, #893).
 
-* The navbar version now has class "version" so you can more easily control 
+* The navbar version now has class "version" so you can more easily control
   its display (#680).
 
 * The default css has been tweaked to ensure that icons are visible on all
@@ -1075,14 +1076,14 @@ See additional details in `?build_news`:
 
 ### Home page
 
-* Can now build sites for older packages that don't have a `Authors@R` field 
+* Can now build sites for older packages that don't have a `Authors@R` field
   (#727).
 
 * Remote urls ending in `.md` are no longer tweaked to end in `.html` (#763).
 
 * Bug report link is only shown if there's a "BugReports" field (#855).
 
-* `content-home.html` template is now used when the homepage is an `.Rmd` 
+* `content-home.html` template is now used when the homepage is an `.Rmd`
   (@goldingn, #787).
 
 * A link to the source `inst/CITATION` was added to the authors page (#714).
@@ -1095,12 +1096,12 @@ See additional details in `?build_news`:
 
 * Unexported functions and test helpers are no longer loaded (#789).
 
-* Selectors that do not match topics now generate a warning. If none of the 
+* Selectors that do not match topics now generate a warning. If none of the
   specified selectors have a match, no topics are selected (#728).
 
 ### Articles
 
-* The display depth of vignette tables of contents can be configured by 
+* The display depth of vignette tables of contents can be configured by
   setting `toc: depth` in `_pkgdown.yml` (#821):
 
   ```yaml
@@ -1113,7 +1114,7 @@ See additional details in `?build_news`:
 * `init_site()` now creates a CNAME file if one doesn't already exist and the
   site's metadata includes a `url` field.
 
-* `build_site()` loses vestigal `mathjax` parameter. This didn't appear to do 
+* `build_site()` loses vestigal `mathjax` parameter. This didn't appear to do
   anything and  no one could remember why it existed (#785).
 
 * `build_site()` now uses colours even if `new_process = TRUE` (@jimhester).
@@ -1122,40 +1123,40 @@ See additional details in `?build_news`:
 
 ## New features
 
-* `build_reference()` and `build_site()` get new `document` argument. When 
-  `TRUE`, the default, will automatically run `devtools::document()` to 
+* `build_reference()` and `build_site()` get new `document` argument. When
+  `TRUE`, the default, will automatically run `devtools::document()` to
   ensure that your documentation is up to date.
 
 * `build_site()` gains a `new_process` argument, which defaults to `TRUE`.
   This will run pkgdown in a separate process, and is recommended practice
   because it improves reproducibility (#647).
 
-* Improved display for icons: icons must be 30px and stored in top-level 
-  `icons/` directory. They are embedded in a separate column of reference 
+* Improved display for icons: icons must be 30px and stored in top-level
+  `icons/` directory. They are embedded in a separate column of reference
   index table, instead of being inside a comment (!) (#607).
 
 ## Front end
 
-* Added a keyboard shortcut for searching. Press `shift` + `/` (`?`) to move 
-  focus to the search bar (#642). 
+* Added a keyboard shortcut for searching. Press `shift` + `/` (`?`) to move
+  focus to the search bar (#642).
 
 * The Algolia logo is correctly shown in the search results (#673).
 
-* Navbar active tab highlighting uses a superior approach (suggested by 
+* Navbar active tab highlighting uses a superior approach (suggested by
   @jcheng5) which should mean that the active page is correctly highlighted
   in all scenarios (#660).
 
-* `pkgdown.js` is better isolated so it should still work even if you 
+* `pkgdown.js` is better isolated so it should still work even if you
   load html widgets that import a different version of jquery (#655).
 
 ## Improvements to Rd translation
 
-* `vignette()` calls that don't link to existing vignettes silently fail 
-  to link instead of generating an uninformative error messages (#652). 
-  Automatic linking works for re-exported objects that are not functions 
+* `vignette()` calls that don't link to existing vignettes silently fail
+  to link instead of generating an uninformative error messages (#652).
+  Automatic linking works for re-exported objects that are not functions
   (@gaborcsardi, #666).
 
-* Empty `\section{}`s are ignored (#656). Previously, empty sections caused 
+* Empty `\section{}`s are ignored (#656). Previously, empty sections caused
   error `Error in rep(TRUE, length(x) - 1)`.
 
 * `\Sexpr{}` supports `results=text`, `results=Rd` and `results=hide` (#651).
@@ -1164,13 +1165,13 @@ See additional details in `?build_news`:
 
 ## Minor bug fixes and improvements
 
-* Add `inst/pkgdown.yml` as a possible site configuration file so that packages 
+* Add `inst/pkgdown.yml` as a possible site configuration file so that packages
   on CRAN can be built without needing the development version (#662).
 
-* Default navbar template now uses site title, not package name (the package 
+* Default navbar template now uses site title, not package name (the package
   name is the default title, so this will not affect most sites) (#654).
 
-* You can suppress indexing by search engines by setting `noindex: true` 
+* You can suppress indexing by search engines by setting `noindex: true`
   `pkgdown.yml` (#686)
 
     ```yaml
@@ -1179,29 +1180,29 @@ See additional details in `?build_news`:
         noindex: true
     ```
 
-* `build_article()` sets `IN_PKGDOWN` env var so `in_pkgdown()` works 
+* `build_article()` sets `IN_PKGDOWN` env var so `in_pkgdown()` works
   (#650).
 
 * `build_home()`: CITATION files with non-UTF-8 encodings (latin1) work
-  correctly, instead of generating an error. For non-UTF-8 locales, ensure you 
-  have e.g. `Encoding: latin1` in your `DESCRIPTION`; but best practice is to 
+  correctly, instead of generating an error. For non-UTF-8 locales, ensure you
+  have e.g. `Encoding: latin1` in your `DESCRIPTION`; but best practice is to
   re-enode your CITATION file to UTF-8 (#689).
 
-* `build_home()`: Markdown files (e.g., `CODE_OF_CONDUCT.md`) stored in 
+* `build_home()`: Markdown files (e.g., `CODE_OF_CONDUCT.md`) stored in
   `.github/` are copied and linked correctly (#682).
 
 * `build_news()`: Multi-page changelogs (generated from `NEWS.md` with
   `news: one_page: false` in `_pkgdown.yml`) are rendered correctly.
 
-* `build_reference()`: reference index shows infix functions (like `%+%`) as 
+* `build_reference()`: reference index shows infix functions (like `%+%`) as
   `` `%+%` ``, not `` `%+%`() `` on  (#659).
 
 # pkgdown 1.0.0
 
 * Major refactoring of path handling. `build_` functions no longer take
-  `path` or `depth` arguments. Instead, set the `destination` directory 
+  `path` or `depth` arguments. Instead, set the `destination` directory
   at the top level of `pkgdown.yml`.
 
 * Similarly, `build_news()` no longer takes a `one_page` argument;
-  this should now be specified in the `_pkgdown.yml` instead. See the 
+  this should now be specified in the `_pkgdown.yml` instead. See the
   documentation for an example.

--- a/tests/testthat/_snaps/templates.md
+++ b/tests/testthat/_snaps/templates.md
@@ -16,3 +16,9 @@
       Error in `as_pkgdown()`:
       ! Both template.bootstrap and template.bslib.version are set.
 
+# Warns when Bootstrap theme is specified in multiple locations
+
+    Multiple Bootstrap preset themes were set. Using "flatly" from template.bslib.preset.
+    x Found template.bslib.preset, template.bslib.bootswatch, template.bootswatch, and template.params.bootswatch.
+    i Remove extraneous theme declarations to avoid this warning.
+

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,6 +1,6 @@
 test_that("check_bslib_theme() works", {
   pkg <- as_pkgdown(test_path("assets/reference"))
-  expect_equal(check_bslib_theme("_default", pkg, bs_version = 4), "default")
+  expect_equal(check_bslib_theme("default", pkg, bs_version = 4), "default")
   expect_equal(check_bslib_theme("lux", pkg, bs_version = 4), "lux")
   expect_snapshot_error(check_bslib_theme("paper", pkg, bs_version = 4))
   expect_snapshot_error(check_bslib_theme("paper", pkg, bs_version = 4, field = c("template", "preset")))

--- a/tests/testthat/test-templates.R
+++ b/tests/testthat/test-templates.R
@@ -146,3 +146,67 @@ test_that("Valid local Bootstrap version masks invalid template package", {
     )))
   )
 })
+
+# Bootstrap theme resolution ----------------------------------------------
+test_that("Finds Bootstrap theme in all the places", {
+  pkg_sketchy <- local_pkgdown_site(meta = '
+    template:
+      bslib:
+        preset: sketchy
+        version: 5
+  ')
+  pkg_superhero <- local_pkgdown_site(meta = '
+    template:
+      bslib:
+        preset: superhero
+        version: 5
+  ')
+  pkg_cosmo <- local_pkgdown_site(meta = '
+    template:
+      bootstrap: 5
+      bootswatch: cosmo
+  ')
+
+  pkg_yeti <- local_pkgdown_site(meta = '
+    template:
+      bootstrap: 5
+      params:
+        bootswatch: yeti
+  ')
+
+  expect_equal(get_bslib_theme(pkg_sketchy), "sketchy")
+  expect_equal(get_bslib_theme(pkg_superhero), "superhero")
+  expect_equal(get_bslib_theme(pkg_cosmo), "cosmo")
+  expect_equal(get_bslib_theme(pkg_yeti), "yeti")
+})
+
+test_that("Warns when Bootstrap theme is specified in multiple locations", {
+  pkg <- local_pkgdown_site(meta = '
+    template:
+      bootstrap: 5
+      bootswatch: cerulean
+      bslib:
+        preset: flatly
+        bootswatch: lux
+      params:
+        bootswatch: darkly
+  ')
+
+  expect_snapshot_warning(
+    get_bslib_theme(pkg)
+  )
+})
+
+test_that("Doesn't warn when the same Bootstrap theme is specified in multiple locations", {
+  pkg <- local_pkgdown_site(meta = '
+    template:
+      bootswatch: cerulean
+      bslib:
+        preset: cerulean
+  ')
+
+  expect_equal(
+    expect_silent(get_bslib_theme(pkg)),
+    "cerulean"
+  )
+})


### PR DESCRIPTION
Updates `get_bslib_theme()` to support `template.bslib.bootswatch`. 

The Boostrap preset theme (a.k.a. Bootswatch) can be included in several places. `get_bslib_theme()` will use the first available (see order below), warning if different themes are specified in more than one place.

```yaml
template:
  bootstrap: 5
  bootswatch: pulse # <3>
  bslib:
    preset: united # <1>
    bootswatch: simplex # <2>
  params:
    bootswatch: quartz # <4>
```

Using the above snippet in a `_pkgdown.yml` would result in the following:

```r
pkg <- local_pkgdown_site(meta = '
  template: 
    bootstrap: 5 
    bootswatch: pulse # <3> 
    bslib: 
      preset: united # <1> 
      bootswatch: simplex # <2> 
    params: 
      bootswatch: quartz # <4>
')

get_bslib_theme(pkg)
#> Warning: Multiple Bootstrap preset themes were set. Using "united" from
#> template.bslib.preset.
#> ✖ Found template.bslib.preset, template.bslib.bootswatch, template.bootswatch,
#>   and template.params.bootswatch.
#> ℹ Remove extraneous theme declarations to avoid this warning.
#> [1] "united"
```