### PR TITLE
Include full article path in site metadata

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -69,6 +69,6 @@ context_set_scoped <- function(name, value, scope = parent.frame()) {
 article_index <- function(pkg) {
   set_names(
     fs::path_rel(pkg$vignettes$file_out, "articles"),
-    path_file(pkg$vignettes$name)
+    pkg$vignettes$name
   )
 }

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -47,3 +47,15 @@ test_that("site meta doesn't break unexpectedly", {
 
   expect_snapshot(yaml)
 })
+
+test_that("site meta includes vignette subdirectories", {
+  pkg <- local_pkgdown_site()
+
+  vig_path <- path(pkg$src_path, "vignettes") 
+  dir_create(path(vig_path, "a"))
+  file_create(path(vig_path, "a", c("a.Rmd", "b.Rmd")))
+  pkg <- as_pkgdown(pkg$src_path)
+
+  meta <- site_meta(pkg)
+  expect_equal(meta$articles, list("a/a" = "a/a.html", "a/b" = "a/b.html"))
+})


### PR DESCRIPTION
This is a pragmatic fix so that autolinking for bslib should start working again.

Fixes #2350