### PR TITLE
Refactor config error messages

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -395,9 +395,9 @@ data_articles_index <- function(pkg = ".") {
   missing <- missing[!article_is_intro(missing, package = pkg$package)]
 
   if (length(missing) > 0) {
-    cli::cli_abort(
-      "{length(missing)} vignette{?s} missing from index in \\
-      {config_path(pkg)}: {.val {missing}}.",
+    config_abort(
+      pkg,
+      "{length(missing)} vignette{?s} missing from index: {.val {missing}}",
       call = caller_env()
     )
   }

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -397,7 +397,7 @@ data_articles_index <- function(pkg = ".") {
   if (length(missing) > 0) {
     config_abort(
       pkg,
-      "{length(missing)} vignette{?s} missing from index: {.val {missing}}",
+      "{length(missing)} vignette{?s} missing from index: {.val {missing}}.",
       call = caller_env()
     )
   }

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -397,7 +397,7 @@ data_articles_index <- function(pkg = ".") {
   if (length(missing) > 0) {
     cli::cli_abort(
       "{length(missing)} vignette{?s} missing from index in \\
-      {pkgdown_config_href({pkg$src_path})}: {.val {missing}}.",
+      {config_path(pkg)}: {.val {missing}}.",
       call = caller_env()
     )
   }

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -4,17 +4,17 @@ data_authors <- function(pkg = ".", roles = default_roles()) {
 
   all <- pkg %>%
     pkg_authors() %>%
-    purrr::map(author_list, author_info)
+    purrr::map(author_list, author_info, pkg = pkg)
 
   main <- pkg %>%
     pkg_authors(roles) %>%
-    purrr::map(author_list, author_info)
+    purrr::map(author_list, author_info, pkg = pkg)
 
   more_authors <- length(main) != length(all)
 
   comments <- pkg %>%
     pkg_authors() %>%
-    purrr::map(author_list, author_info) %>%
+    purrr::map(author_list, author_info, pkg = pkg) %>%
     purrr::map("comment") %>%
     purrr::compact() %>%
     length() > 0
@@ -55,9 +55,9 @@ data_home_sidebar_authors <- function(pkg = ".") {
 
   sidebar <- pkg$meta$authors$sidebar
   bullets <- c(
-    markdown_text_inline(sidebar$before, "authors.sidebar.before"),
+    markdown_text_inline(sidebar$before, "authors.sidebar.before", pkg = pkg),
     authors,
-    markdown_text_inline(sidebar$after, "authors.sidebar.after")
+    markdown_text_inline(sidebar$after, "authors.sidebar.after", pkg = pkg)
   )
 
   if (data$needs_page) {
@@ -89,7 +89,11 @@ author_name <- function(x, authors, pkg) {
   author <- authors[[name]]
 
   if (!is.null(author$html)) {
-    name <- markdown_text_inline(author$html, paste0("authors.", name, ".html"))
+    name <- markdown_text_inline(
+      author$html,
+      paste0("authors.", name, ".html"),
+      pkg = pkg
+    )
   }
 
   if (is.null(author$href)) {
@@ -109,8 +113,8 @@ format_author_name <- function(given, family) {
   }
 }
 
-author_list <- function(x, authors_info = NULL, comment = FALSE) {
-  name <- author_name(x, authors_info)
+author_list <- function(x, authors_info = NULL, comment = FALSE, pkg = ".") {
+  name <- author_name(x, authors_info, pkg = pkg)
 
   roles <- paste0(role_lookup(x$role), collapse = ", ")
   substr(roles, 1, 1) <- toupper(substr(roles, 1, 1))

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -56,12 +56,12 @@ data_home_sidebar_authors <- function(pkg = ".") {
   bullets <- c(
     markdown_text_inline(
       pkg$meta$authors$sidebar$before,
-      pkgdown_field(pkg, c("authors", "sidebar", "before"))
+      pkgdown_field(c("authors", "sidebar", "before"))
     ),
     authors,
     markdown_text_inline(
       pkg$meta$authors$sidebar$after,
-      pkgdown_field(pkg, c("authors", "sidebar", "after"))
+      pkgdown_field(c("authors", "sidebar", "after"))
     )
   )
 
@@ -96,7 +96,7 @@ author_name <- function(x, authors, pkg) {
   if (!is.null(author$html)) {
     name <- markdown_text_inline(
       author$html,
-      pkgdown_field(pkg, c("authors", name, "html"))
+      pkgdown_field(c("authors", name, "html"))
     )
   }
 

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -56,12 +56,12 @@ data_home_sidebar_authors <- function(pkg = ".") {
   bullets <- c(
     markdown_text_inline(
       pkg$meta$authors$sidebar$before,
-      pkgdown_field(c("authors", "sidebar", "before"))
+      config_field(c("authors", "sidebar", "before"))
     ),
     authors,
     markdown_text_inline(
       pkg$meta$authors$sidebar$after,
-      pkgdown_field(c("authors", "sidebar", "after"))
+      config_field(c("authors", "sidebar", "after"))
     )
   )
 
@@ -96,7 +96,7 @@ author_name <- function(x, authors, pkg) {
   if (!is.null(author$html)) {
     name <- markdown_text_inline(
       author$html,
-      pkgdown_field(c("authors", name, "html"))
+      config_field(c("authors", name, "html"))
     )
   }
 

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -4,17 +4,17 @@ data_authors <- function(pkg = ".", roles = default_roles()) {
 
   all <- pkg %>%
     pkg_authors() %>%
-    purrr::map(author_list, author_info, pkg = pkg)
+    purrr::map(author_list, author_info)
 
   main <- pkg %>%
     pkg_authors(roles) %>%
-    purrr::map(author_list, author_info, pkg = pkg)
+    purrr::map(author_list, author_info)
 
   more_authors <- length(main) != length(all)
 
   comments <- pkg %>%
     pkg_authors() %>%
-    purrr::map(author_list, author_info, pkg = pkg) %>%
+    purrr::map(author_list, author_info) %>%
     purrr::map("comment") %>%
     purrr::compact() %>%
     length() > 0
@@ -53,16 +53,11 @@ data_home_sidebar_authors <- function(pkg = ".") {
 
   authors <- data$main %>% purrr::map_chr(author_desc, comment = FALSE)
 
+  sidebar <- pkg$meta$authors$sidebar
   bullets <- c(
-    markdown_text_inline(
-      pkg$meta$authors$sidebar$before,
-      config_field(c("authors", "sidebar", "before"))
-    ),
+    markdown_text_inline(sidebar$before, "authors.sidebar.before"),
     authors,
-    markdown_text_inline(
-      pkg$meta$authors$sidebar$after,
-      config_field(c("authors", "sidebar", "after"))
-    )
+    markdown_text_inline(sidebar$after, "authors.sidebar.after")
   )
 
   if (data$needs_page) {
@@ -94,10 +89,7 @@ author_name <- function(x, authors, pkg) {
   author <- authors[[name]]
 
   if (!is.null(author$html)) {
-    name <- markdown_text_inline(
-      author$html,
-      config_field(c("authors", name, "html"))
-    )
+    name <- markdown_text_inline(author$html, paste0("authors.", name, ".html"))
   }
 
   if (is.null(author$href)) {
@@ -117,8 +109,8 @@ format_author_name <- function(given, family) {
   }
 }
 
-author_list <- function(x, authors_info = NULL, comment = FALSE, pkg) {
-  name <- author_name(x, authors_info, pkg = pkg)
+author_list <- function(x, authors_info = NULL, comment = FALSE) {
+  name <- author_name(x, authors_info)
 
   roles <- paste0(role_lookup(x$role), collapse = ", ")
   substr(roles, 1, 1) <- toupper(substr(roles, 1, 1))

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -65,14 +65,9 @@ data_home_sidebar <- function(pkg = ".", call = caller_env()) {
   if (length(html_path)) {
     if (!file.exists(html_path)) {
       rel_html_path <- fs::path_rel(html_path, pkg$src_path)
-
-      msg_fld <- config_field(c('home', 'sidebar', 'html'), fmt = TRUE)
-
-      config_abort(pkg,
-        c(
-          "Can't locate {.file {rel_html_path}}.",
-          x = paste0(msg_fld, " is misconfigured.")
-        ),
+      config_abort(
+        pkg,
+        "Path specified in {.field home.sidebar.html} ({.file {rel_html_path}}) doesn't exist.",
         call = call
       )
 

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -67,11 +67,9 @@ data_home_sidebar <- function(pkg = ".", call = caller_env()) {
       rel_html_path <- fs::path_rel(html_path, pkg$src_path)
       config_abort(
         pkg,
-        "Path specified in {.field home.sidebar.html} ({.file {rel_html_path}}) doesn't exist.",
+        "{.field home.sidebar.html} specifies a file that doesn't exist ({.file {rel_html_path}}).",
         call = call
       )
-
-
     }
     return(read_file(html_path))
   }

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -68,11 +68,10 @@ data_home_sidebar <- function(pkg = ".", call = caller_env()) {
 
       msg_fld <- pkgdown_field(c('home', 'sidebar', 'html'), fmt = TRUE)
 
-      cli::cli_abort(
+      config_abort(pkg,
         c(
           "Can't locate {.file {rel_html_path}}.",
-          x = paste0(msg_fld, " is misconfigured."),
-          i = "Fix the problem in {config_path(pkg)}."
+          x = paste0(msg_fld, " is misconfigured.")
         ),
         call = call
       )

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -66,14 +66,13 @@ data_home_sidebar <- function(pkg = ".", call = caller_env()) {
     if (!file.exists(html_path)) {
       rel_html_path <- fs::path_rel(html_path, pkg$src_path)
 
-      msg_fld <- pkgdown_field(
-        pkg, c('home', 'sidebar', 'html'), fmt = TRUE, cfg = TRUE
-      )
+      msg_fld <- pkgdown_field(c('home', 'sidebar', 'html'), fmt = TRUE)
 
       cli::cli_abort(
         c(
           "Can't locate {.file {rel_html_path}}.",
-          x = paste0(msg_fld, " is misconfigured.")
+          x = paste0(msg_fld, " is misconfigured."),
+          i = "Fix the problem in {config_path(pkg)}."
         ),
         call = call
       )

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -66,7 +66,7 @@ data_home_sidebar <- function(pkg = ".", call = caller_env()) {
     if (!file.exists(html_path)) {
       rel_html_path <- fs::path_rel(html_path, pkg$src_path)
 
-      msg_fld <- pkgdown_field(c('home', 'sidebar', 'html'), fmt = TRUE)
+      msg_fld <- config_field(c('home', 'sidebar', 'html'), fmt = TRUE)
 
       config_abort(pkg,
         c(

--- a/R/build-redirects.R
+++ b/R/build-redirects.R
@@ -39,12 +39,9 @@ build_redirects <- function(pkg = ".",
   cli::cli_rule("Building redirects")
   if (is.null(pkg$meta$url)) {
     msg_fld <- pkgdown_field("url", fmt = TRUE)
-    cli::cli_abort(
-      c(
-        paste0(msg_fld, " is required to generate redirects."),
-        i = "Fix the problem in {config_path(pkg)}."
-      ),
-      call = caller_env()
+    config_abort(
+      pkg,
+      paste0(msg_fld, " is required to generate redirects.")
     )
   }
 
@@ -57,12 +54,10 @@ build_redirects <- function(pkg = ".",
 
 build_redirect <- function(entry, index, pkg) {
   if (!is.character(entry) || length(entry) != 2) {
-    msg_fld <- pkgdown_field("url", fmt = TRUE)
-    cli::cli_abort(
-      c(
-        "Entry {.emph {index}} must be a character vector of length 2.",
-        x = paste0("Edit ", msg_fld, " in {config_path(pkg)}.")
-      ),
+    msg_fld <- pkgdown_field("redirects")
+    config_abort(
+      pkg,
+      "{.field {msg_fld}[[{index}]]} must be a character vector of length 2.",
       call = caller_env()
     )
   }

--- a/R/build-redirects.R
+++ b/R/build-redirects.R
@@ -38,7 +38,7 @@ build_redirects <- function(pkg = ".",
 
   cli::cli_rule("Building redirects")
   if (is.null(pkg$meta$url)) {
-    msg_fld <- pkgdown_field("url", fmt = TRUE)
+    msg_fld <- config_field("url", fmt = TRUE)
     config_abort(
       pkg,
       paste0(msg_fld, " is required to generate redirects.")
@@ -54,7 +54,7 @@ build_redirects <- function(pkg = ".",
 
 build_redirect <- function(entry, index, pkg) {
   if (!is.character(entry) || length(entry) != 2) {
-    msg_fld <- pkgdown_field("redirects")
+    msg_fld <- config_field("redirects")
     config_abort(
       pkg,
       "{.field {msg_fld}[[{index}]]} must be a character vector of length 2.",

--- a/R/build-redirects.R
+++ b/R/build-redirects.R
@@ -38,9 +38,12 @@ build_redirects <- function(pkg = ".",
 
   cli::cli_rule("Building redirects")
   if (is.null(pkg$meta$url)) {
-    msg_fld <- pkgdown_field(pkg, "url", cfg = TRUE, fmt = TRUE)
+    msg_fld <- pkgdown_field("url", fmt = TRUE)
     cli::cli_abort(
-      paste0(msg_fld, " is required to generate redirects."),
+      c(
+        paste0(msg_fld, " is required to generate redirects."),
+        i = "Fix the problem in {config_path(pkg)}."
+      ),
       call = caller_env()
     )
   }
@@ -54,11 +57,11 @@ build_redirects <- function(pkg = ".",
 
 build_redirect <- function(entry, index, pkg) {
   if (!is.character(entry) || length(entry) != 2) {
-    msg_fld <- pkgdown_field(pkg, "url", cfg = TRUE, fmt = TRUE)
+    msg_fld <- pkgdown_field("url", fmt = TRUE)
     cli::cli_abort(
       c(
         "Entry {.emph {index}} must be a character vector of length 2.",
-        x = paste0("Edit ", msg_fld, ".")
+        x = paste0("Edit ", msg_fld, " in {config_path(pkg)}.")
       ),
       call = caller_env()
     )

--- a/R/build-redirects.R
+++ b/R/build-redirects.R
@@ -38,11 +38,7 @@ build_redirects <- function(pkg = ".",
 
   cli::cli_rule("Building redirects")
   if (is.null(pkg$meta$url)) {
-    msg_fld <- config_field("url", fmt = TRUE)
-    config_abort(
-      pkg,
-      paste0(msg_fld, " is required to generate redirects.")
-    )
+    config_abort(pkg, "{.field url} is required to generate redirects.")
   }
 
   purrr::iwalk(
@@ -54,10 +50,9 @@ build_redirects <- function(pkg = ".",
 
 build_redirect <- function(entry, index, pkg) {
   if (!is.character(entry) || length(entry) != 2) {
-    msg_fld <- config_field("redirects")
     config_abort(
       pkg,
-      "{.field {msg_fld}[[{index}]]} must be a character vector of length 2.",
+      "{.field redirects[[{index}]]} must be a character vector of length 2.",
       call = caller_env()
     )
   }

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -140,7 +140,10 @@ check_missing_topics <- function(rows, pkg, error_call = caller_env()) {
   if (any(missing)) {
     config_abort(
       pkg, 
-      "{sum(missing)} topic{?s} missing from index: {.val {pkg$topics$name[missing]}}.",
+      c(
+        "{sum(missing)} topic{?s} missing from index: {.val {pkg$topics$name[missing]}}.",
+        i = "Either use {.code @keywords internal} to drop from index, or"
+      ),
       call = error_call
     )
   }

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -93,7 +93,7 @@ check_contents <- function(contents, id, pkg) {
       pkg,
       c(
         "Section {.val {id}}: {.field {which(!is_char)}} must be a character.",
-        i = "You might need to add '' around special values like 'N' or 'off'"
+        i = "You might need to add '' around special YAML values like 'N' or 'off'"
       ),
       call = call
     )
@@ -140,7 +140,7 @@ check_missing_topics <- function(rows, pkg, error_call = caller_env()) {
   if (any(missing)) {
     config_abort(
       pkg, 
-      "{sum(missing)} topic{?s} missing from index: {.val {pkg$topics$name[missing]}}",
+      "{sum(missing)} topic{?s} missing from index: {.val {pkg$topics$name[missing]}}.",
       call = error_call
     )
   }

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -68,38 +68,33 @@ data_reference_index_rows <- function(section, index, pkg) {
 }
 
 check_contents <- function(contents, id, pkg) {
-  malformed <- "This typically indicates that your {config_path(pkg)} is malformed."
   call <- quote(build_reference_index())
 
   if (length(contents) == 0) {
-    cli::cli_abort(
-      c(
-        "Section {.val {id}}: {.field contents} is empty.",
-        i = malformed
-      ),
+    config_abort(
+      pkg,
+      "Section {.val {id}}: {.field contents} is empty.",
       call = call
     )
   }
 
   is_null <- purrr::map_lgl(contents, is.null)
   if (any(is_null)) {
-    cli::cli_abort(
-      c(
-        "Section {.val {id}}: contents {.field {which(is_null)}} is empty.",
-        i = malformed
-      ),
+    config_abort(
+      pkg,
+      "Section {.val {id}}: contents {.field {which(is_null)}} is empty.",
       call = call
     )
   }
 
   is_char <- purrr::map_lgl(contents, is.character)
   if (!all(is_char)) {
-    cli::cli_abort(
+    config_abort(
+      pkg,
       c(
         "Section {.val {id}}: {.field {which(!is_char)}} must be a character.",
-        i = "You might need to add '' around special values like 'N' or 'off'",
-        i = malformed
-      ), 
+        i = "You might need to add '' around special values like 'N' or 'off'"
+      ),
       call = call
     )
   }
@@ -143,11 +138,10 @@ check_missing_topics <- function(rows, pkg, error_call = caller_env()) {
   missing <- !in_index & !pkg$topics$internal
 
   if (any(missing)) {
-    cli::cli_abort(c(
-      "All topics must be included in reference index",
-      "x" = "Missing topics: {pkg$topics$name[missing]}",
-      i = "Either add to {config_path(pkg)} or use @keywords internal"
-    ),
-    call = error_call)
+    config_abort(
+      pkg, 
+      "{sum(missing)} topic{?s} missing from index: {.val {pkg$topics$name[missing]}}",
+      call = error_call
+    )
   }
 }

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -68,7 +68,7 @@ data_reference_index_rows <- function(section, index, pkg) {
 }
 
 check_contents <- function(contents, id, pkg) {
-  malformed <- "This typically indicates that your {pkgdown_config_href(pkg$src_path)} is malformed."
+  malformed <- "This typically indicates that your {config_path(pkg)} is malformed."
   call <- quote(build_reference_index())
 
   if (length(contents) == 0) {
@@ -146,7 +146,7 @@ check_missing_topics <- function(rows, pkg, error_call = caller_env()) {
     cli::cli_abort(c(
       "All topics must be included in reference index",
       "x" = "Missing topics: {pkg$topics$name[missing]}",
-      i = "Either add to {pkgdown_config_href({pkg$src_path})} or use @keywords internal"
+      i = "Either add to {config_path(pkg)} or use @keywords internal"
     ),
     call = error_call)
   }

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -31,7 +31,7 @@ data_reference_index_rows <- function(section, index, pkg) {
   rows <- list()
   if (has_name(section, "title")) {
     rows[[1]] <- list(
-      title = markdown_text_inline(section$title),
+      title = markdown_text_inline(section$title, pkg = pkg),
       slug = make_slug(section$title),
       desc = markdown_text_block(section$desc),
       is_internal = is_internal
@@ -40,7 +40,7 @@ data_reference_index_rows <- function(section, index, pkg) {
 
   if (has_name(section, "subtitle")) {
     rows[[2]] <- list(
-      subtitle = markdown_text_inline(section$subtitle),
+      subtitle = markdown_text_inline(section$subtitle, pkg = pkg),
       slug = make_slug(section$subtitle),
       desc = markdown_text_block(section$desc),
       is_internal = is_internal

--- a/R/check.R
+++ b/R/check.R
@@ -20,6 +20,6 @@ check_pkgdown <- function(pkg = ".") {
   data_reference_index(pkg)
 
   cli::cli_inform(c(
-    "v" = "No problems found in {pkgdown_config_href({pkg$src_path})}"
+    "v" = "No problems found in {config_path(pkg)}."
   ))
 }

--- a/R/check.R
+++ b/R/check.R
@@ -19,7 +19,5 @@ check_pkgdown <- function(pkg = ".") {
   data_articles_index(pkg)
   data_reference_index(pkg)
 
-  cli::cli_inform(c(
-    "v" = "No problems found in {config_path(pkg)}."
-  ))
+  cli::cli_inform(c("v" = "No problems found."))
 }

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -17,7 +17,7 @@ markdown_text_inline <- function(text, where = "<inline>", ...) {
   children <- xml2::xml_children(xml2::xml_find_first(html, ".//body"))
   if (length(children) > 1) {
     cli::cli_abort(
-      "Can't use a block element in {.var {where}}, need an inline element: {.var {text}}",
+      "{.field {where}} must supply an inline element, not a block element.",
       call = caller_env()
     )
   }

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -8,7 +8,7 @@ markdown_text <- function(text, ...) {
   markdown_path_html(md_path, ...)
 }
 
-markdown_text_inline <- function(text, where = "<inline>", ...) {
+markdown_text_inline <- function(text, where = "<inline>", pkg, ...) {
   html <- markdown_text(text, ...)
   if (is.null(html)) {
     return()
@@ -16,7 +16,8 @@ markdown_text_inline <- function(text, where = "<inline>", ...) {
 
   children <- xml2::xml_children(xml2::xml_find_first(html, ".//body"))
   if (length(children) > 1) {
-    cli::cli_abort(
+    config_abort(
+      pkg,
       "{.field {where}} must supply an inline element, not a block element.",
       call = caller_env()
     )

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -67,7 +67,7 @@ navbar_links <- function(pkg, depth = 0L) {
 render_navbar_links <- function(x, depth = 0L, pkg) {
   if (!is.list(x)) {
     cli::cli_abort(
-      "Invalid navbar specification in {pkgdown_config_href({pkg$src_path})}", 
+      "Invalid navbar specification in {config_path(pkg)}.", 
       call = quote(data_template())
     )
   }

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -66,8 +66,9 @@ navbar_links <- function(pkg, depth = 0L) {
 
 render_navbar_links <- function(x, depth = 0L, pkg) {
   if (!is.list(x)) {
-    cli::cli_abort(
-      "Invalid navbar specification in {config_path(pkg)}.", 
+    config_abort(
+      pkg,
+      "Invalid navbar specification.", 
       call = quote(data_template())
     )
   }

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -68,7 +68,7 @@ render_navbar_links <- function(x, depth = 0L, pkg) {
   if (!is.list(x)) {
     config_abort(
       pkg,
-      "Invalid navbar specification.", 
+      "{.field navbar} is incorrectly specified.",
       call = quote(data_template())
     )
   }

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -68,7 +68,10 @@ render_navbar_links <- function(x, depth = 0L, pkg) {
   if (!is.list(x)) {
     config_abort(
       pkg,
-      "{.field navbar} is incorrectly specified.",
+      c(
+        "{.field navbar} is incorrectly specified.",
+        i = "See details in {.vignette pkgdown::customise}."
+      ),
       call = quote(data_template())
     )
   }

--- a/R/package.R
+++ b/R/package.R
@@ -191,13 +191,6 @@ pkgdown_config_path <- function(path) {
     )
   )
 }
-pkgdown_config_href <- function(path) {
-  config <- pkgdown_config_path(path)
-  if (is.null(config)) {
-    cli::cli_abort("Can't find {.file _pkgdown.yml}.", .internal = TRUE)
-  }
-  cli::style_hyperlink(fs::path_file(config), paste0("file://", config))
-}
 
 read_meta <- function(path) {
   path <- pkgdown_config_path(path)

--- a/R/package.R
+++ b/R/package.R
@@ -147,8 +147,8 @@ get_bootstrap_version <- function(template, config_path = NULL, package = NULL) 
       c(
         sprintf(
           "Both {.field %s} and {.field %s} are set.",
-          pkgdown_field(c("template", "bootstrap")),
-          pkgdown_field(c("template", "bslib", "version"))
+          config_field(c("template", "bootstrap")),
+          config_field(c("template", "bslib", "version"))
         ),
         i = instructions
       ),
@@ -168,7 +168,7 @@ check_bootstrap_version <- function(version, pkg) {
     cli::cli_warn("{.var bootstrap: 4} no longer supported, using {.var bootstrap: 5} instead")
     5
   } else {
-    msg_fld <- pkgdown_field(c("template", "bootstrap"), fmt = TRUE)
+    msg_fld <- config_field(c("template", "bootstrap"), fmt = TRUE)
     config_abort(
       pkg,
       c(

--- a/R/package.R
+++ b/R/package.R
@@ -147,8 +147,8 @@ get_bootstrap_version <- function(template, config_path = NULL, package = NULL) 
       c(
         sprintf(
           "Both {.field %s} and {.field %s} are set.",
-          pkgdown_field(list(), c("template", "bootstrap")),
-          pkgdown_field(list(), c("template", "bslib", "version"))
+          pkgdown_field(c("template", "bootstrap")),
+          pkgdown_field(c("template", "bslib", "version"))
         ),
         i = instructions
       ),
@@ -168,11 +168,12 @@ check_bootstrap_version <- function(version, pkg) {
     cli::cli_warn("{.var bootstrap: 4} no longer supported, using {.var bootstrap: 5} instead")
     5
   } else {
-    msg_fld <- pkgdown_field(pkg, c("template", "bootstrap"), cfg = TRUE, fmt = TRUE)
+    msg_fld <- pkgdown_field(c("template", "bootstrap"), fmt = TRUE)
     cli::cli_abort(
       c(
         "Boostrap version must be 3 or 5.",
-        x = paste0("You set a value of {.val {version}} to ", msg_fld, ".")
+        x = paste0("You set a value of {.val {version}} to ", msg_fld, "."),
+        i = "Edit {config_path(pkg)} to fix the problem."
       ),
       call = caller_env()
     )

--- a/R/package.R
+++ b/R/package.R
@@ -145,11 +145,7 @@ get_bootstrap_version <- function(template, config_path = NULL, package = NULL) 
 
     cli::cli_abort(
       c(
-        sprintf(
-          "Both {.field %s} and {.field %s} are set.",
-          config_field(c("template", "bootstrap")),
-          config_field(c("template", "bslib", "version"))
-        ),
+        "Must set one only of {.field template.bootstrap} and {.field template.bslib.version}.",
         i = instructions
       ),
       call = caller_env()
@@ -168,13 +164,9 @@ check_bootstrap_version <- function(version, pkg) {
     cli::cli_warn("{.var bootstrap: 4} no longer supported, using {.var bootstrap: 5} instead")
     5
   } else {
-    msg_fld <- config_field(c("template", "bootstrap"), fmt = TRUE)
     config_abort(
       pkg,
-      c(
-        "Boostrap version must be 3 or 5.",
-        x = paste0("You set a value of {.val {version}} in ", msg_fld, ".")
-      ),
+      "{.field template.bootstrap} must be 3 or 5, not {.val {version}}.",
       call = caller_env()
     )
   }

--- a/R/package.R
+++ b/R/package.R
@@ -136,7 +136,7 @@ get_bootstrap_version <- function(template, config_path = NULL, package = NULL) 
         paste0(
           "Update the pkgdown config in {.pkg ", package, "}, ",
           "or set a Bootstrap version in your {.file ",
-          if (is.null(config_path)) "_pkgdown.yml" else config_path,
+          config_path %||% "_pkgdown.yml",
           "}."
         )
       } else if (!is.null(config_path)) {
@@ -169,11 +169,11 @@ check_bootstrap_version <- function(version, pkg) {
     5
   } else {
     msg_fld <- pkgdown_field(c("template", "bootstrap"), fmt = TRUE)
-    cli::cli_abort(
+    config_abort(
+      pkg,
       c(
         "Boostrap version must be 3 or 5.",
-        x = paste0("You set a value of {.val {version}} to ", msg_fld, "."),
-        i = "Edit {config_path(pkg)} to fix the problem."
+        x = paste0("You set a value of {.val {version}} in ", msg_fld, ".")
       ),
       call = caller_env()
     )

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -38,6 +38,7 @@ local_pkgdown_site <- function(path = NULL, meta = NULL, env = parent.frame()) {
     desc$set("Package", "testpackage")
     desc$set("Title", "A test package")
     desc$write(file = file.path(path, "DESCRIPTION"))
+    
     file_create(path(path, "_pkgdown.yml"))
   }
 

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -38,6 +38,7 @@ local_pkgdown_site <- function(path = NULL, meta = NULL, env = parent.frame()) {
     desc$set("Package", "testpackage")
     desc$set("Title", "A test package")
     desc$write(file = file.path(path, "DESCRIPTION"))
+    file_create(path(path, "_pkgdown.yml"))
   }
 
   if (is.character(meta)) {
@@ -60,6 +61,7 @@ local_pkgdown_template_pkg <- function(path = NULL, meta = NULL, env = parent.fr
     desc$set("Package", "templatepackage")
     desc$set("Title", "A test template package")
     desc$write(file = file.path(path, "DESCRIPTION"))
+    file.create(path(path, "_pkgdown.yaml"))
   }
 
   if (!is.null(meta)) {

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -62,7 +62,6 @@ local_pkgdown_template_pkg <- function(path = NULL, meta = NULL, env = parent.fr
     desc$set("Package", "templatepackage")
     desc$set("Title", "A test template package")
     desc$write(file = file.path(path, "DESCRIPTION"))
-    file.create(path(path, "_pkgdown.yaml"))
   }
 
   if (!is.null(meta)) {

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -17,7 +17,7 @@ pkgdown_sitrep <- function(pkg = ".") {
   warns <- c()
 
   if (is.null(pkg$meta[["url"]])) {
-    msg_fld <- pkgdown_field("url", fmt = TRUE)
+    msg_fld <- config_field("url", fmt = TRUE)
     warns <- c(warns, x = paste0(msg_fld, " is absent. See {.vignette pkgdown::metadata}."))
   }
 

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -17,7 +17,7 @@ pkgdown_sitrep <- function(pkg = ".") {
   warns <- c()
 
   if (is.null(pkg$meta[["url"]])) {
-    msg_fld <- pkgdown_field(pkg, "url", cfg = TRUE, fmt = TRUE)
+    msg_fld <- pkgdown_field("url", fmt = TRUE)
     warns <- c(warns, x = paste0(msg_fld, " is absent. See {.vignette pkgdown::metadata}."))
   }
 

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -31,7 +31,7 @@ pkgdown_sitrep <- function(pkg = ".") {
     cli::cli_inform(c(
       "v" = "pkgdown situation report: {.emph {cli::col_green('all clear')}}",
        "!" = "{.emph Double-check the following URLs:}",
-       " " = "{pkgdown_config_href({pkg$src_path})} contains URL {.url {pkg$meta['url']}}",
+       " " = "{config_path(pkg)} contains URL {.url {pkg$meta['url']}}",
        " " = "{.file DESCRIPTION} contains URL{?s} {.url {desc_urls}}"
     ))
   } else {

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -17,8 +17,10 @@ pkgdown_sitrep <- function(pkg = ".") {
   warns <- c()
 
   if (is.null(pkg$meta[["url"]])) {
-    msg_fld <- config_field("url", fmt = TRUE)
-    warns <- c(warns, x = paste0(msg_fld, " is absent. See {.vignette pkgdown::metadata}."))
+    warns <- c(
+      warns,
+      x = "{.field url} is absent. See {.vignette pkgdown::metadata}."
+    )
   }
 
   desc_urls <- pkg$desc$get_urls()

--- a/R/theme.R
+++ b/R/theme.R
@@ -134,9 +134,9 @@ check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), b
     sprintf(
       "Can't find Bootswatch or bslib theme preset {.val %s} ({.field %s}) for Bootstrap version {.val %s} ({.field %s}).",
       theme,
-      pkgdown_field(pkg, field),
+      pkgdown_field(field),
       bs_version,
-      pkgdown_field(pkg, c("template", "bootstrap"))
+      pkgdown_field(c("template", "bootstrap"))
     ),
     x = "Edit settings in {config_path(pkg)}"
   ), call = caller_env())

--- a/R/theme.R
+++ b/R/theme.R
@@ -114,10 +114,10 @@ get_bslib_theme <- function(pkg) {
   }
 
   field <- names(themes)[which(is_present)[1]]
-  check_bslib_theme(themes[[field]], pkg, strsplit(field, ".")[[1]])
+  check_bslib_theme(themes[[field]], pkg, field)
 }
 
-check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), bs_version = pkg$bs_version) {
+check_bslib_theme <- function(theme, pkg, field = "template.bootswatch", bs_version = pkg$bs_version) {
   bslib_themes <- c(
     bslib::bootswatch_themes(bs_version),
     bslib::builtin_themes(bs_version),
@@ -132,12 +132,9 @@ check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), b
 
   config_abort(
     pkg,
-    sprintf(
-      "Can't find Bootswatch or bslib theme preset {.val %s} ({.field %s}) for Bootstrap version {.val %s} ({.field %s}).",
-      theme,
-      config_field(field),
-      bs_version,
-      config_field(c("template", "bootstrap"))
+    c(
+      x = "Can't find Bootswatch/bslib theme preset {.val {theme}} ({.field {field}}).",
+      i = "Using Bootstrap version {.val {bs_version}} ({.field template.bootstrap})."
     ),
     call = caller_env()
   )

--- a/R/theme.R
+++ b/R/theme.R
@@ -138,7 +138,7 @@ check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), b
       bs_version,
       pkgdown_field(pkg, c("template", "bootstrap"))
     ),
-    x = "Edit settings in {pkgdown_config_href({pkg$src_path})}"
+    x = "Edit settings in {config_path(pkg)}"
   ), call = caller_env())
 }
 

--- a/R/theme.R
+++ b/R/theme.R
@@ -135,9 +135,9 @@ check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), b
     sprintf(
       "Can't find Bootswatch or bslib theme preset {.val %s} ({.field %s}) for Bootstrap version {.val %s} ({.field %s}).",
       theme,
-      pkgdown_field(field),
+      config_field(field),
       bs_version,
-      pkgdown_field(c("template", "bootstrap"))
+      config_field(c("template", "bootstrap"))
     ),
     call = caller_env()
   )

--- a/R/theme.R
+++ b/R/theme.R
@@ -130,7 +130,8 @@ check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), b
     return(theme)
   }
 
-  cli::cli_abort(c(
+  config_abort(
+    pkg,
     sprintf(
       "Can't find Bootswatch or bslib theme preset {.val %s} ({.field %s}) for Bootstrap version {.val %s} ({.field %s}).",
       theme,
@@ -138,8 +139,8 @@ check_bslib_theme <- function(theme, pkg, field = c("template", "bootswatch"), b
       bs_version,
       pkgdown_field(c("template", "bootstrap"))
     ),
-    x = "Edit settings in {config_path(pkg)}"
-  ), call = caller_env())
+    call = caller_env()
+  )
 }
 
 bs_theme_deps_suppress <- function(deps = list()) {

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -4,7 +4,7 @@ check_yaml_has <- function(missing, where, pkg, call = caller_env()) {
   }
 
   missing_components <- lapply(missing, function(x) c(where, x))
-  msg_flds <- config_field(missing_components)
+  msg_flds <- purrr::map_chr(missing_components, paste, collapse = ".")
 
   config_abort(
     pkg, 
@@ -21,23 +21,13 @@ yaml_character <- function(pkg, where) {
   } else if (is.character(x)) {
     x
   } else {
-    fld <- config_field(where, fmt = TRUE)
+    path <- paste0(where, collapse = ".")
     config_abort(
       pkg,
-      paste0(fld, " must be a character vector."),
+      "{.field {path}} must be a character vector.",
       call = caller_env()
     )
   }
-}
-
-config_field <- function(fields, fmt = FALSE) {
-  if (!is.list(fields)) fields <- list(fields)
-
-  flds <- purrr::map_chr(fields, ~ paste0(.x, collapse = "."))
-  if (fmt) {
-    flds <- paste0("{.field ", flds, "}")
-  }
-  flds
 }
 
 config_abort <- function(pkg,

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -8,7 +8,7 @@ check_yaml_has <- function(missing, where, pkg, call = caller_env()) {
 
   cli::cli_abort(c(
     "Can't find {cli::qty(missing)} component{?s} {.field {msg_flds}}.",
-    i = "Edit {pkgdown_config_href({pkg$src_path})} to define {cli::qty(missing)} {?it/them}."
+    i = "Edit {config_path(pkg)} to define {cli::qty(missing)} {?it/them}."
     ),
     call = call
   )
@@ -41,7 +41,7 @@ pkgdown_field <- function(pkg, fields, cfg = FALSE, fmt = FALSE) {
 
   if (cfg) {
     if (fmt) {
-      config_path <- cli::format_inline(pkgdown_config_href(pkg$src_path))
+      config_path <- cli::format_inline(config_path(pkg))
     } else {
       config_path <- pkgdown_config_relpath(pkg)
     }
@@ -51,6 +51,14 @@ pkgdown_field <- function(pkg, fields, cfg = FALSE, fmt = FALSE) {
 
     flds
   }
+}
+
+config_path <- function(pkg) {
+  config <- pkgdown_config_path(pkg$src_path)
+  if (is.null(config)) {
+    cli::cli_abort("Can't find {.file _pkgdown.yml}.", .internal = TRUE)
+  }
+  cli::style_hyperlink(fs::path_file(config), paste0("file://", config))
 }
 
 # print helper ------------------------------------------------------------

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -4,7 +4,7 @@ check_yaml_has <- function(missing, where, pkg, call = caller_env()) {
   }
 
   missing_components <- lapply(missing, function(x) c(where, x))
-  msg_flds <- pkgdown_field(pkg, missing_components, fmt = FALSE, cfg = FALSE)
+  msg_flds <- pkgdown_field(missing_components)
 
   cli::cli_abort(c(
     "Can't find {cli::qty(missing)} component{?s} {.field {msg_flds}}.",
@@ -22,7 +22,7 @@ yaml_character <- function(pkg, where) {
   } else if (is.character(x)) {
     x
   } else {
-    fld <- pkgdown_field(pkg, where, fmt = TRUE)
+    fld <- pkgdown_field(where, fmt = TRUE)
     cli::cli_abort(
       paste0(fld, " must be a character vector."),
       call = caller_env()
@@ -30,27 +30,14 @@ yaml_character <- function(pkg, where) {
   }
 }
 
-pkgdown_field <- function(pkg, fields, cfg = FALSE, fmt = FALSE) {
-
+pkgdown_field <- function(fields, fmt = FALSE) {
   if (!is.list(fields)) fields <- list(fields)
 
   flds <- purrr::map_chr(fields, ~ paste0(.x, collapse = "."))
   if (fmt) {
     flds <- paste0("{.field ", flds, "}")
   }
-
-  if (cfg) {
-    if (fmt) {
-      config_path <- cli::format_inline(config_path(pkg))
-    } else {
-      config_path <- pkgdown_config_relpath(pkg)
-    }
-
-    paste0(flds, " in ", config_path)
-  } else {
-
-    flds
-  }
+  flds
 }
 
 config_path <- function(pkg) {

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -6,10 +6,9 @@ check_yaml_has <- function(missing, where, pkg, call = caller_env()) {
   missing_components <- lapply(missing, function(x) c(where, x))
   msg_flds <- pkgdown_field(missing_components)
 
-  cli::cli_abort(c(
+  config_abort(
+    pkg, 
     "Can't find {cli::qty(missing)} component{?s} {.field {msg_flds}}.",
-    i = "Edit {config_path(pkg)} to define {cli::qty(missing)} {?it/them}."
-    ),
     call = call
   )
 }
@@ -23,7 +22,8 @@ yaml_character <- function(pkg, where) {
     x
   } else {
     fld <- pkgdown_field(where, fmt = TRUE)
-    cli::cli_abort(
+    config_abort(
+      pkg,
       paste0(fld, " must be a character vector."),
       call = caller_env()
     )
@@ -38,6 +38,22 @@ pkgdown_field <- function(fields, fmt = FALSE) {
     flds <- paste0("{.field ", flds, "}")
   }
   flds
+}
+
+config_abort <- function(pkg,
+                         message,
+                         ...,
+                         call = caller_env(),
+                         .envir = caller_env()) {
+  cli::cli_abort(
+    c(
+      message,
+      i = "Edit {config_path(pkg)} to fix the problem."
+    ),
+    ...,
+    call = call,
+    .envir = .envir
+  )
 }
 
 config_path <- function(pkg) {

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -67,7 +67,7 @@ config_path <- function(pkg) {
 # print helper ------------------------------------------------------------
 
 print_yaml <- function(x) {
-  structure(x, class = "print_yµaml")
+  structure(x, class = "print_yaml")
 }
 #' @export
 print.print_yaml <- function(x, ...) {

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -4,7 +4,7 @@ check_yaml_has <- function(missing, where, pkg, call = caller_env()) {
   }
 
   missing_components <- lapply(missing, function(x) c(where, x))
-  msg_flds <- pkgdown_field(missing_components)
+  msg_flds <- config_field(missing_components)
 
   config_abort(
     pkg, 
@@ -21,7 +21,7 @@ yaml_character <- function(pkg, where) {
   } else if (is.character(x)) {
     x
   } else {
-    fld <- pkgdown_field(where, fmt = TRUE)
+    fld <- config_field(where, fmt = TRUE)
     config_abort(
       pkg,
       paste0(fld, " must be a character vector."),
@@ -30,7 +30,7 @@ yaml_character <- function(pkg, where) {
   }
 }
 
-pkgdown_field <- function(fields, fmt = FALSE) {
+config_field <- function(fields, fmt = FALSE) {
   if (!is.list(fields)) fields <- list(fields)
 
   flds <- purrr::map_chr(fields, ~ paste0(.x, collapse = "."))
@@ -67,7 +67,7 @@ config_path <- function(pkg) {
 # print helper ------------------------------------------------------------
 
 print_yaml <- function(x) {
-  structure(x, class = "print_yaml")
+  structure(x, class = "print_yµaml")
 }
 #' @export
 print.print_yaml <- function(x, ...) {

--- a/tests/testthat/_snaps/build-articles.md
+++ b/tests/testthat/_snaps/build-articles.md
@@ -113,7 +113,8 @@
       . <- data_articles_index(pkg)
     Condition
       Error:
-      ! 1 vignette missing from index in _pkgdown.yml: "c".
+      ! 1 vignette missing from index: "c"
+      i Edit _pkgdown.yml to fix the problem.
 
 # output is reproducible by default, i.e. 'seed' is respected
 

--- a/tests/testthat/_snaps/build-articles.md
+++ b/tests/testthat/_snaps/build-articles.md
@@ -113,7 +113,7 @@
       . <- data_articles_index(pkg)
     Condition
       Error:
-      ! 1 vignette missing from index: "c"
+      ! 1 vignette missing from index: "c".
       i Edit _pkgdown.yml to fix the problem.
 
 # output is reproducible by default, i.e. 'seed' is respected

--- a/tests/testthat/_snaps/build-home-index.md
+++ b/tests/testthat/_snaps/build-home-index.md
@@ -50,7 +50,7 @@
 
     Can't locate 'file.html'.
     x home.sidebar.html is misconfigured.
-    i Fix the problem in _pkgdown.yml.
+    i Edit _pkgdown.yml to fix the problem.
 
 # data_home_sidebar() can get a custom markdown formatted component
 
@@ -77,7 +77,7 @@
     Condition
       Error:
       ! Can't find component home.sidebar.components.fancy.
-      i Edit _pkgdown.yml to define it.
+      i Edit _pkgdown.yml to fix the problem.
 
 ---
 
@@ -86,7 +86,7 @@
     Condition
       Error:
       ! Can't find components home.sidebar.components.fancy and home.sidebar.components.cool.
-      i Edit _pkgdown.yml to define them.
+      i Edit _pkgdown.yml to fix the problem.
 
 ---
 
@@ -95,7 +95,7 @@
     Condition
       Error:
       ! Can't find component home.sidebar.components.fancy.title.
-      i Edit _pkgdown.yml to define it.
+      i Edit _pkgdown.yml to fix the problem.
 
 ---
 
@@ -104,5 +104,5 @@
     Condition
       Error:
       ! Can't find components home.sidebar.components.fancy.title and home.sidebar.components.fancy.text.
-      i Edit _pkgdown.yml to define them.
+      i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/build-home-index.md
+++ b/tests/testthat/_snaps/build-home-index.md
@@ -48,8 +48,7 @@
 
 # data_home_sidebar() errors well when no HTML file
 
-    Can't locate 'file.html'.
-    x home.sidebar.html is misconfigured.
+    Path specified in home.sidebar.html ('file.html') doesn't exist.
     i Edit _pkgdown.yml to fix the problem.
 
 # data_home_sidebar() can get a custom markdown formatted component

--- a/tests/testthat/_snaps/build-home-index.md
+++ b/tests/testthat/_snaps/build-home-index.md
@@ -49,7 +49,8 @@
 # data_home_sidebar() errors well when no HTML file
 
     Can't locate 'file.html'.
-    x home.sidebar.html in _pkgdown.yml is misconfigured.
+    x home.sidebar.html is misconfigured.
+    i Fix the problem in _pkgdown.yml.
 
 # data_home_sidebar() can get a custom markdown formatted component
 

--- a/tests/testthat/_snaps/build-home-index.md
+++ b/tests/testthat/_snaps/build-home-index.md
@@ -48,7 +48,7 @@
 
 # data_home_sidebar() errors well when no HTML file
 
-    Path specified in home.sidebar.html ('file.html') doesn't exist.
+    home.sidebar.html specifies a file that doesn't exist ('file.html').
     i Edit _pkgdown.yml to fix the problem.
 
 # data_home_sidebar() can get a custom markdown formatted component

--- a/tests/testthat/_snaps/build-redirects.md
+++ b/tests/testthat/_snaps/build-redirects.md
@@ -4,6 +4,6 @@
       build_redirect(c("old.html"), 5, pkg)
     Condition
       Error:
-      ! Entry 5 must be a character vector of length 2.
-      x Edit url in _pkgdown.yml.
+      ! redirects[[5]] must be a character vector of length 2.
+      i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/build-reference-index.md
+++ b/tests/testthat/_snaps/build-reference-index.md
@@ -52,6 +52,7 @@
     Condition
       Error:
       ! 3 topics missing from index: "c", "e", and "?".
+      i Either use `@keywords internal` to drop from index, or
       i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content entry is empty

--- a/tests/testthat/_snaps/build-reference-index.md
+++ b/tests/testthat/_snaps/build-reference-index.md
@@ -51,14 +51,13 @@
       data_reference_index(pkg)
     Condition
       Error:
-      ! All topics must be included in reference index
-      x Missing topics: c, e, and ?
-      i Either add to _pkgdown.yml or use @keywords internal
+      ! 3 topics missing from index: "c", "e", and "?"
+      i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content entry is empty
 
     Section "bla": contents 2 is empty.
-    i This typically indicates that your _pkgdown.yml is malformed.
+    i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content entry is not a character
 
@@ -68,7 +67,7 @@
       Error in `build_reference_index()`:
       ! Section "bla": 2 must be a character.
       i You might need to add '' around special values like 'N' or 'off'
-      i This typically indicates that your _pkgdown.yml is malformed.
+      i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content is totally empty
 
@@ -77,7 +76,7 @@
     Condition
       Error in `build_reference_index()`:
       ! Section "bla": contents is empty.
-      i This typically indicates that your _pkgdown.yml is malformed.
+      i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content entry refers to a not installed package
 

--- a/tests/testthat/_snaps/build-reference-index.md
+++ b/tests/testthat/_snaps/build-reference-index.md
@@ -51,7 +51,7 @@
       data_reference_index(pkg)
     Condition
       Error:
-      ! 3 topics missing from index: "c", "e", and "?"
+      ! 3 topics missing from index: "c", "e", and "?".
       i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content entry is empty
@@ -66,7 +66,7 @@
     Condition
       Error in `build_reference_index()`:
       ! Section "bla": 2 must be a character.
-      i You might need to add '' around special values like 'N' or 'off'
+      i You might need to add '' around special YAML values like 'N' or 'off'
       i Edit _pkgdown.yml to fix the problem.
 
 # errors well when a content is totally empty

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -4,7 +4,7 @@
       check_pkgdown(pkg)
     Condition
       Error in `check_pkgdown()`:
-      ! 1 topic missing from index: "?"
+      ! 1 topic missing from index: "?".
       i Edit _pkgdown.yml to fix the problem.
 
 # fails if article index incomplete
@@ -13,7 +13,7 @@
       check_pkgdown(pkg)
     Condition
       Error in `check_pkgdown()`:
-      ! 2 vignettes missing from index: "articles/nested" and "width"
+      ! 2 vignettes missing from index: "articles/nested" and "width".
       i Edit _pkgdown.yml to fix the problem.
 
 # informs if everything is ok

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -5,6 +5,7 @@
     Condition
       Error in `check_pkgdown()`:
       ! 1 topic missing from index: "?".
+      i Either use `@keywords internal` to drop from index, or
       i Edit _pkgdown.yml to fix the problem.
 
 # fails if article index incomplete

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -4,9 +4,8 @@
       check_pkgdown(pkg)
     Condition
       Error in `check_pkgdown()`:
-      ! All topics must be included in reference index
-      x Missing topics: ?
-      i Either add to _pkgdown.yml or use @keywords internal
+      ! 1 topic missing from index: "?"
+      i Edit _pkgdown.yml to fix the problem.
 
 # fails if article index incomplete
 
@@ -14,12 +13,13 @@
       check_pkgdown(pkg)
     Condition
       Error in `check_pkgdown()`:
-      ! 2 vignettes missing from index in _pkgdown.yml: "articles/nested" and "width".
+      ! 2 vignettes missing from index: "articles/nested" and "width"
+      i Edit _pkgdown.yml to fix the problem.
 
 # informs if everything is ok
 
     Code
       check_pkgdown(pkg)
     Message
-      v No problems found in _pkgdown.yml.
+      v No problems found.
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -21,5 +21,5 @@
     Code
       check_pkgdown(pkg)
     Message
-      v No problems found in _pkgdown.yml
+      v No problems found in _pkgdown.yml.
 

--- a/tests/testthat/_snaps/markdown.md
+++ b/tests/testthat/_snaps/markdown.md
@@ -1,4 +1,4 @@
 # markdown_text_inline() works with inline markdown
 
-    Can't use a block element in `<inline>`, need an inline element: `x y`
+    <inline> must supply an inline element, not a block element.
 

--- a/tests/testthat/_snaps/markdown.md
+++ b/tests/testthat/_snaps/markdown.md
@@ -1,4 +1,5 @@
 # markdown_text_inline() works with inline markdown
 
     <inline> must supply an inline element, not a block element.
+    i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/navbar.md
+++ b/tests/testthat/_snaps/navbar.md
@@ -188,7 +188,7 @@
       data_navbar(pkg)
     Condition
       Error in `data_template()`:
-      ! Invalid navbar specification in _pkgdown.yml
+      ! Invalid navbar specification in _pkgdown.yml.
 
 # render_navbar_links BS3 & BS4 default
 

--- a/tests/testthat/_snaps/navbar.md
+++ b/tests/testthat/_snaps/navbar.md
@@ -190,6 +190,7 @@
     Condition
       Error in `data_template()`:
       ! navbar is incorrectly specified.
+      i See details in `vignette(pkgdown::customise)`.
       i Edit _pkgdown.yml to fix the problem.
 
 # render_navbar_links BS3 & BS4 default

--- a/tests/testthat/_snaps/navbar.md
+++ b/tests/testthat/_snaps/navbar.md
@@ -181,6 +181,7 @@
     Condition
       Error in `navbar_links()`:
       ! navbar.structure.left must be a character vector.
+      i Edit _pkgdown.yml to fix the problem.
 
 # data_navbar() errors with bad left/right
 
@@ -188,7 +189,8 @@
       data_navbar(pkg)
     Condition
       Error in `data_template()`:
-      ! Invalid navbar specification in _pkgdown.yml.
+      ! Invalid navbar specification.
+      i Edit _pkgdown.yml to fix the problem.
 
 # render_navbar_links BS3 & BS4 default
 

--- a/tests/testthat/_snaps/navbar.md
+++ b/tests/testthat/_snaps/navbar.md
@@ -189,7 +189,7 @@
       data_navbar(pkg)
     Condition
       Error in `data_template()`:
-      ! Invalid navbar specification.
+      ! navbar is incorrectly specified.
       i Edit _pkgdown.yml to fix the problem.
 
 # render_navbar_links BS3 & BS4 default

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -18,5 +18,6 @@
     Condition
       Error:
       ! Boostrap version must be 3 or 5.
-      x You set a value of 1 to template.bootstrap in _pkgdown.yml.
+      x You set a value of 1 to template.bootstrap.
+      i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -18,6 +18,6 @@
     Condition
       Error:
       ! Boostrap version must be 3 or 5.
-      x You set a value of 1 to template.bootstrap.
+      x You set a value of 1 in template.bootstrap.
       i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -17,7 +17,6 @@
       check_bootstrap_version(1, pkg)
     Condition
       Error:
-      ! Boostrap version must be 3 or 5.
-      x You set a value of 1 in template.bootstrap.
+      ! template.bootstrap must be 3 or 5, not 1.
       i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -1,11 +1,13 @@
 # check_bslib_theme() works
 
-    Can't find Bootswatch or bslib theme preset "paper" (template.bootswatch) for Bootstrap version "4" (template.bootstrap).
+    x Can't find Bootswatch/bslib theme preset "paper" (template.bootswatch).
+    i Using Bootstrap version 4 (template.bootstrap).
     i Edit _pkgdown.yml to fix the problem.
 
 ---
 
-    Can't find Bootswatch or bslib theme preset "paper" (template.preset) for Bootstrap version "4" (template.bootstrap).
+    x Can't find Bootswatch/bslib theme preset "paper" (template and preset).
+    i Using Bootstrap version 4 (template.bootstrap).
     i Edit _pkgdown.yml to fix the problem.
 
 # capture data_template()

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -1,12 +1,12 @@
 # check_bslib_theme() works
 
     Can't find Bootswatch or bslib theme preset "paper" (template.bootswatch) for Bootstrap version "4" (template.bootstrap).
-    x Edit settings in _pkgdown.yml
+    i Edit _pkgdown.yml to fix the problem.
 
 ---
 
     Can't find Bootswatch or bslib theme preset "paper" (template.preset) for Bootstrap version "4" (template.bootstrap).
-    x Edit settings in _pkgdown.yml
+    i Edit _pkgdown.yml to fix the problem.
 
 # capture data_template()
 

--- a/tests/testthat/_snaps/sitrep.md
+++ b/tests/testthat/_snaps/sitrep.md
@@ -5,7 +5,7 @@
     Condition
       Warning:
       pkgdown situation report: configuration error
-      x url in _pkgdown.yml is absent. See `vignette(pkgdown::metadata)`.
+      x url is absent. See `vignette(pkgdown::metadata)`.
       x 'DESCRIPTION' URL is empty.
 
 ---

--- a/tests/testthat/_snaps/templates.md
+++ b/tests/testthat/_snaps/templates.md
@@ -15,6 +15,7 @@
     Condition
       Error in `as_pkgdown()`:
       ! Both template.bootstrap and template.bslib.version are set.
+      i Remove one of them from '_pkgdown.yml '
 
 # Warns when Bootstrap theme is specified in multiple locations
 

--- a/tests/testthat/_snaps/templates.md
+++ b/tests/testthat/_snaps/templates.md
@@ -5,7 +5,8 @@
     Condition
       Error in `as_pkgdown()`:
       ! Must set one only of template.bootstrap and template.bslib.version.
-      i Update the pkgdown config in templatepackage, or set a Bootstrap version in your '_pkgdown.yml'.
+      i Specified locally and in template package templatepackage.
+      i Edit _pkgdown.yml to fix the problem.
 
 # Invalid bootstrap version spec in _pkgdown.yml
 
@@ -15,7 +16,7 @@
     Condition
       Error in `as_pkgdown()`:
       ! Must set one only of template.bootstrap and template.bslib.version.
-      i Remove one of them from '_pkgdown.yml '
+      i Edit _pkgdown.yml to fix the problem.
 
 # Warns when Bootstrap theme is specified in multiple locations
 

--- a/tests/testthat/_snaps/templates.md
+++ b/tests/testthat/_snaps/templates.md
@@ -4,7 +4,7 @@
       local_pkgdown_site(meta = list(template = list(package = "templatepackage")))
     Condition
       Error in `as_pkgdown()`:
-      ! Both template.bootstrap and template.bslib.version are set.
+      ! Must set one only of template.bootstrap and template.bslib.version.
       i Update the pkgdown config in templatepackage, or set a Bootstrap version in your '_pkgdown.yml'.
 
 # Invalid bootstrap version spec in _pkgdown.yml
@@ -14,7 +14,7 @@
         version = 5))))
     Condition
       Error in `as_pkgdown()`:
-      ! Both template.bootstrap and template.bslib.version are set.
+      ! Must set one only of template.bootstrap and template.bslib.version.
       i Remove one of them from '_pkgdown.yml '
 
 # Warns when Bootstrap theme is specified in multiple locations

--- a/tests/testthat/_snaps/utils-yaml.md
+++ b/tests/testthat/_snaps/utils-yaml.md
@@ -1,4 +1,4 @@
-# pkgdown_field produces useful description
+# config_field produces useful description
 
     Code
       check_yaml_has("x", where = "a", pkg = pkg)

--- a/tests/testthat/_snaps/utils-yaml.md
+++ b/tests/testthat/_snaps/utils-yaml.md
@@ -1,13 +1,6 @@
 # pkgdown_field produces useful description
 
     Code
-      cli::cli_inform(pkgdown_field(pkg, c("a"), cfg = TRUE, fmt = TRUE))
-    Message
-      a in _pkgdown.yml
-
----
-
-    Code
       check_yaml_has("x", where = "a", pkg = pkg)
     Condition
       Error:

--- a/tests/testthat/_snaps/utils-yaml.md
+++ b/tests/testthat/_snaps/utils-yaml.md
@@ -5,11 +5,11 @@
     Condition
       Error:
       ! Can't find component a.x.
-      i Edit _pkgdown.yml to define it.
+      i Edit _pkgdown.yml to fix the problem.
     Code
       check_yaml_has(c("x", "y"), where = "a", pkg = pkg)
     Condition
       Error:
       ! Can't find components a.x and a.y.
-      i Edit _pkgdown.yml to define them.
+      i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/utils-yaml.md
+++ b/tests/testthat/_snaps/utils-yaml.md
@@ -1,4 +1,4 @@
-# config_field produces useful description
+# check_yaml_has produces informative errors
 
     Code
       check_yaml_has("x", where = "a", pkg = pkg)

--- a/tests/testthat/test-build-home-authors.R
+++ b/tests/testthat/test-build-home-authors.R
@@ -9,7 +9,7 @@ test_that("ORCID can be identified from all comment styles", {
     '  )'
   ))
   authors <- unclass(desc$get_authors())
-  authors <- purrr::map(authors, author_list, list(), pkg = list())
+  authors <- purrr::map(authors, author_list, list())
   orcid <- purrr::map(authors, "orcid")
   expect_equal(orcid, list(NULL, NULL, NULL, orcid_link("1"), orcid_link("2")))
 })

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -18,7 +18,9 @@ test_that("header attributes are parsed", {
 
 test_that("markdown_text_inline() works with inline markdown", {
   expect_equal(markdown_text_inline("**lala**"), "<strong>lala</strong>")
-  expect_snapshot_error(markdown_text_inline("x\n\ny"))
+
+  pkg <- local_pkgdown_site()
+  expect_snapshot_error(markdown_text_inline("x\n\ny", pkg = pkg))
 })
 
 test_that("markdown_text_block() works with inline and block markdown", {

--- a/tests/testthat/test-navbar.R
+++ b/tests/testthat/test-navbar.R
@@ -131,7 +131,7 @@ test_that("data_navbar() errors with bad side specifications", {
         left: 1
   ")
 
-   expect_snapshot(data_navbar(pkg), error = TRUE)
+  expect_snapshot(data_navbar(pkg), error = TRUE)
 })
 
 test_that("data_navbar() errors with bad left/right", {
@@ -139,7 +139,6 @@ test_that("data_navbar() errors with bad left/right", {
     navbar:
       right: [github]
   ")
-  file.create(path(pkg$src_path, "_pkgdown.yml"))
 
    expect_snapshot(data_navbar(pkg), error = TRUE)
 })

--- a/tests/testthat/test-utils-yaml.R
+++ b/tests/testthat/test-utils-yaml.R
@@ -2,12 +2,8 @@ test_that("pkgdown_field produces useful description", {
   pkg <- local_pkgdown_site()
   file_touch(file.path(pkg$src_path, "_pkgdown.yml"))
 
-  expect_equal(pkgdown_field(pkg, c("a", "b")), "a.b")
-  expect_equal(pkgdown_field(pkg, c("a", "b"), fmt = TRUE), "{.field a.b}")
-  expect_equal(pkgdown_field(pkg, c("a"), cfg = TRUE), "a in _pkgdown.yml")
-  expect_snapshot(
-    cli::cli_inform(pkgdown_field(pkg, c("a"), cfg = TRUE, fmt = TRUE))
-  )
+  expect_equal(pkgdown_field(c("a", "b")), "a.b")
+  expect_equal(pkgdown_field(c("a", "b"), fmt = TRUE), "{.field a.b}")
 
   expect_snapshot(error = TRUE, {
     check_yaml_has("x", where = "a", pkg = pkg)

--- a/tests/testthat/test-utils-yaml.R
+++ b/tests/testthat/test-utils-yaml.R
@@ -1,9 +1,9 @@
-test_that("pkgdown_field produces useful description", {
+test_that("config_field produces useful description", {
   pkg <- local_pkgdown_site()
   file_touch(file.path(pkg$src_path, "_pkgdown.yml"))
 
-  expect_equal(pkgdown_field(c("a", "b")), "a.b")
-  expect_equal(pkgdown_field(c("a", "b"), fmt = TRUE), "{.field a.b}")
+  expect_equal(config_field(c("a", "b")), "a.b")
+  expect_equal(config_field(c("a", "b"), fmt = TRUE), "{.field a.b}")
 
   expect_snapshot(error = TRUE, {
     check_yaml_has("x", where = "a", pkg = pkg)

--- a/tests/testthat/test-utils-yaml.R
+++ b/tests/testthat/test-utils-yaml.R
@@ -1,9 +1,5 @@
-test_that("config_field produces useful description", {
+test_that("check_yaml_has produces informative errors", {
   pkg <- local_pkgdown_site()
-  file_touch(file.path(pkg$src_path, "_pkgdown.yml"))
-
-  expect_equal(config_field(c("a", "b")), "a.b")
-  expect_equal(config_field(c("a", "b"), fmt = TRUE), "{.field a.b}")
 
   expect_snapshot(error = TRUE, {
     check_yaml_has("x", where = "a", pkg = pkg)


### PR DESCRIPTION
* Create `config_abort()` with standard message pointing to `_config.yaml`
* That simplifies `pkgdown_field()`, which after a couple of steps got refactored away.

Part of #1927.

@olivroy would you be interested in reviewing this?