### PR TITLE
Only do html operations for html vignettes

### DIFF
--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -52,7 +52,8 @@ render_rmarkdown <- function(pkg, input, output, ..., seed = NULL, copy_images =
     path <- inject(rmarkdown_render_with_seed(!!!args))
   }
 
-  if (identical(path_ext(path)[[1]], "html")) {
+  is_html <- identical(path_ext(path)[[1]], "html")
+  if (is_html) {
     update_html(
       path,
       tweak_rmarkdown_html,
@@ -65,7 +66,7 @@ render_rmarkdown <- function(pkg, input, output, ..., seed = NULL, copy_images =
   }
 
   # Copy over images needed by the document
-  if (copy_images) {
+  if (copy_images && is_html) {
     ext_src <- rmarkdown::find_external_resources(input_path)
 
     # temporarily copy the rendered html into the input path directory and scan
@@ -88,7 +89,10 @@ render_rmarkdown <- function(pkg, input, output, ..., seed = NULL, copy_images =
     dir_create(unique(path_dir(dst)))
     file_copy(src, dst, overwrite = TRUE)
   }
-  check_missing_images(pkg, input_path, output)
+
+  if (is_html) {
+    check_missing_images(pkg, input_path, output)
+  }
 
   invisible(path)
 }


### PR DESCRIPTION
This eliminates some warnings that appear when building the pkgdown site itself.