### PR TITLE
Fix cli evaluating brace contents in error msgs

### DIFF
--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -37,9 +37,7 @@ render_rmarkdown <- function(pkg, input, output, ..., seed = NULL, copy_images =
       callr::r_safe(rmarkdown_render_with_seed, args = args, show = !quiet),
       error = function(cnd) {
         lines <- strsplit(gsub("^\r?\n", "", cnd$stderr), "\r?\n")[[1]]
-        lines <- lines[nchar(lines) >0]
-        lines <- gsub("{", "{{", lines, fixed = TRUE)
-        lines <- gsub("}", "}}", lines, fixed = TRUE)
+        lines <- escape_cli(lines)
         cli::cli_abort(
           c(
             "!" = "Failed to render {.path {input}}.",
@@ -100,6 +98,17 @@ render_rmarkdown <- function(pkg, input, output, ..., seed = NULL, copy_images =
   invisible(path)
 }
 
+#' Escapes a cli msg
+#'
+#' Removes empty lines and escapes braces
+#' @param msg A character vector with messages to be escaped
+#' @noRd
+escape_cli <- function(msg) {
+  msg <- msg[nchar(msg) >0]
+  msg <- gsub("{", "{{", msg, fixed = TRUE)
+  msg <- gsub("}", "}}", msg, fixed = TRUE)
+  msg
+}
 
 rmarkdown_render_with_seed <- function(..., seed = NULL) {
   if (!is.null(seed)) {

--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -37,6 +37,9 @@ render_rmarkdown <- function(pkg, input, output, ..., seed = NULL, copy_images =
       callr::r_safe(rmarkdown_render_with_seed, args = args, show = !quiet),
       error = function(cnd) {
         lines <- strsplit(gsub("^\r?\n", "", cnd$stderr), "\r?\n")[[1]]
+        lines <- lines[nchar(lines) >0]
+        lines <- gsub("{", "{{", lines, fixed = TRUE)
+        lines <- gsub("}", "}}", lines, fixed = TRUE)
         cli::cli_abort(
           c(
             "!" = "Failed to render {.path {input}}.",


### PR DESCRIPTION
The cli functions evaluate things in braces.

Errors may include braces that we do not want to evaluate

For instance, pkgdown was reporting an error when building my vignettes:

```
Error in `map()`:
i In index: 1.
Caused by error:
! Could not evaluate cli `{}` expression: `document`.
Caused by error:
! object 'document' not found
```

Because the rendering of my vignette reported:

```
LaTeX Error: Missing \begin{document}.
```

and `cli_abort` intepreted `{document}` as an
object to be evaluated.

Now it reports:

```
Error in `build_article()`:
! Failed to render vignettes/...
x ! LaTeX Error: Missing \begin{document}.
...
```

as expected