### PR TITLE
Consistently use `path()`, not `file.path()`

### DIFF
--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -61,7 +61,7 @@ data_home_sidebar <- function(pkg = ".", call = caller_env()) {
   if (isFALSE(pkg$meta$home$sidebar))
     return(pkg$meta$home$sidebar)
 
-  html_path <- file.path(pkg$src_path, pkg$meta$home$sidebar$html)
+  html_path <- path(pkg$src_path, pkg$meta$home$sidebar$html)
 
   if (length(html_path)) {
     if (!file.exists(html_path)) {

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -310,13 +310,13 @@ build_reference_topic <- function(topic,
     deps <- purrr::map(
       deps,
       htmltools::copyDependencyToDir,
-      outputDir = file.path(pkg$dst_path, "reference", "libs"),
+      outputDir = path(pkg$dst_path, "reference", "libs"),
       mustWork = FALSE
     )
     deps <- purrr::map(
       deps,
       htmltools::makeDependencyRelative,
-      basepath = file.path(pkg$dst_path, "reference"),
+      basepath = path(pkg$dst_path, "reference"),
       mustWork = FALSE
     )
     data$dependencies <- htmltools::renderDependencies(deps, c("file", "href"))

--- a/R/build-search-docs.R
+++ b/R/build-search-docs.R
@@ -96,7 +96,7 @@ build_search <- function(pkg = ".",
   search_index <- build_search_index(pkg)
   jsonlite::write_json(
     search_index,
-    file.path(pkg$dst_path, "search.json"),
+    path(pkg$dst_path, "search.json"),
     auto_unbox = TRUE
   )
 }
@@ -127,7 +127,7 @@ build_search_index <- function(pkg) {
 }
 
 news_search_index <- function(path, pkg) {
-  html <- xml2::read_html(file.path(pkg$dst_path, path), encoding = "UTF-8")
+  html <- xml2::read_html(path(pkg$dst_path, path), encoding = "UTF-8")
 
   # Get contents minus logo
   node <- xml2::xml_find_all(html, ".//main")
@@ -147,7 +147,7 @@ news_search_index <- function(path, pkg) {
 }
 
 file_search_index <- function(path, pkg) {
-  html <- xml2::read_html(file.path(pkg$dst_path, path), encoding = "UTF-8")
+  html <- xml2::read_html(path(pkg$dst_path, path), encoding = "UTF-8")
   # Get page title
   title <- xml2::xml_find_first(html, ".//meta[@property='og:title']") %>%
     xml2::xml_attr("content")

--- a/R/deploy-site.R
+++ b/R/deploy-site.R
@@ -145,7 +145,7 @@ deploy_to_branch <- function(pkg = ".",
   pkg <- as_pkgdown(pkg, override = list(destination = site_dest_dir))
 
   if (!is.null(subdir) && !is.null(pkg$meta$url)) {
-    pkg$meta$url <- file.path(pkg$meta$url, subdir)
+    pkg$meta$url <- path(pkg$meta$url, subdir)
   }
 
   build_site_github_pages(pkg, ..., clean = clean)

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -37,7 +37,7 @@ local_pkgdown_site <- function(path = NULL, meta = NULL, env = parent.frame()) {
     desc <- desc::desc("!new")
     desc$set("Package", "testpackage")
     desc$set("Title", "A test package")
-    desc$write(file = file.path(path, "DESCRIPTION"))
+    desc$write(file = path(path, "DESCRIPTION"))
     
     file_create(path(path, "_pkgdown.yml"))
   }
@@ -61,7 +61,7 @@ local_pkgdown_template_pkg <- function(path = NULL, meta = NULL, env = parent.fr
     desc <- desc::desc("!new")
     desc$set("Package", "templatepackage")
     desc$set("Title", "A test template package")
-    desc$write(file = file.path(path, "DESCRIPTION"))
+    desc$write(file = path(path, "DESCRIPTION"))
   }
 
   if (!is.null(meta)) {

--- a/R/theme.R
+++ b/R/theme.R
@@ -6,7 +6,7 @@ build_bslib <- function(pkg = ".") {
   cur_digest <- purrr::map_chr(cur_deps, file_digest)
 
   deps <- bslib::bs_theme_dependencies(bs_theme)
-  deps <- lapply(deps, htmltools::copyDependencyToDir, file.path(pkg$dst_path, "deps"))
+  deps <- lapply(deps, htmltools::copyDependencyToDir, path(pkg$dst_path, "deps"))
   deps <- lapply(deps, htmltools::makeDependencyRelative, pkg$dst_path)
 
   new_deps <- find_deps(pkg)
@@ -44,7 +44,7 @@ data_deps <- function(pkg, depth) {
 }
 
 data_deps_path <- function(pkg) {
-  file.path(pkg$dst_path, "deps", "data-deps.txt")
+  path(pkg$dst_path, "deps", "data-deps.txt")
 }
 
 find_deps <- function(pkg) {

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -77,6 +77,8 @@ out_of_date <- function(source, target) {
 
 # Path helpers ------------------------------------------------------------
 
+file.path <- function(...) stop("Use path!")
+
 path_abs <- function(path, start = ".") {
   is_abs <- is_absolute_path(path)
 

--- a/tests/testthat/test-build-articles.R
+++ b/tests/testthat/test-build-articles.R
@@ -159,7 +159,7 @@ test_that("articles in vignettes/articles/ are unnested into articles/", {
 
   expect_equal(
     normalizePath(path),
-    normalizePath(file.path(pkg$dst_path, "articles", "nested.html"))
+    normalizePath(path(pkg$dst_path, "articles", "nested.html"))
   )
 
   # Check automatic redirect from articles/articles/foo.html -> articles/foo.html
@@ -260,7 +260,7 @@ test_that("titles are escaped when needed", {
   pkg <- local_pkgdown_site(test_path("assets/articles"))
   suppressMessages(build_article(pkg = pkg, name = "needs-escape"))
 
-  html <- xml2::read_html(file.path(pkg$dst_path, "articles/needs-escape.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "articles/needs-escape.html"))
   expect_equal(xpath_text(html, "//title", trim = TRUE), "a <-> b • testpackage")
   expect_equal(xpath_text(html, "//h1", trim = TRUE), "a <-> b")
 })
@@ -270,7 +270,7 @@ test_that("output is reproducible by default, i.e. 'seed' is respected", {
   pkg <- local_pkgdown_site(test_path("assets/articles"))
   suppressMessages(build_article(pkg = pkg, name = "random"))
 
-  output <- xml2::read_html(file.path(pkg$dst_path, "articles/random.html")) %>%
+  output <- xml2::read_html(path(pkg$dst_path, "articles/random.html")) %>%
     rvest::html_node("div.contents > pre") %>%
     rvest::html_text() %>%
     # replace line feeds with whitespace to make output platform independent

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -45,7 +45,7 @@ test_that("data_home_sidebar() can be defined by a HTML file", {
   pkg$meta$home$sidebar$html <- "sidebar.html"
   expect_equal(
     data_home_sidebar(pkg),
-    read_file(file.path(pkg$src_path, "sidebar.html"))
+    read_file(path(pkg$src_path, "sidebar.html"))
   )
 })
 

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -16,10 +16,10 @@ test_that("data_news works as expected for h1 & h2", {
       bootstrap: 5
   ")
 
-  write_lines(lines_h1, file.path(pkg$src_path, "NEWS.md"))
+  write_lines(lines_h1, path(pkg$src_path, "NEWS.md"))
   expect_snapshot_output(data_news(pkg)[c("version", "page", "anchor")])
 
-  write_lines(lines_h2, file.path(pkg$src_path, "NEWS.md"))
+  write_lines(lines_h2, path(pkg$src_path, "NEWS.md"))
   expect_snapshot_output(data_news(pkg)[c("version", "page", "anchor")])
 })
 
@@ -32,7 +32,7 @@ test_that("multi-page news are rendered", {
       one_page: false
     "
   )
-  write_lines(file.path(pkg$src_path, "NEWS.md"), text = c(
+  write_lines(path(pkg$src_path, "NEWS.md"), text = c(
     "# testpackage 2.0", "",
     "* bullet (#222 @someone)", "",
     "# testpackage 1.1", "",
@@ -80,7 +80,7 @@ test_that("github links are added to news items", {
       "- Bug fixes (@hadley, #100)", "",
       "- Merges (@josue-rodriguez)"
     ),
-    file.path(temp_pkg$src_path, "NEWS.md")
+    path(temp_pkg$src_path, "NEWS.md")
   )
   news_tbl <- data_news(temp_pkg)
   html <- xml2::read_xml(news_tbl$html)
@@ -203,7 +203,7 @@ test_that("clear error for bad hierarchy - bad nesting", {
       "* first thing (#111 @githubuser)", "",
       "* second thing", ""
     ),
-    file.path(temp_pkg$src_path, "NEWS.md")
+    path(temp_pkg$src_path, "NEWS.md")
   )
 
   expect_snapshot_error(data_news(temp_pkg))
@@ -224,7 +224,7 @@ test_that("clear error for bad hierarchy - h3", {
       "* first thing (#111 @githubuser)", "",
       "* second thing", ""
     ),
-    file.path(temp_pkg$src_path, "NEWS.md")
+    path(temp_pkg$src_path, "NEWS.md")
   )
 
   expect_snapshot_error(data_news(temp_pkg))
@@ -232,7 +232,7 @@ test_that("clear error for bad hierarchy - h3", {
 
 test_that("news can contain footnotes", {
   pkg <- local_pkgdown_site()
-  write_lines(path = file.path(pkg$src_path, "NEWS.md"), c(
+  write_lines(path = path(pkg$src_path, "NEWS.md"), c(
     "## testpackage 1.0.0.9000",
     "",
     "* bullet",
@@ -257,6 +257,6 @@ test_that("data_news warns if no headings found", {
       bootstrap: 5
   ")
 
-  write_lines(lines, file.path(pkg$src_path, "NEWS.md"))
+  write_lines(lines, path(pkg$src_path, "NEWS.md"))
   expect_snapshot(. <- data_news(pkg))
 })

--- a/tests/testthat/test-build-redirects.R
+++ b/tests/testthat/test-build-redirects.R
@@ -27,7 +27,7 @@ test_that("build_redirect() errors if one entry is not right.", {
     bs_version = 5
   )
   pkg <- structure(pkg, class = "pkgdown")
-  file_touch(file.path(pkg$src_path, "_pkgdown.yml"))
+  file_touch(path(pkg$src_path, "_pkgdown.yml"))
 
   expect_snapshot(build_redirect(c("old.html"), 5, pkg), error = TRUE)
 })

--- a/tests/testthat/test-build-reference.R
+++ b/tests/testthat/test-build-reference.R
@@ -23,7 +23,7 @@ test_that("examples_env sets width", {
     code:
       width: 50
   ")
-  dir.create(file.path(pkg$dst_path, "reference"), recursive = TRUE)
+  dir.create(path(pkg$dst_path, "reference"), recursive = TRUE)
 
   examples_env(pkg)
   expect_equal(getOption("width"), 50)
@@ -33,7 +33,7 @@ test_that("examples_env sets width", {
 test_that("test usage ok on rendered page", {
   pkg <- local_pkgdown_site(test_path("assets/reference"))
   suppressMessages(build_reference(pkg, topics = "c"))
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "c.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "c.html"))
   expect_equal(xpath_text(html, "//div[@id='ref-usage']", trim = TRUE), "c()")
   clean_site(pkg, quiet = TRUE)
 
@@ -43,7 +43,7 @@ test_that("test usage ok on rendered page", {
     ")
   suppressMessages(init_site(pkg))
   suppressMessages(build_reference(pkg, topics = "c"))
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "c.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "c.html"))
   # tweak_anchors() moves id into <h2>
   expect_equal(xpath_text(html, "//div[h2[@id='ref-usage']]/div", trim = TRUE), "c()")
 })
@@ -51,7 +51,7 @@ test_that("test usage ok on rendered page", {
 test_that(".Rd without usage doesn't get Usage section", {
   pkg <- local_pkgdown_site(test_path("assets/reference"))
   expect_snapshot(build_reference(pkg, topics = "e"))
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "e.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "e.html"))
   expect_equal(xpath_length(html, "//div[@id='ref-usage']"), 0)
   clean_site(pkg, quiet = TRUE)
 
@@ -61,7 +61,7 @@ test_that(".Rd without usage doesn't get Usage section", {
     ")
   suppressMessages(init_site(pkg))
   expect_snapshot(build_reference(pkg, topics = "e"))
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "e.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "e.html"))
   # tweak_anchors() moves id into <h2>
   expect_equal(xpath_length(html, "//div[h2[@id='ref-usage']]"), 0)
 })
@@ -70,7 +70,7 @@ test_that("pkgdown html dependencies are suppressed from examples in references"
   pkg <- local_pkgdown_site(test_path("assets/reference-html-dep"))
   suppressMessages(init_site(pkg))
   expect_snapshot(build_reference(pkg, topics = "a"))
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "a.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "a.html"))
 
   # jquery is only loaded once, even though it's included by an example
   expect_equal(xpath_length(html, ".//script[(@src and contains(@src, '/jquery'))]"), 1)
@@ -95,7 +95,7 @@ test_that("examples are reproducible by default, i.e. 'seed' is respected", {
   pkg <- local_pkgdown_site(test_path("assets/reference"))
   suppressMessages(build_reference(pkg, topics = "f"))
 
-  examples <- xml2::read_html(file.path(pkg$dst_path, "reference", "f.html")) %>%
+  examples <- xml2::read_html(path(pkg$dst_path, "reference", "f.html")) %>%
     rvest::html_node("div#ref-examples div.sourceCode") %>%
     rvest::html_text() %>%
     # replace line feeds with whitespace to make output platform independent
@@ -108,7 +108,7 @@ test_that("arguments get individual ids", {
   pkg <- local_pkgdown_site(test_path("assets/reference"))
   suppressMessages(build_reference(pkg, topics = "a"))
 
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "a.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "a.html"))
   expect_equal(xpath_attr(html, "//dt", "id"), c("arg-a", "arg-b", "arg-c"))
 
 })
@@ -117,7 +117,7 @@ test_that("title and page title escapes html", {
   pkg <- local_pkgdown_site(test_path("assets/reference"))
   suppressMessages(build_reference(pkg, topics = "g"))
   
-  html <- xml2::read_html(file.path(pkg$dst_path, "reference", "g.html"))
+  html <- xml2::read_html(path(pkg$dst_path, "reference", "g.html"))
   expect_equal(xpath_text(html, "//title", trim = TRUE), "g <-> h — g • testpackage")
   expect_equal(xpath_text(html, "//h1", trim = TRUE), "g <-> h")
 })

--- a/tests/testthat/test-navbar.R
+++ b/tests/testthat/test-navbar.R
@@ -71,7 +71,7 @@ test_that("data_navbar() works by default", {
     news = list(one_page = FALSE, cran_dates = FALSE),
     repo = list(url = list(home = "https://github.com/r-lib/pkgdown/"))
   ))
-  write_lines(file.path(pkg$src_path, "NEWS.md"), text = c(
+  write_lines(path(pkg$src_path, "NEWS.md"), text = c(
     "# testpackage 2.0", "",
     "* bullet (#222 @someone)"
   ))
@@ -93,7 +93,7 @@ test_that("data_navbar() can re-order default elements", {
         left: [github, search]
         right: [news]
   ")
-  file.create(file.path(pkg$src_path, "NEWS.md"))
+  file.create(path(pkg$src_path, "NEWS.md"))
 
   expect_snapshot(data_navbar(pkg)[c("left", "right")])
 })

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -22,7 +22,7 @@ test_that("check_bootstrap_version() allows 3, 4 (with warning), and 5", {
 
 test_that("check_bootstrap_version() gives informative error otherwise", {
   pkg <- local_pkgdown_site(test_path("assets/articles"))
-  file_touch(file.path(pkg$src_path, "_pkgdown.yml"))
+  file_touch(path(pkg$src_path, "_pkgdown.yml"))
 
   expect_snapshot(check_bootstrap_version(1, pkg), error = TRUE)
 })


### PR DESCRIPTION
Fixes #2535