### PR TITLE
Add alt text to vignette

### DIFF
--- a/vignettes/test/rendering.Rmd
+++ b/vignettes/test/rendering.Rmd
@@ -19,7 +19,7 @@ Yay[^footnote]
 
 ## Figures
 
-```{r}
+```{r, fig.alt="simple plot"}
 plot(1:10)
 ```
 
@@ -30,7 +30,7 @@ x <- readLines("test.txt")
 x
 ```
 
-![](bacon.jpg)
+![bacon](bacon.jpg)
 
 ## Details tag
 
@@ -169,7 +169,7 @@ blop
 
 something nice
 
-```{r}
+```{r, fig.alt="A nice plot"}
 plot(1:42)
 ```
 

--- a/vignettes/test/rendering.Rmd
+++ b/vignettes/test/rendering.Rmd
@@ -5,7 +5,8 @@ author: "Author is skipped from the TOC"
 date: "Date is skipped from the TOC"
 ---
 
-```{r include = FALSE}
+```{r}
+#| include: FALSE
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 ```
 
@@ -19,7 +20,8 @@ Yay[^footnote]
 
 ## Figures
 
-```{r, fig.alt="simple plot"}
+```{r}
+#| fig.alt: Test plot
 plot(1:10)
 ```
 
@@ -122,7 +124,8 @@ warning(cli::style_bold("This is bold"))
 ```
 Some text
 
-```{r, error = TRUE}
+```{r}
+#| error: TRUE
 stop(cli::style_italic("This is italic"))
 ```
 
@@ -169,7 +172,8 @@ blop
 
 something nice
 
-```{r, fig.alt="A nice plot"}
+```{r}
+#| fig.alt: Another test plot
 plot(1:42)
 ```
 


### PR DESCRIPTION
Fixes new warnings about missing alt-text.

Sites re-built with the next release may see a *lot* of alt-text warnings (I don't typically include `fig.alt`, but I guess I should).