### PR TITLE
Fix typo in vignette

### DIFF
--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -56,7 +56,7 @@ template:
 ```
 
 Changing the bootswatch theme affects both the HTML (via the navbar, more on that below) and the CSS, so you'll need to re-build your complete site with `build_site()` to fully appreciate the changes.
-While you're experimenting, you can speed things up by just rebuilding the home page and the CSS by running `build_home_index(); init_site()` (and then refreshing the browser).
+While you're experimenting, you can speed things up by just rebuilding the home page and the CSS by running `build_home_index()`; `init_site()` (and then refreshing the browser).
 
 Bootswatch templates with tall navbars (e.g. lux, pulse) also require that you set the `pkgdown-nav-height` bslib variable.
 Because Bootswatch themes are provided by the [bslib](https://rstudio.github.io/bslib/) R package, you can also nest the `bootswatch` field under the `bslib` field.


### PR DESCRIPTION
Minor typo,

But while I was reading the vignette, some thoughts occured to me. Just thought I'd share them as the timing seems right (actively working on pkgdown 2.1, and closed more than 100 issues in a few weeks(?!) you are a machine!)

I wanted to share my thoughts on my last pain point when iterating and customizing a site locally: `init_site()` or no `init_site()`.


## typical site customization workflow

In this type of workflow, now allowed with #2439 and #2571, I find step 0.1 to be the most nebulous 

0. `usethis::use_pkgdown()`
0.1 `init_site()` (only needed sometimes?)
1. Edit _pkgdown.yml or other site components (adding a logo, color, changing font, layout etc.)
2.  `build_home()`
4. Preview page
5. Repeat (1-3)

In short, I'd want to know what **special** edits to site config  (1) requires manually running `init_site()` (0.1).

I would use your answer to add this to `?init_site`, as it seems sufficient. BUT, ideally, it would be great to identify these *special* cases,  if there was a way for pkgdown to be smart about this, therefore acheiving the end goal I had when I opened #2439 and #2329.

You don't do site customization this often, but when you do, it is more fun if it's not too difficult!

# In very long words, my unfiltered thoughts on `init_site()`

When iterating on theming or customizing a site, sometimes you need to run  `init_site()`, (which can take a longer) (especially on Windows with no SSD, copying files is sooo slow, I don't understand why). So, it is slow to call this a lot. 

I see that in the vignette, it is required to call `init_site()` when changing font for previewing. I guess it is required in other contexts, what are they? And when is it not required? AFAIR, iterating by changing bslib variables in template doesn't require `init_site()`.

I wonder if you could add to `?init_site` a section like that. 

When do you need to run `init_site()`.
* When iterating on theme.css?
* When changing fonts


When you don't have to (since we made that redundant in #2439 
* to create the site: call `usethis::use_pkgdown()` + `build_site()` instead.
* To preview site: use `build_site()`.
* when changing bslib variables in `_pkgdown.yml` 

Maybe a more agile `refresh_site()` or `init_site(lazy = TRUE)` could be introduced that would only do the required things? (`a la usethis::use_github_action()`, Calling `use_github_action()` asks (or lets you and informs) overwrite R-CMD-check.yml.
Personally, I am leveraging `usethis::write_over()` in my workflows. I wonder if pkgdown could have something similar.

* `refresh_site()` could be called in the `build_*()` functions, similar to what we did in #2439, a *lazy* alternative to `init_site()`.

AFAICT, `init_site(lazy = TRUE)` would have to do something if.
* if docs/ doesn't exist
  * regular `init_site()` 
* if `_pkgdown.yml` changed
  *  Copy it if changed
  * if detected a change in **special** components, call `init_site(lazy = FALSE)`
* If logo has changed,
  * `refresh_site()` would know about this and would inform + overwrite logo  favicons. Otherwise, does nothing. 
* If theme.css has changed
  *  copy it to `docs/`
* if development.mode changes?

Since pkgdown keeps a copy of pkgdown.yml in the `docs/` folder, it would just be to a few targeted comparisons, between `_pkgdown.yml` and `docs/_pkgdown.yml`

Do inform of how `init_site(lazy = TRUE)` handled special components.

* Kept logo unchanged
* Kept theme.css unchanged
* Kept fonts unchanged
etc.

Here are my thoughts on `init_site()` for context.

(Disclaimer: I haven't followed all your latest development on pkgdown after 2.0.9 release) I opened, `init_site()` was the main friction point left for me, as I don't like calling it (I find it long to run, and I am never sure if it *really* has to do all the things it does, what it overwrites and 

Overall, it is just not clear to me when you have to build everything from scratch, and when things are fine and you can preview your site, and it will show your recent additions.

I ended up calling unlink("docs/", recursive = TRUE) way too many times, as I didn't know  