### PR TITLE
Rethrow parsing error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     purrr (>= 1.0.0),
     ragg,
     rlang (>= 1.1.0),
-    rmarkdown (>= 2.26.2),
+    rmarkdown (>= 2.27),
     tibble,
     whisker,
     withr (>= 2.4.3),
@@ -72,5 +72,3 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 SystemRequirements: pandoc
-Remotes:  
-    rstudio/rmarkdown

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -20,3 +20,16 @@
       ! template.bootstrap must be 3 or 5, not 1.
       i Edit _pkgdown.yml to fix the problem.
 
+# read_meta() errors gracefully if _pkgdown.yml failed to parse
+
+    Code
+      read_meta(file, check_path = FALSE)
+    Condition
+      Error in `read_meta()`:
+      ! The url: field failed to parse.
+      i Error occured between lines 1 and 9.
+      i Edit 'assets/bad-yaml/_pkgdown.yml' to fix the problem.
+      i Did not find the expected keys at line 9 while parsing a block mapping.
+      Caused by error in `yaml.load()`:
+      ! (assets/bad-yaml/_pkgdown.yml) Parser error: while parsing a block mapping at line 1, column 1 did not find expected key at line 9, column 3
+

--- a/tests/testthat/assets/bad-yaml/_pkgdown.yml
+++ b/tests/testthat/assets/bad-yaml/_pkgdown.yml
@@ -1,0 +1,16 @@
+url: https://pkgdown.r-lib.org
+
+home:
+  title: Build websites for R packages
+
+authors:
+   Jay Hesselberth:
+    href: https://hesselberthlab.org
+  Maëlle Salmon:
+    href: https://masalmon.eu
+  Hadley Wickham:
+    href: http://hadley.nz
+  Posit Software, PBC:
+    href: https://www.posit.co
+    html: >-
+      <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' width='62' height='16' style="margin-bottom: 3px;" />

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -82,3 +82,14 @@ test_that("titles don't get autolinked code", {
   rd <- rd_text("\\title{\\code{foo()}}", fragment = FALSE)
   expect_equal(extract_title(rd), "<code>foo()</code>")
 })
+
+test_that("read_meta() errors gracefully if _pkgdown.yml failed to parse", {
+  file <- test_path("assets", "bad-yaml", "_pkgdown.yml")
+  expect_snapshot(
+    error = TRUE,
+    read_meta(
+      file,
+      check_path = FALSE
+    )
+  )
+})


### PR DESCRIPTION
A proof of concept, as I am pretty sure I overcomplicated things.


Currently, consider the file I added in bad yaml.

which is just that the spacing at line 7 is off by one.

![image](https://github.com/r-lib/pkgdown/assets/52606734/74ba67c1-edfc-47f0-b10c-a4968b8bb3fb)

Unfortunately, RStudio doesn't (yet?) lint _pkgdown.yml.

It does for _quarto.yml.

This tiny mistake gives the following message, which feels like a cryptic base R message hard to debug.
![image](https://github.com/r-lib/pkgdown/assets/52606734/2a2c6c4f-1ada-4266-b083-5084ae47567b)

My goal with this PR is to help nudge in the right direction, by 1. creating clickable hyperlinks.

2. rearrange the context of the error.

I have not fully tested this, i.e. not checked every possible yaml parsing errors, but I wanted to showcase my progress. I wanted to see if you would welcome this type of change.

