### PR TITLE
build_home and build_home_index were the last site parts components you couldn't call directly without init_site()

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -293,7 +293,7 @@ build_home <- function(pkg = ".",
   check_bool(quiet)
 
   cli::cli_rule("Building home")
-  dir_create(pkg$dst_path)
+  create_subdir(pkg, "")
 
   build_citation_authors(pkg)
 


### PR DESCRIPTION
I didn't realize I was missing this one.

To finalize on #2439. 

With this PR, all  `build_*()` work without `init_site()`.

fyi `fs::path("dir", "")` = "dir" but fs::path("dir", NULL) gives `character(0)`.

Make `init_site()` even less relevant for previewing a site part!