### PR TITLE
Tweak spacing within code blocks

### DIFF
--- a/inst/BS5/assets/pkgdown.scss
+++ b/inst/BS5/assets/pkgdown.scss
@@ -431,7 +431,7 @@ code {
 }
 // Ensure there's enough space for the copy button
 pre {
-  padding: 1rem 0.5rem;
+  padding: 0.75rem;
 }
 
 // Spacing tweaks for gt table


### PR DESCRIPTION
This provides enough space (look at the `pkgdown::build_site()` on the homepage), but I think it looks better because it's symmetrical.

@maelle just need a sanity check that this looks ok