### PR TITLE
Better distinguish reference titles from subtitles

### DIFF
--- a/inst/BS5/assets/pkgdown.scss
+++ b/inst/BS5/assets/pkgdown.scss
@@ -329,6 +329,11 @@ img.logo {
   dt {font-weight: normal;}
   // Don't allow breaking within a function name
   code {word-wrap: normal;}
+  // Underline top-level reference topics ("titles") to better distinguish them from second-level ones ("subtitles")
+  main h2 {
+    text-decoration-line: underline;
+    text-underline-offset: 0.33em;
+  }
 }
 .icon {
   float: right;


### PR DESCRIPTION
Minimalistic styling addition that underlines top-level reference topics ("titles") to better distinguish them from second-level ones ("subtitles"). I found it always hard to visually tell them apart with pkgdown's default styling, so I think this would make sense to be included by default.