### PR TITLE
Unify config error messages

### DIFF
--- a/R/build-article.R
+++ b/R/build-article.R
@@ -43,7 +43,7 @@ build_article <- function(name,
 
   front <- rmarkdown::yaml_front_matter(input_path)
   # Take opengraph from article's yaml front matter
-  front_opengraph <- check_open_graph(front$opengraph, input)
+  front_opengraph <- check_open_graph(pkg, front$opengraph, input)
   data$opengraph <- modify_list(data$opengraph, front_opengraph)
 
   # Allow users to opt-in to their own template

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -146,7 +146,7 @@ build_news_multi <- function(pkg = ".") {
 
 utils::globalVariables(".")
 
-data_news <- function(pkg = list()) {
+data_news <- function(pkg = list(), call = caller_env() ) {
   html <- markdown_body(pkg, path(pkg$src_path, "NEWS.md"))
   xml <- xml2::read_html(html)
   downlit::downlit_html_node(xml)
@@ -163,14 +163,12 @@ data_news <- function(pkg = list()) {
     xml2::xml_name()
   ulevels <- unique(levels)
   if (!identical(ulevels, "h1") && !identical(ulevels, "h2")) {
-    cli::cli_abort(
-      c(
-        "Invalid NEWS.md: inconsistent use of section headings.",
-        i = "Top-level headings must be either all <h1> or all <h2>.",
-        i = "See {.help pkgdown::build_news} for more details."
-      ),
-      call = caller_env()
+    msg <- c(
+      "inconsistent use of section headings.",
+      i = "Top-level headings must be either all <h1> or all <h2>.",
+      i = "See {.help pkgdown::build_news} for more details."
     )
+    config_abort(pkg, msg, path = "NEWS.md", call = call)
   }
   if (ulevels == "h1") {
     # Bump every heading down a level so to get a single <h1> for the page title
@@ -183,10 +181,11 @@ data_news <- function(pkg = list()) {
   sections <- sections[!is.na(versions)]
 
   if (length(sections) == 0) {
-    cli::cli_warn(c(
-      "No version headings found in {src_path('NEWS.md')}",
+    msg <- c(
+      "no version headings found",
       i = "See {.help pkgdown::build_news} for expected structure."
-    ))
+    )
+    config_warn(pkg, msg, path = "NEWS.md", call = call)
   }
 
   versions <- versions[!is.na(versions)]

--- a/R/check.R
+++ b/R/check.R
@@ -76,19 +76,14 @@ check_urls <- function(pkg = ".", call = caller_env()) {
   url <- pkg$meta[["url"]]
 
   if (is.null(url)) {
-    cli::cli_abort(
-      c("{config_path(pkg)} lacks {.field url}.", details),
-      call = call
-    )
+    config_abort(pkg, c("{.field url} is missing.", details), call = call)
   } else {
     desc_urls <- pkg$desc$get_urls()
     desc_urls <- sub("/$", "", desc_urls)
 
     if (!pkg$meta[["url"]] %in% desc_urls) {
-      cli::cli_abort(
-        c("{.file DESCRIPTION} {.field URL} lacks package url ({url}).", details),
-        call = call
-      )
+      msg <- "{.field URL} is missing package url ({url})."
+      config_abort(pkg, c(msg, details), path = "DESCRIPTION", call = call)
     }
   }
 }

--- a/R/config.R
+++ b/R/config.R
@@ -241,7 +241,7 @@ config_warn <- function(pkg,
 }
 
 config_message <- function(pkg, message, path = NULL) {
-
+  # Not all projects necessary have a _pkgdown.yml (#2542)
   path <- path %||% pkgdown_config_path(pkg) %||% "_pkgdown.yml"
   if (is_absolute_path(path)) {
     path_label <- path_rel(path, pkg$src_path)
@@ -252,10 +252,4 @@ config_message <- function(pkg, message, path = NULL) {
   link <- cli::style_hyperlink(path_label, paste0("file://", path))  
   message[[1]] <- paste0("In ", link, ", ", message[[1]])
   message
-}
-
-config_path <- function(pkg) {
-  # Not all projects necessary have a _pkgdown.yml (#2542)
-  config <- pkgdown_config_path(pkg) %||% "_pkgdown.yml"
-  cli::style_hyperlink(path_file(config), paste0("file://", config))  
 }

--- a/R/config.R
+++ b/R/config.R
@@ -220,31 +220,38 @@ config_abort_type <- function(must_be, not, error_pkg, error_path, error_call) {
 
 config_abort <- function(pkg,
                          message,
-                         path = pkgdown_config_path(pkg) %||% "_pkgdown.yml",
+                         path = NULL,
                          ...,
                          call = caller_env(),
                          .envir = caller_env()) {
   
+  message <- config_message(pkg, message, path)
+  cli::cli_abort(message, ..., call = call, .envir = .envir)
+}
+
+config_warn <- function(pkg,
+                        message,
+                        path = NULL,
+                        ...,
+                        call = caller_env(),
+                        .envir = caller_env()) {
+  
+  message <- config_message(pkg, message, path)
+  cli::cli_warn(message, ..., call = call, .envir = .envir)
+}
+
+config_message <- function(pkg, message, path = NULL) {
+
+  path <- path %||% pkgdown_config_path(pkg) %||% "_pkgdown.yml"
   if (is_absolute_path(path)) {
     path_label <- path_rel(path, pkg$src_path)
   } else {
     path_label <- path
   }
-
+  
   link <- cli::style_hyperlink(path_label, paste0("file://", path))  
   message[[1]] <- paste0("In ", link, ", ", message[[1]])
-  cli::cli_abort(message, ..., call = call, .envir = .envir)
-}
-config_warn <- function(pkg,
-                         message,
-                         path = pkgdown_config_path(pkg) %||% "_pkgdown.yml",
-                         ...,
-                         call = caller_env(),
-                         .envir = caller_env()) {
-  
-  link <- cli::style_hyperlink(path_rel(path, pkg$src_path), paste0("file://", path))  
-  message[[1]] <- paste0("In ", link, ", ", message[[1]])
-  cli::cli_warn(message, ..., call = call, .envir = .envir)
+  message
 }
 
 config_path <- function(pkg) {

--- a/R/config.R
+++ b/R/config.R
@@ -220,18 +220,31 @@ config_abort_type <- function(must_be, not, error_pkg, error_path, error_call) {
 
 config_abort <- function(pkg,
                          message,
+                         path = pkgdown_config_path(pkg) %||% "_pkgdown.yml",
                          ...,
                          call = caller_env(),
                          .envir = caller_env()) {
+  
+  if (is_absolute_path(path)) {
+    path_label <- path_rel(path, pkg$src_path)
+  } else {
+    path_label <- path
+  }
 
-  edit <- cli::format_inline("Edit {config_path(pkg)} to fix the problem.")
-
-  cli::cli_abort(
-    c(message, i = edit),
-    ...,
-    call = call,
-    .envir = .envir
-  )
+  link <- cli::style_hyperlink(path_label, paste0("file://", path))  
+  message[[1]] <- paste0("In ", link, ", ", message[[1]])
+  cli::cli_abort(message, ..., call = call, .envir = .envir)
+}
+config_warn <- function(pkg,
+                         message,
+                         path = pkgdown_config_path(pkg) %||% "_pkgdown.yml",
+                         ...,
+                         call = caller_env(),
+                         .envir = caller_env()) {
+  
+  link <- cli::style_hyperlink(path_rel(path, pkg$src_path), paste0("file://", path))  
+  message[[1]] <- paste0("In ", link, ", ", message[[1]])
+  cli::cli_warn(message, ..., call = call, .envir = .envir)
 }
 
 config_path <- function(pkg) {

--- a/R/package.R
+++ b/R/package.R
@@ -138,7 +138,7 @@ get_bootstrap_version <- function(template, package = NULL, pkg) {
     config_abort(
       pkg,
       c(
-        "Must set one only of {.field template.bootstrap} and {.field template.bslib.version}.",
+        "must set only one of {.field template.bootstrap} and {.field template.bslib.version}.",
         i = hint
       ),
       call = caller_env()

--- a/R/render.R
+++ b/R/render.R
@@ -180,7 +180,7 @@ check_open_graph <- function(pkg, og, file_path = NULL, call = caller_env()) {
   supported_fields <- c("image", "twitter")
   unsupported_fields <- setdiff(names(og), supported_fields)
   if (length(unsupported_fields)) {
-    msg <- "Unsupported {.field {base_path}} {cli::qty(unsupported_fields)} field{?s}: {.val {unsupported_fields}}."
+    msg <- "{.field {base_path}} contains unsupported fields {.val {unsupported_fields}}."
     config_warn(pkg, msg, path = file_path, call = call)
   }
   check_open_graph_list(

--- a/R/render.R
+++ b/R/render.R
@@ -137,7 +137,7 @@ data_template <- function(pkg = ".", depth = 0L) {
 data_open_graph <- function(pkg = ".", call = caller_env()) {
   pkg <- as_pkgdown(pkg)
   og <- config_pluck_list(pkg, "template.opengraph", default = list())
-  og <- check_open_graph(pkg, og, pkgdown_config_path(pkg) %||% "_pkgdown.yml", call = call)
+  og <- check_open_graph(pkg, og, call = call)
 
   logo <- find_logo(pkg$src_path)
   if (is.null(og$image) && !is.null(logo)) {
@@ -161,12 +161,12 @@ data_open_graph <- function(pkg = ".", call = caller_env()) {
   og
 }
 
-check_open_graph <- function(pkg, og, file_path, call = caller_env()) {
+check_open_graph <- function(pkg, og, file_path = NULL, call = caller_env()) {
   if (is.null(og)) {
     return()
   }
-
-  is_yaml <- path_ext(file_path) %in% c("yml", "yaml")
+  
+  is_yaml <- is.null(file_path)
   base_path <- if (is_yaml) "template.opengraph" else "opengraph"
 
   check_open_graph_list(

--- a/R/render.R
+++ b/R/render.R
@@ -137,7 +137,7 @@ data_template <- function(pkg = ".", depth = 0L) {
 data_open_graph <- function(pkg = ".", call = caller_env()) {
   pkg <- as_pkgdown(pkg)
   og <- config_pluck_list(pkg, "template.opengraph", default = list())
-  og <- check_open_graph(og, pkgdown_config_path(pkg) %||% "_pkgdown.yml", call = call)
+  og <- check_open_graph(pkg, og, pkgdown_config_path(pkg) %||% "_pkgdown.yml", call = call)
 
   logo <- find_logo(pkg$src_path)
   if (is.null(og$image) && !is.null(logo)) {
@@ -161,17 +161,18 @@ data_open_graph <- function(pkg = ".", call = caller_env()) {
   og
 }
 
-check_open_graph <- function(og, path, call = caller_env()) {
+check_open_graph <- function(pkg, og, file_path, call = caller_env()) {
   if (is.null(og)) {
     return()
   }
 
-  is_yaml <- path_ext(path) %in% c("yml", "yaml")
+  is_yaml <- path_ext(file_path) %in% c("yml", "yaml")
   base_path <- if (is_yaml) "template.opengraph" else "opengraph"
 
   check_open_graph_list(
+    pkg,
     og,
-    file_path = path,
+    file_path = file_path,
     error_path = base_path,
     error_call = call
   )
@@ -179,26 +180,24 @@ check_open_graph <- function(og, path, call = caller_env()) {
   supported_fields <- c("image", "twitter")
   unsupported_fields <- setdiff(names(og), supported_fields)
   if (length(unsupported_fields)) {
-    cli::cli_warn(
-      "{.file {path}}: Unsupported {.field {base_path}} {cli::qty(unsupported_fields)} field{?s}: {.val {unsupported_fields}}.",
-      call = call
-    )
+    msg <- "Unsupported {.field {base_path}} {cli::qty(unsupported_fields)} field{?s}: {.val {unsupported_fields}}."
+    config_warn(pkg, msg, path = file_path, call = call)
   }
   check_open_graph_list(
+    pkg,
     og$twitter,
-    file_path = path,
+    file_path = file_path,
     error_path = paste0(base_path, ".twitter"),
     error_call = call
   )
   if (!is.null(og$twitter) && is.null(og$twitter$creator) && is.null(og$twitter$site)) {
-    cli::cli_abort(
-      "{.file {path}}: {.field opengraph.twitter} must include either {.field creator} or {.field site}.",
-      call = call
-    )
+    msg <- "{.field opengraph.twitter} must include either {.field creator} or {.field site}."
+    config_abort(pkg, msg, path = file_path, call = call)
   }
   check_open_graph_list(
+    pkg,
     og$image,
-    file_path = path,
+    file_path = file_path,
     error_path = paste0(base_path, ".image"),
     error_call = call
   )
@@ -213,7 +212,8 @@ render_template <- function(path, data) {
   whisker::whisker.render(template, data)
 }
 
-check_open_graph_list <- function(x,
+check_open_graph_list <- function(pkg,
+                                  x,
                                   file_path,
                                   error_path,
                                   error_call = caller_env()) {
@@ -221,8 +221,10 @@ check_open_graph_list <- function(x,
     return()
   }
   not <- obj_type_friendly(x)
-  cli::cli_abort(
-    "{.file {file_path}}: {.field {error_path}} must be a list, not {not}.",
+  config_abort(
+    pkg, 
+    "{.field {error_path}} must be a list, not {not}.",
+    path = file_path,
     call = error_call
   )
 }

--- a/R/theme.R
+++ b/R/theme.R
@@ -175,7 +175,10 @@ get_bslib_theme <- function(pkg) {
   check_bslib_theme(themes[[field]], pkg, field)
 }
 
-check_bslib_theme <- function(theme, pkg, field = "template.bootswatch", bs_version = pkg$bs_version) {
+check_bslib_theme <- function(theme,
+                              pkg,
+                              field = "template.bootswatch",
+                              bs_version = pkg$bs_version) {
   bslib_themes <- c(
     bslib::bootswatch_themes(bs_version),
     bslib::builtin_themes(bs_version),
@@ -191,7 +194,7 @@ check_bslib_theme <- function(theme, pkg, field = "template.bootswatch", bs_vers
   config_abort(
     pkg,
     c(
-      x = "Can't find Bootswatch/bslib theme preset {.val {theme}} ({.field {field}}).",
+      x = "{.field {field}} contains unknown Bootswatch/bslib theme {.val {theme}}.",
       i = "Using Bootstrap version {.val {bs_version}} ({.field template.bootstrap})."
     ),
     call = caller_env()

--- a/tests/testthat/_snaps/build-article.md
+++ b/tests/testthat/_snaps/build-article.md
@@ -36,8 +36,7 @@
       build_rmarkdown_format(pkg, "article")
     Condition
       Error in `build_rmarkdown_format()`:
-      ! code.width must be a whole number, not the string "abc".
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, code.width must be a whole number, not the string "abc".
 
 # output is reproducible by default, i.e. 'seed' is respected
 
@@ -52,7 +51,7 @@
       build_article(pkg = pkg, name = "bad-opengraph")
     Condition
       Error in `build_article()`:
-      ! 'vignettes/bad-opengraph.Rmd': opengraph.twitter must be a list, not the number 1.
+      ! In vignettes/bad-opengraph.Rmd, opengraph.twitter must be a list, not the number 1.
 
 # render_rmarkdown copies image files in subdirectories
 

--- a/tests/testthat/_snaps/build-articles.md
+++ b/tests/testthat/_snaps/build-articles.md
@@ -4,40 +4,34 @@
       data_articles_index_(1)
     Condition
       Error in `data_articles_index_()`:
-      ! articles must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, articles must be a list, not the number 1.
     Code
       data_articles_index_(list(1))
     Condition
       Error in `data_articles_index_()`:
-      ! articles[1] must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, articles[1] must be a list, not the number 1.
     Code
       data_articles_index_(list(list()))
     Condition
       Error in `data_articles_index_()`:
-      ! articles[1] must have components "title" and "contents".
+      ! In _pkgdown.yml, articles[1] must have components "title" and "contents".
       2 missing components: "title" and "contents".
-      i Edit _pkgdown.yml to fix the problem.
     Code
       data_articles_index_(list(list(title = 1, contents = 1)))
     Condition
       Error in `data_articles_index_()`:
-      ! articles[1].title must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, articles[1].title must be a string, not the number 1.
     Code
       data_articles_index_(list(list(title = "a\n\nb", contents = 1)))
     Condition
       Error in `data_articles_index_()`:
-      ! articles[1].title must be inline markdown.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, articles[1].title must be inline markdown.
     Code
       data_articles_index_(list(list(title = "a", contents = 1)))
     Condition
       Error in `data_articles_index_()`:
-      ! articles[1].contents[1] must be a string.
+      ! In _pkgdown.yml, articles[1].contents[1] must be a string.
       i You might need to add '' around special YAML values like 'N' or 'off'
-      i Edit _pkgdown.yml to fix the problem.
 
 # validates external-articles
 
@@ -45,45 +39,38 @@
       data_articles_(1)
     Condition
       Error in `data_articles_()`:
-      ! external-articles must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, external-articles must be a list, not the number 1.
     Code
       data_articles_(list(1))
     Condition
       Error in `data_articles_()`:
-      ! external-articles[1] must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, external-articles[1] must be a list, not the number 1.
     Code
       data_articles_(list(list(name = "x")))
     Condition
       Error in `data_articles_()`:
-      ! external-articles[1] must have components "name", "title", "href", and "description".
+      ! In _pkgdown.yml, external-articles[1] must have components "name", "title", "href", and "description".
       3 missing components: "title", "href", and "description".
-      i Edit _pkgdown.yml to fix the problem.
     Code
       data_articles_(list(list(name = 1, title = "x", href = "x", description = "x")))
     Condition
       Error in `data_articles_()`:
-      ! external-articles[1].name must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, external-articles[1].name must be a string, not the number 1.
     Code
       data_articles_(list(list(name = "x", title = 1, href = "x", description = "x")))
     Condition
       Error in `data_articles_()`:
-      ! external-articles[1].title must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, external-articles[1].title must be a string, not the number 1.
     Code
       data_articles_(list(list(name = "x", title = "x", href = 1, description = "x")))
     Condition
       Error in `data_articles_()`:
-      ! external-articles[1].href must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, external-articles[1].href must be a string, not the number 1.
     Code
       data_articles_(list(list(name = "x", title = "x", href = "x", description = 1)))
     Condition
       Error in `data_articles_()`:
-      ! external-articles[1].description must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, external-articles[1].description must be a string, not the number 1.
 
 # articles in vignettes/articles/ are unnested into articles/
 
@@ -99,6 +86,5 @@
       . <- data_articles_index(pkg)
     Condition
       Error:
-      ! 1 vignette missing from index: "c".
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, 1 vignette missing from index: "c".
 

--- a/tests/testthat/_snaps/build-footer.md
+++ b/tests/testthat/_snaps/build-footer.md
@@ -13,30 +13,25 @@
       data_footer_(footer = 1)
     Condition
       Error in `data_footer_()`:
-      ! footer must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, footer must be a list, not the number 1.
     Code
       data_footer_(footer = list(structure = 1))
     Condition
       Error in `data_footer_()`:
-      ! footer.structure must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, footer.structure must be a list, not the number 1.
     Code
       data_footer_(footer = list(components = 1))
     Condition
       Error in `data_footer_()`:
-      ! footer.components must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, footer.components must be a list, not the number 1.
     Code
       data_footer_(authors = list(footer = list(roles = 1)))
     Condition
       Error in `data_footer_()`:
-      ! authors.footer.roles must be a character vector, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, authors.footer.roles must be a character vector, not the number 1.
     Code
       data_footer_(authors = list(footer = list(text = 1)))
     Condition
       Error in `data_footer_()`:
-      ! authors.footer.text must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, authors.footer.text must be a string, not the number 1.
 

--- a/tests/testthat/_snaps/build-home-authors.md
+++ b/tests/testthat/_snaps/build-home-authors.md
@@ -4,20 +4,17 @@
       data_authors_(authors = 1)
     Condition
       Error in `data_authors_()`:
-      ! authors must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, authors must be a list, not the number 1.
     Code
       data_authors_(template = list(authors = list(before = 1)))
     Condition
       Error in `data_authors_()`:
-      ! template.authors.before must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.authors.before must be a string, not the number 1.
     Code
       data_authors_(template = list(authors = list(after = 1)))
     Condition
       Error in `data_authors_()`:
-      ! template.authors.after must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.authors.after must be a string, not the number 1.
 
 # data_home_sidebar_authors validates yaml inputs
 
@@ -25,20 +22,17 @@
       data_home_sidebar_authors_(authors = list(sidebar = list(roles = 1)))
     Condition
       Error in `data_home_sidebar_authors_()`:
-      ! authors.sidebar.roles must be a character vector, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, authors.sidebar.roles must be a character vector, not the number 1.
     Code
       data_home_sidebar_authors_(authors = list(sidebar = list(before = 1)))
     Condition
       Error in `data_home_sidebar_authors_()`:
-      ! authors.sidebar.before must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, authors.sidebar.before must be a string, not the number 1.
     Code
       data_home_sidebar_authors_(authors = list(sidebar = list(before = "x\n\ny")))
     Condition
       Error in `data_home_sidebar_authors_()`:
-      ! authors.sidebar.before must be inline markdown.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, authors.sidebar.before must be inline markdown.
 
 # sidebar can accept additional before and after text
 

--- a/tests/testthat/_snaps/build-home-index.md
+++ b/tests/testthat/_snaps/build-home-index.md
@@ -16,26 +16,22 @@
       data_home_(home = 1)
     Condition
       Error in `data_home_()`:
-      ! home must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, home must be a list, not the number 1.
     Code
       data_home_(home = list(title = 1))
     Condition
       Error in `data_home_()`:
-      ! home.title must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, home.title must be a string, not the number 1.
     Code
       data_home_(home = list(description = 1))
     Condition
       Error in `data_home_()`:
-      ! home.description must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, home.description must be a string, not the number 1.
     Code
       data_home_(template = list(trailing_slash_redirect = 1))
     Condition
       Error in `data_home_()`:
-      ! template.trailing_slash_redirect must be true or false, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.trailing_slash_redirect must be true or false, not the number 1.
 
 # data_home_sidebar() works by default
 
@@ -109,42 +105,36 @@
       data_home_sidebar_(html = 1)
     Condition
       Error in `data_home_sidebar_()`:
-      ! home.sidebar.html must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, home.sidebar.html must be a string, not the number 1.
     Code
       data_home_sidebar_(structure = 1)
     Condition
       Error in `data_home_sidebar_()`:
-      ! home.sidebar.structure must be a character vector, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, home.sidebar.structure must be a character vector, not the number 1.
     Code
       data_home_sidebar_(structure = "fancy")
     Condition
       Error in `data_home_sidebar_()`:
-      ! home.sidebar.components must have component "fancy".
+      ! In _pkgdown.yml, home.sidebar.components must have component "fancy".
       1 missing component: "fancy".
-      i Edit _pkgdown.yml to fix the problem.
     Code
       data_home_sidebar_(structure = c("fancy", "cool"))
     Condition
       Error in `data_home_sidebar_()`:
-      ! home.sidebar.components must have components "fancy" and "cool".
+      ! In _pkgdown.yml, home.sidebar.components must have components "fancy" and "cool".
       2 missing components: "fancy" and "cool".
-      i Edit _pkgdown.yml to fix the problem.
     Code
       data_home_sidebar_(structure = "fancy", components = list(fancy = list(text = "bla")))
     Condition
       Error in `data_home_sidebar_()`:
-      ! home.sidebar.components.fancy must have components "title" and "text".
+      ! In _pkgdown.yml, home.sidebar.components.fancy must have components "title" and "text".
       1 missing component: "title".
-      i Edit _pkgdown.yml to fix the problem.
     Code
       data_home_sidebar_(structure = "fancy", components = list(fancy = list()))
     Condition
       Error in `data_home_sidebar_()`:
-      ! home.sidebar.components.fancy must have components "title" and "text".
+      ! In _pkgdown.yml, home.sidebar.components.fancy must have components "title" and "text".
       2 missing components: "title" and "text".
-      i Edit _pkgdown.yml to fix the problem.
 
 # data_home_sidebar() errors well when no HTML file
 
@@ -152,6 +142,5 @@
       data_home_sidebar(pkg)
     Condition
       Error:
-      ! home.sidebar.html specifies a file that doesn't exist ('file.html').
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, home.sidebar.html specifies a file that doesn't exist ('file.html').
 

--- a/tests/testthat/_snaps/build-news.md
+++ b/tests/testthat/_snaps/build-news.md
@@ -59,7 +59,7 @@
       data_news(temp_pkg)
     Condition
       Error:
-      ! Invalid NEWS.md: inconsistent use of section headings.
+      ! In NEWS.md, inconsistent use of section headings.
       i Top-level headings must be either all <h1> or all <h2>.
       i See `?pkgdown::build_news()` for more details.
 
@@ -69,7 +69,7 @@
       data_news(temp_pkg)
     Condition
       Error:
-      ! Invalid NEWS.md: inconsistent use of section headings.
+      ! In NEWS.md, inconsistent use of section headings.
       i Top-level headings must be either all <h1> or all <h2>.
       i See `?pkgdown::build_news()` for more details.
 
@@ -87,6 +87,6 @@
       . <- data_news(pkg)
     Condition
       Warning:
-      No version headings found in NEWS.md
+      In NEWS.md, no version headings found
       i See `?pkgdown::build_news()` for expected structure.
 

--- a/tests/testthat/_snaps/build-redirects.md
+++ b/tests/testthat/_snaps/build-redirects.md
@@ -11,12 +11,10 @@
       data_redirects_(redirects = "old.html")
     Condition
       Error in `data_redirects_()`:
-      ! redirects must be a list, not the string "old.html".
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, redirects must be a list, not the string "old.html".
     Code
       data_redirects_(redirects = list("old.html"))
     Condition
       Error in `data_redirects_()`:
-      ! redirects[1] must be a character vector of length 2, not the string "old.html".
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, redirects[1] must be a character vector of length 2, not the string "old.html".
 

--- a/tests/testthat/_snaps/build-reference-index.md
+++ b/tests/testthat/_snaps/build-reference-index.md
@@ -56,9 +56,8 @@
       data_reference_index(pkg)
     Condition
       Error:
-      ! 3 topics missing from index: "c", "e", and "?".
+      ! In _pkgdown.yml, 3 topics missing from index: "c", "e", and "?".
       i Either use `@keywords internal` to drop from index, or
-      i Edit _pkgdown.yml to fix the problem.
 
 # gives informative errors
 
@@ -66,63 +65,53 @@
       data_reference_index_(1)
     Condition
       Error in `config_pluck_reference()`:
-      ! reference must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference must be a list, not the number 1.
     Code
       data_reference_index_(list(1))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1] must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1] must be a list, not the number 1.
     Code
       data_reference_index_(list(list(title = 1)))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].title must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].title must be a string, not the number 1.
     Code
       data_reference_index_(list(list(title = "a\n\nb")))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].title must be inline markdown.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].title must be inline markdown.
     Code
       data_reference_index_(list(list(subtitle = 1)))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].subtitle must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].subtitle must be a string, not the number 1.
     Code
       data_reference_index_(list(list(subtitle = "a\n\nb")))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].subtitle must be inline markdown.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].subtitle must be inline markdown.
     Code
       data_reference_index_(list(list(title = "bla", contents = 1)))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].contents[1] must be a string.
+      ! In _pkgdown.yml, reference[1].contents[1] must be a string.
       i You might need to add '' around special YAML values like 'N' or 'off'
-      i Edit _pkgdown.yml to fix the problem.
     Code
       data_reference_index_(list(list(title = "bla", contents = NULL)))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].contents is empty.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].contents is empty.
     Code
       data_reference_index_(list(list(title = "bla", contents = list("a", NULL))))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].contents[2] is empty.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].contents[2] is empty.
     Code
       data_reference_index_(list(list(title = "bla", contents = list())))
     Condition
       Error in `data_reference_index_()`:
-      ! reference[1].contents is empty.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, reference[1].contents is empty.
     Code
       data_reference_index_(list(list(title = "bla", contents = "notapackage::lala")))
     Condition

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -23,9 +23,8 @@
       v Open graph metadata ok.
       v Articles metadata ok.
       x Reference metadata not ok.
-        1 topic missing from index: "?".
+        In _pkgdown.yml, 1 topic missing from index: "?".
         Either use `@keywords internal` to drop from index, or
-        Edit _pkgdown.yml to fix the problem.
 
 # checks fails on first problem
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -18,7 +18,7 @@
     Message
       -- Sitrep ----------------------------------------------------------------------
       x URLs not ok.
-        'DESCRIPTION' URL lacks package url (http://test.org).
+        In DESCRIPTION, URL is missing package url (http://test.org).
         See details in `vignette(pkgdown::metadata)`.
       v Open graph metadata ok.
       v Articles metadata ok.
@@ -32,7 +32,7 @@
       check_pkgdown(pkg)
     Condition
       Error in `check_pkgdown()`:
-      ! 'DESCRIPTION' URL lacks package url (http://test.org).
+      ! In DESCRIPTION, URL is missing package url (http://test.org).
       i See details in `vignette(pkgdown::metadata)`.
 
 # both inform if everything is ok
@@ -56,7 +56,7 @@
       check_urls(pkg)
     Condition
       Error:
-      ! _pkgdown.yml lacks url.
+      ! In _pkgdown.yml, url is missing.
       i See details in `vignette(pkgdown::metadata)`.
 
 ---
@@ -65,6 +65,6 @@
       check_urls(pkg)
     Condition
       Error:
-      ! 'DESCRIPTION' URL lacks package url (https://testpackage.r-lib.org).
+      ! In DESCRIPTION, URL is missing package url (https://testpackage.r-lib.org).
       i See details in `vignette(pkgdown::metadata)`.
 

--- a/tests/testthat/_snaps/config.md
+++ b/tests/testthat/_snaps/config.md
@@ -4,8 +4,7 @@
       config_pluck_character(pkg, "x")
     Condition
       Error:
-      ! x must be a character vector, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, x must be a character vector, not the number 1.
 
 # config_pluck_string generates informative error
 
@@ -13,8 +12,7 @@
       config_pluck_string(pkg, "x")
     Condition
       Error:
-      ! x must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, x must be a string, not the number 1.
 
 # config_check_list gives informative errors
 
@@ -22,13 +20,11 @@
       config_check_list_(1, has_names = "x")
     Condition
       Error in `config_check_list_()`:
-      ! path must be a list, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, path must be a list, not the number 1.
     Code
       config_check_list_(list(x = 1, y = 1), has_names = c("y", "z"))
     Condition
       Error in `config_check_list_()`:
-      ! path must have components "y" and "z".
+      ! In _pkgdown.yml, path must have components "y" and "z".
       1 missing component: "z".
-      i Edit _pkgdown.yml to fix the problem.
 

--- a/tests/testthat/_snaps/markdown.md
+++ b/tests/testthat/_snaps/markdown.md
@@ -4,8 +4,7 @@
       markdown_text_inline(pkg, "x\n\ny", error_path = "title")
     Condition
       Error:
-      ! title must be inline markdown.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, title must be inline markdown.
 
 # validates math yaml
 
@@ -13,12 +12,10 @@
       config_math_rendering_(`math-rendering` = 1)
     Condition
       Error in `config_math_rendering_()`:
-      ! template.math-rendering must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.math-rendering must be a string, not the number 1.
     Code
       config_math_rendering_(`math-rendering` = "math")
     Condition
       Error in `config_math_rendering_()`:
-      ! template.math-rendering must be one of mathml, mathjax, and katex, not math.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.math-rendering must be one of mathml, mathjax, and katex, not math.
 

--- a/tests/testthat/_snaps/navbar.md
+++ b/tests/testthat/_snaps/navbar.md
@@ -171,15 +171,13 @@
       data_navbar_(navbar = list(structure = list(left = 1)))
     Condition
       Error in `navbar_links()`:
-      ! navbar.structure.left must be a character vector, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, navbar.structure.left must be a character vector, not the number 1.
     Code
       data_navbar_(navbar = list(right = "github"))
     Condition
       Error in `data_template()`:
-      ! navbar is incorrectly specified.
+      ! In _pkgdown.yml, navbar is incorrectly specified.
       i See details in `vignette(pkgdown::customise)`.
-      i Edit _pkgdown.yml to fix the problem.
 
 # render_navbar_links BS3 & BS4 default
 

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -17,8 +17,7 @@
       check_bootstrap_version(1, pkg)
     Condition
       Error:
-      ! template.bootstrap must be 3 or 5, not 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.bootstrap must be 3 or 5, not 1.
 
 # read_meta() errors gracefully if _pkgdown.yml failed to parse
 

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -1,18 +1,3 @@
-# check_bslib_theme() works
-
-    Code
-      check_bslib_theme("paper", pkg, bs_version = 4)
-    Condition
-      Error:
-      x In _pkgdown.yml, Can't find Bootswatch/bslib theme preset "paper" (template.bootswatch).
-      i Using Bootstrap version 4 (template.bootstrap).
-    Code
-      check_bslib_theme("paper", pkg, bs_version = 4, field = c("template", "preset"))
-    Condition
-      Error:
-      x In _pkgdown.yml, Can't find Bootswatch/bslib theme preset "paper" (template and preset).
-      i Using Bootstrap version 4 (template.bootstrap).
-
 # capture data_template()
 
     package:
@@ -71,12 +56,12 @@
       data_open_graph_(list(foo = list()))
     Condition
       Warning in `data_open_graph_()`:
-      In _pkgdown.yml, Unsupported template.opengraph field: "foo".
+      In _pkgdown.yml, template.opengraph contains unsupported fields "foo".
     Code
       data_open_graph_(list(foo = list(), bar = list()))
     Condition
       Warning in `data_open_graph_()`:
-      In _pkgdown.yml, Unsupported template.opengraph fields: "foo" and "bar".
+      In _pkgdown.yml, template.opengraph contains unsupported fields "foo" and "bar".
     Code
       data_open_graph_(list(twitter = 1))
     Condition

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -4,16 +4,14 @@
       check_bslib_theme("paper", pkg, bs_version = 4)
     Condition
       Error:
-      x Can't find Bootswatch/bslib theme preset "paper" (template.bootswatch).
+      x In _pkgdown.yml, Can't find Bootswatch/bslib theme preset "paper" (template.bootswatch).
       i Using Bootstrap version 4 (template.bootstrap).
-      i Edit _pkgdown.yml to fix the problem.
     Code
       check_bslib_theme("paper", pkg, bs_version = 4, field = c("template", "preset"))
     Condition
       Error:
-      x Can't find Bootswatch/bslib theme preset "paper" (template and preset).
+      x In _pkgdown.yml, Can't find Bootswatch/bslib theme preset "paper" (template and preset).
       i Using Bootstrap version 4 (template.bootstrap).
-      i Edit _pkgdown.yml to fix the problem.
 
 # capture data_template()
 
@@ -70,32 +68,28 @@
 # check_opengraph validates inputs
 
     Code
-      check_open_graph_(list(foo = list()), )
+      data_open_graph_(list(foo = list()))
     Condition
-      Warning in `check_open_graph_()`:
-      '_pkgdown.yml': Unsupported template.opengraph field: "foo".
-    Output
-      named list()
+      Warning in `data_open_graph_()`:
+      In _pkgdown.yml, Unsupported template.opengraph field: "foo".
     Code
-      check_open_graph_(list(foo = list(), bar = list()))
+      data_open_graph_(list(foo = list(), bar = list()))
     Condition
-      Warning in `check_open_graph_()`:
-      '_pkgdown.yml': Unsupported template.opengraph fields: "foo" and "bar".
-    Output
-      named list()
+      Warning in `data_open_graph_()`:
+      In _pkgdown.yml, Unsupported template.opengraph fields: "foo" and "bar".
     Code
-      check_open_graph_(list(twitter = 1))
+      data_open_graph_(list(twitter = 1))
     Condition
-      Error in `check_open_graph_()`:
-      ! '_pkgdown.yml': template.opengraph.twitter must be a list, not the number 1.
+      Error in `data_open_graph_()`:
+      ! In _pkgdown.yml, template.opengraph.twitter must be a list, not the number 1.
     Code
-      check_open_graph_(list(twitter = list()))
+      data_open_graph_(list(twitter = list()))
     Condition
-      Error in `check_open_graph_()`:
-      ! '_pkgdown.yml': opengraph.twitter must include either creator or site.
+      Error in `data_open_graph_()`:
+      ! In _pkgdown.yml, opengraph.twitter must include either creator or site.
     Code
-      check_open_graph_(list(image = 1))
+      data_open_graph_(list(image = 1))
     Condition
-      Error in `check_open_graph_()`:
-      ! '_pkgdown.yml': template.opengraph.image must be a list, not the number 1.
+      Error in `data_open_graph_()`:
+      ! In _pkgdown.yml, template.opengraph.image must be a list, not the number 1.
 

--- a/tests/testthat/_snaps/templates.md
+++ b/tests/testthat/_snaps/templates.md
@@ -4,7 +4,7 @@
       local_pkgdown_site(meta = list(template = list(package = "templatepackage")))
     Condition
       Error in `as_pkgdown()`:
-      ! In _pkgdown.yml, Must set one only of template.bootstrap and template.bslib.version.
+      ! In _pkgdown.yml, must set only one of template.bootstrap and template.bslib.version.
       i Specified locally and in template package templatepackage.
 
 # Invalid bootstrap version spec in _pkgdown.yml
@@ -14,7 +14,7 @@
         version = 5))))
     Condition
       Error in `as_pkgdown()`:
-      ! In _pkgdown.yml, Must set one only of template.bootstrap and template.bslib.version.
+      ! In _pkgdown.yml, must set only one of template.bootstrap and template.bslib.version.
 
 # Warns when Bootstrap theme is specified in multiple locations
 

--- a/tests/testthat/_snaps/templates.md
+++ b/tests/testthat/_snaps/templates.md
@@ -4,9 +4,8 @@
       local_pkgdown_site(meta = list(template = list(package = "templatepackage")))
     Condition
       Error in `as_pkgdown()`:
-      ! Must set one only of template.bootstrap and template.bslib.version.
+      ! In _pkgdown.yml, Must set one only of template.bootstrap and template.bslib.version.
       i Specified locally and in template package templatepackage.
-      i Edit _pkgdown.yml to fix the problem.
 
 # Invalid bootstrap version spec in _pkgdown.yml
 
@@ -15,8 +14,7 @@
         version = 5))))
     Condition
       Error in `as_pkgdown()`:
-      ! Must set one only of template.bootstrap and template.bslib.version.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, Must set one only of template.bootstrap and template.bslib.version.
 
 # Warns when Bootstrap theme is specified in multiple locations
 

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -6,12 +6,6 @@
       Error:
       x In _pkgdown.yml, template.bootswatch contains unknown Bootswatch/bslib theme "paper".
       i Using Bootstrap version 4 (template.bootstrap).
-    Code
-      check_bslib_theme("paper", pkg, bs_version = 4, field = c("template", "preset"))
-    Condition
-      Error:
-      x In _pkgdown.yml, template and preset contains unknown Bootswatch/bslib theme "paper".
-      i Using Bootstrap version 4 (template.bootstrap).
 
 # validations yaml specification
 

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -1,3 +1,18 @@
+# check_bslib_theme() works
+
+    Code
+      check_bslib_theme("paper", pkg, bs_version = 4)
+    Condition
+      Error:
+      x In _pkgdown.yml, template.bootswatch contains unknown Bootswatch/bslib theme "paper".
+      i Using Bootstrap version 4 (template.bootstrap).
+    Code
+      check_bslib_theme("paper", pkg, bs_version = 4, field = c("template", "preset"))
+    Condition
+      Error:
+      x In _pkgdown.yml, template and preset contains unknown Bootswatch/bslib theme "paper".
+      i Using Bootstrap version 4 (template.bootstrap).
+
 # validations yaml specification
 
     Code

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -4,18 +4,15 @@
       build_bslib_(theme = 1)
     Condition
       Error in `bs_theme_rules()`:
-      ! template.theme must be a string, not the number 1.
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.theme must be a string, not the number 1.
     Code
       build_bslib_(theme = "fruit")
     Condition
       Error in `build_bslib_()`:
-      ! template.theme uses theme "fruit"
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.theme uses theme "fruit"
     Code
       build_bslib_(`theme-dark` = "fruit")
     Condition
       Error in `build_bslib_()`:
-      ! template.theme-dark uses theme "fruit"
-      i Edit _pkgdown.yml to fix the problem.
+      ! In _pkgdown.yml, template.theme-dark uses theme "fruit"
 

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -67,15 +67,17 @@ test_that("can include text in header, before body, and after body", {
 })
 
 test_that("check_opengraph validates inputs", {
-  check_open_graph_ <- function(...) {
-    check_open_graph(..., path = "_pkgdown.yml")
+  data_open_graph_ <- function(x) {
+    pkg <- local_pkgdown_site(meta = list(template = list(opengraph = x)))
+    data_open_graph(pkg)
+    invisible()
   }
 
   expect_snapshot(error = TRUE, {
-    check_open_graph_(list(foo = list()), )
-    check_open_graph_(list(foo = list(), bar = list()))
-    check_open_graph_(list(twitter = 1))
-    check_open_graph_(list(twitter = list()))
-    check_open_graph_(list(image = 1))
+    data_open_graph_(list(foo = list()))
+    data_open_graph_(list(foo = list(), bar = list()))
+    data_open_graph_(list(twitter = 1))
+    data_open_graph_(list(twitter = list()))
+    data_open_graph_(list(image = 1))
   })
 })

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,31 +1,3 @@
-test_that("check_bslib_theme() works", {
-  pkg <- as_pkgdown(test_path("assets/reference"))
-  expect_equal(check_bslib_theme("default", pkg, bs_version = 4), "default")
-  expect_equal(check_bslib_theme("lux", pkg, bs_version = 4), "lux")
-  expect_snapshot(error = TRUE, {
-    check_bslib_theme("paper", pkg, bs_version = 4)
-    check_bslib_theme("paper", pkg, bs_version = 4, field = c("template", "preset"))
-  })
-})
-
-test_that("get_bslib_theme() works with template.bslib.preset", {
-  pkg <- local_pkgdown_site(
-    meta = list(
-      template = list(bslib = list(preset = "shiny"), bootstrap = 5)
-    )
-  )
-  expect_equal(get_bslib_theme(pkg), "shiny")
-  expect_no_error(bs_theme(pkg))
-
-  pkg <- local_pkgdown_site(
-    meta = list(
-      template = list(bslib = list(preset = "lux"), bootstrap = 5)
-    )
-  )
-  expect_equal(get_bslib_theme(pkg), "lux")
-  expect_no_error(bs_theme(pkg))
-})
-
 test_that("capture data_template()", {
   pkg <- local_pkgdown_site()
   data <- data_template(pkg)

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -1,3 +1,30 @@
+test_that("check_bslib_theme() works", {
+  pkg <- as_pkgdown(test_path("assets/reference"))
+  expect_equal(check_bslib_theme("default", pkg, bs_version = 4), "default")
+  expect_equal(check_bslib_theme("lux", pkg, bs_version = 4), "lux")
+  expect_snapshot(error = TRUE, {
+    check_bslib_theme("paper", pkg, bs_version = 4)
+  })
+})
+
+test_that("get_bslib_theme() works with template.bslib.preset", {
+  pkg <- local_pkgdown_site(
+    meta = list(
+      template = list(bslib = list(preset = "shiny"), bootstrap = 5)
+    )
+  )
+  expect_equal(get_bslib_theme(pkg), "shiny")
+  expect_no_error(bs_theme(pkg))
+
+  pkg <- local_pkgdown_site(
+    meta = list(
+      template = list(bslib = list(preset = "lux"), bootstrap = 5)
+    )
+  )
+  expect_equal(get_bslib_theme(pkg), "lux")
+  expect_no_error(bs_theme(pkg))
+})
+
 test_that("validations yaml specification", {
   build_bslib_ <- function(...) {
     pkg <- local_pkgdown_site(


### PR DESCRIPTION
To always show path at the beginning

@jayhesselberth @maelle what do you think of this style? I like it because it allows us to reuse more code when producing errors for Rmd metadata. If you like the basic idea, I'll spend a bit more time polishing the code before merging the PR. It'll also make it easier to integrate #2549, so that whenever the error occurs in a GHA, you'll get an annotation on the file that caused the problem.