### PR TITLE
Improve `describe_contents()` parsing algorithm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* `build_reference()` does a better job of parsing `\value{}` blocks (#2371).
 * New `vignette("non-english")` that discusses non-English sites including how to submit new translations (#2605).
 * `build_reference()` now generates the usage that users actually type for infix and replacement methods (#2303).
 * @olivroy is now a pkgdown author in recognition of his contributions. 

--- a/tests/testthat/test-rd-data.R
+++ b/tests/testthat/test-rd-data.R
@@ -48,7 +48,6 @@ test_that("leading whitespace doesn't break items", {
     value2html("\n\\item{a}{b}\n\n\\item{c}{d}\n\n\\item{e}{f}"),
     c(
       "<dl>",
-        "",
         "<dt>a</dt>", "<dd><p>b</p></dd>", "", "",
         "<dt>c</dt>", "<dd><p>d</p></dd>", "", "",
         "<dt>e</dt>", "<dd><p>f</p></dd>",
@@ -57,14 +56,10 @@ test_that("leading whitespace doesn't break items", {
   )
 })
 
-test_that("whitespace between text is preserved", {
+test_that("whitespace between text is not preserved", {
   expect_equal(
     value2html("a\n\nb\n\nc"),
-    c(
-      "<p>a</p>", "", "",
-      "<p>b</p>", "", "",
-      "<p>c</p>"
-    )
+    c("<p>a</p>", "<p>b</p>", "<p>c</p>")
   )
 })
 
@@ -80,5 +75,14 @@ test_that("can have multiple interleaved blocks", {
       "<p>text2</p>",
       "<dl>", "<dt>e</dt>", "<dd><p>f</p></dd>", "</dl>"
     )
+  )
+})
+
+test_that("other tags don't affect breaking", {
+  expect_equal(
+    value2html("1\\code{xxx}\n2\n3"), value2html("1\\code{xxx}\n2\n3")
+  )
+  expect_equal(
+    value2html("1\\code{xxx}\n  2\n  3"), value2html("1\\code{xxx}\n2\n3")
   )
 })

--- a/tests/testthat/test-rd-data.R
+++ b/tests/testthat/test-rd-data.R
@@ -78,11 +78,14 @@ test_that("can have multiple interleaved blocks", {
   )
 })
 
-test_that("other tags don't affect breaking", {
+test_that("other tags don't affect breaking (#2371)", {
   expect_equal(
-    value2html("1\\code{xxx}\n2\n3"), value2html("1\\code{xxx}\n2\n3")
+    value2html("1\\code{xxx}\n2\n3"),
+    c("<p>1<code>xxx</code>", "2", "3</p>")
   )
+  # additionally teading whitespace
   expect_equal(
-    value2html("1\\code{xxx}\n  2\n  3"), value2html("1\\code{xxx}\n2\n3")
+    value2html("1\\code{xxx}\n  2\n  3"),
+    c("<p>1<code>xxx</code>", "2", "3</p>")
   )
 })


### PR DESCRIPTION
This is a good example of where _not_ to apply vectorised thinking because it's much clearer what's going on when we think about the current and previous item.

Fixes #2371