### PR TITLE
Only syntax highlight news once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # pkgdown (development version)
 
 * `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
+
+    ```R
+    1 + 1
+    ```
+
 * `build_reference()` no longer displays `\dontshow{}` or `\testonly{}` blocks in examples. It will run the code in `\dontshow{}`; it won't run the code in `\testonly{}`(#2188).
 * `build_article()` no long has a `data` argument. This is technically a breaking change, but I can't figure out why anyone would have ever used it.
 * `build_reference()` does a better job of parsing `\value{}` blocks (#2371).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
 * `build_reference()` no longer displays `\dontshow{}` or `\testonly{}` blocks in examples. It will run the code in `\dontshow{}`; it won't run the code in `\testonly{}`(#2188).
 * `build_article()` no long has a `data` argument. This is technically a breaking change, but I can't figure out why anyone would have ever used it.
 * `build_reference()` does a better job of parsing `\value{}` blocks (#2371).

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -148,7 +148,6 @@ build_news_multi <- function(pkg = ".") {
 data_news <- function(pkg, call = caller_env() ) {
   html <- markdown_body(pkg, path(pkg$src_path, "NEWS.md"))
   xml <- xml2::read_html(html)
-  downlit::downlit_html_node(xml)
 
   sections <- xml2::xml_find_all(xml, "./body/div")
   footnotes <- has_class(sections, "footnotes")

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -19,6 +19,19 @@ test_that("data_news works as expected for h1 & h2", {
   expect_snapshot_output(data_news(pkg)[c("version", "page", "anchor")])
 })
 
+test_that("news is syntax highlighted once", {
+  pkg <- local_pkgdown_site()
+  pkg <- pkg_add_file(pkg, "NEWS.md", c(
+    "# testpackage 1.0.0.9000",
+    "```r", 
+    "x <- 1", 
+    "```"
+  ))
+  suppressMessages(build_news(pkg, preview = FALSE))
+  html <- xml2::read_html(path(pkg$dst_path, "news", "index.html"))
+  expect_equal(xpath_text(html, "//code"), "x <- 1")
+})
+
 test_that("multi-page news are rendered", {
   skip_if_no_pandoc()
 


### PR DESCRIPTION
We don't need to do it in `data_news()` because `render_page()` will handle it.

Fixes #2630