### PR TITLE
Correctly expand paths on Windows, and nudge towards fs paths

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -19,10 +19,21 @@ as_pkgdown <- function(pkg = ".", override = list()) {
 
   check_string(pkg)
   if (!dir_exists(pkg)) {
+    if (dir.exists(pkg)) { #nolint
+      cli::cli_abort(
+      "pkgdown accepts {.href [fs paths](https://fs.r-lib.org/reference/path_expand.html#details)}."
+      )
+    }
     cli::cli_abort("{.file {pkg}} is not an existing directory")
   }
+
+  if (!dir.exists(pkg)) { #nolint
+    # Use complete path if fs path doesn't exist according to base R #2639
+    pkg <- path_expand(pkg)
+  }
+
   src_path <- pkg
-  
+
   desc <- read_desc(src_path)
   meta <- read_meta(src_path)
   meta <- modify_list(meta, override)


### PR DESCRIPTION
fix #2639 

This shouldn't happen a lot in the wild, but still a good quality of life improvement for Windows users. 

I spent quite a while trying to understand what was going on last year when I ran into this RStudio issue. https://github.com/rstudio/rstudio/issues/13134.