### PR TITLE
Remove `document`, and warn on `autolink_html()` usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # pkgdown (development version)
 
 * `document` in `build_site()` and `build_reference()` has been removed after being deprecated in pkgdown 1.4.0. `devel` should be used instead.
-* `autolink_html()` was deprecated in pkgdown 1.6 and now warns every time you use it. `downlit::downlit_html_path()` should be used instead.
+* `autolink_html()` was deprecated in pkgdown 1.6.0 and now warns every time you use it. `downlit::downlit_html_path()` should be used instead.
 * `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
 
     ```R

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pkgdown (development version)
 
-* `document` in `build_site()` and `build_reference()` has been removed after being deprecated in pkgdown 1.6.0. `devel` should be used instead.
+* `document` in `build_site()` and `build_reference()` has been removed after being deprecated in pkgdown 1.4.0. `devel` should be used instead.
 * `autolink_html()` was deprecated in pkgdown 1.6 and now warns every time you use it. `downlit::downlit_html_path()` should be used instead.
 * `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* `document` in `build_site()` and `build_reference()` is now defunct after being deprecated in pkgdown 1.6.0. `devel` should be used instead.
+
+* `autolink_html()` was deprecated in pkgdown 1.6 and now warns every time you use it. `downlit::downlit_html_path()` should be used instead.
+
 * `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
 
     ```R

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,7 @@
 # pkgdown (development version)
 
-* `document` in `build_site()` and `build_reference()` is now defunct after being deprecated in pkgdown 1.6.0. `devel` should be used instead.
-
+* `document` in `build_site()` and `build_reference()` has been removed after being deprecated in pkgdown 1.6.0. `devel` should be used instead.
 * `autolink_html()` was deprecated in pkgdown 1.6 and now warns every time you use it. `downlit::downlit_html_path()` should be used instead.
-
 * `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
 
     ```R

--- a/R/autolink_html.R
+++ b/R/autolink_html.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Please use [downlit::downlit_html_path] instead.
+#' Please use [downlit::downlit_html_path()] instead.
 #'
 #' @param input,output Input and output paths for HTML file
 #' @param local_packages A named character vector providing relative paths
@@ -21,6 +21,11 @@
 #' )
 #' }
 autolink_html <- function(input, output = input, local_packages = character()) {
+  lifecycle::deprecate_warn(
+    "1.6.0",
+    "autolink_html()",
+    "downlit::downlit_html_path()"
+  )
   withr::local_options(list(
     downlit.package = "",
     downlit.local_packages = local_packages

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -146,9 +146,9 @@
 #'   If `TRUE` (the default), assumes you are in a live development
 #'   environment, and loads source package with [pkgload::load_all()].
 #'   If `FALSE`, uses the installed version of the package.
-#' @param document **Deprecated** Use `devel` instead.
 #' @param topics Build only specified topics. If supplied, sets `lazy`
 #'   and `preview` to `FALSE`.
+#' @param document `r lifecycle::badge("defunct")` Use `devel` instead.
 #' @export
 build_reference <- function(pkg = ".",
                             lazy = TRUE,
@@ -158,8 +158,8 @@ build_reference <- function(pkg = ".",
                             override = list(),
                             preview = NA,
                             devel = TRUE,
-                            document = "DEPRECATED",
-                            topics = NULL) {
+                            topics = NULL,
+                            document = "DEPRECATED") {
   pkg <- section_init(pkg, depth = 1L, override = override)
   check_bool(lazy)
   check_bool(examples)
@@ -169,12 +169,11 @@ build_reference <- function(pkg = ".",
   check_character(topics, allow_null = TRUE)
 
   if (document != "DEPRECATED") {
-    lifecycle::deprecate_warn(
-      "1.4.0",
+    lifecycle::deprecate_stop(
+      "1.6.0",
       "build_site(document)",
-      details = "build_site(devel)"
+      "build_site(devel)"
     )
-    devel <- document
   }
 
   cli::cli_rule("Building function reference")

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -148,7 +148,6 @@
 #'   If `FALSE`, uses the installed version of the package.
 #' @param topics Build only specified topics. If supplied, sets `lazy`
 #'   and `preview` to `FALSE`.
-#' @param document `r lifecycle::badge("defunct")` Use `devel` instead.
 #' @export
 build_reference <- function(pkg = ".",
                             lazy = TRUE,
@@ -158,8 +157,7 @@ build_reference <- function(pkg = ".",
                             override = list(),
                             preview = NA,
                             devel = TRUE,
-                            topics = NULL,
-                            document = "DEPRECATED") {
+                            topics = NULL) {
   pkg <- section_init(pkg, depth = 1L, override = override)
   check_bool(lazy)
   check_bool(examples)
@@ -167,14 +165,6 @@ build_reference <- function(pkg = ".",
   check_number_whole(seed, allow_null = TRUE)
   check_bool(devel)
   check_character(topics, allow_null = TRUE)
-
-  if (document != "DEPRECATED") {
-    lifecycle::deprecate_stop(
-      "1.6.0",
-      "build_site(document)",
-      "build_site(devel)"
-    )
-  }
 
   cli::cli_rule("Building function reference")
   build_reference_index(pkg)

--- a/R/build.R
+++ b/R/build.R
@@ -326,20 +326,11 @@ build_site <- function(pkg = ".",
                        preview = NA,
                        devel = FALSE,
                        new_process = !devel,
-                       install = !devel,
-                       document = "DEPRECATED") {
+                       install = !devel) {
   pkg <- as_pkgdown(pkg, override = override)
   check_bool(devel)
   check_bool(new_process)
   check_bool(install)
-
-  if (document != "DEPRECATED") {
-    lifecycle::deprecate_stop(
-      "2.1.0",
-      "build_site(document)",
-      "build_site(devel)"
-    )
-  }
 
   if (install) {
     withr::local_temp_libpaths()

--- a/R/build.R
+++ b/R/build.R
@@ -334,12 +334,11 @@ build_site <- function(pkg = ".",
   check_bool(install)
 
   if (document != "DEPRECATED") {
-    lifecycle::deprecate_warn(
-      "1.4.0",
+    lifecycle::deprecate_stop(
+      "2.1.0",
       "build_site(document)",
-      details = "build_site(devel)"
+      "build_site(devel)"
     )
-    devel <- document
   }
 
   if (install) {

--- a/man/autolink_html.Rd
+++ b/man/autolink_html.Rd
@@ -16,7 +16,7 @@ from the target HTML document.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-Please use \link[downlit:downlit_html_path]{downlit::downlit_html_path} instead.
+Please use \code{\link[downlit:downlit_html_path]{downlit::downlit_html_path()}} instead.
 }
 \examples{
 \dontrun{

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -14,8 +14,7 @@ build_reference(
   override = list(),
   preview = NA,
   devel = TRUE,
-  topics = NULL,
-  document = "DEPRECATED"
+  topics = NULL
 )
 
 build_reference_index(pkg = ".")
@@ -47,8 +46,6 @@ If \code{FALSE}, uses the installed version of the package.}
 
 \item{topics}{Build only specified topics. If supplied, sets \code{lazy}
 and \code{preview} to \code{FALSE}.}
-
-\item{document}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}} Use \code{devel} instead.}
 }
 \description{
 By default, pkgdown will generate an index that lists all functions in

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -14,8 +14,8 @@ build_reference(
   override = list(),
   preview = NA,
   devel = TRUE,
-  document = "DEPRECATED",
-  topics = NULL
+  topics = NULL,
+  document = "DEPRECATED"
 )
 
 build_reference_index(pkg = ".")
@@ -45,10 +45,10 @@ If \code{TRUE} (the default), assumes you are in a live development
 environment, and loads source package with \code{\link[pkgload:load_all]{pkgload::load_all()}}.
 If \code{FALSE}, uses the installed version of the package.}
 
-\item{document}{\strong{Deprecated} Use \code{devel} instead.}
-
 \item{topics}{Build only specified topics. If supplied, sets \code{lazy}
 and \code{preview} to \code{FALSE}.}
+
+\item{document}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}} Use \code{devel} instead.}
 }
 \description{
 By default, pkgdown will generate an index that lists all functions in

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -58,7 +58,7 @@ in the current process affects the build process.}
 \item{install}{If \code{TRUE}, will install the package in a temporary library
 so it is available for vignettes.}
 
-\item{document}{\strong{Deprecated} Use \code{devel} instead.}
+\item{document}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}} Use \code{devel} instead.}
 }
 \description{
 \code{build_site()} is a convenient wrapper around six functions:

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -14,8 +14,7 @@ build_site(
   preview = NA,
   devel = FALSE,
   new_process = !devel,
-  install = !devel,
-  document = "DEPRECATED"
+  install = !devel
 )
 }
 \arguments{
@@ -57,8 +56,6 @@ in the current process affects the build process.}
 
 \item{install}{If \code{TRUE}, will install the package in a temporary library
 so it is available for vignettes.}
-
-\item{document}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}} Use \code{devel} instead.}
 }
 \description{
 \code{build_site()} is a convenient wrapper around six functions:


### PR DESCRIPTION
Remove `document` from `build_site()` and `build_reference()` + warn on `autolink_html()`