### PR TITLE
Add `override` to `init_site()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgdown (development version)
 
+* `init_site()` gains an `override` parameter fpr consistency with `build_site()` (#2644).
 * `build_news()` only syntax highlights the page once, not twice, which prevents every block of R code getting a blank line at the start (#2630).
 
     ```R

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -295,7 +295,7 @@ build_home <- function(pkg = ".",
   check_bool(quiet)
 
   cli::cli_rule("Building home")
-  create_subdir(pkg, "")
+  create_subdir(pkg, "", override = override)
 
   build_citation_authors(pkg)
 

--- a/R/build-news.R
+++ b/R/build-news.R
@@ -80,7 +80,7 @@ build_news <- function(pkg = ".",
     return(invisible())
 
   cli::cli_rule("Building news")
-  create_subdir(pkg, "news")
+  create_subdir(pkg, "news", override = override)
 
   one_page <- config_pluck_bool(pkg, "news.one_page", default = TRUE)
   if (one_page) {

--- a/R/build-tutorials.R
+++ b/R/build-tutorials.R
@@ -38,7 +38,7 @@ build_tutorials <- function(pkg = ".", override = list(), preview = NA) {
   }
 
   cli::cli_rule("Building tutorials")
-  create_subdir(pkg, "tutorials")
+  create_subdir(pkg, "tutorials", override = override)
 
   data <- purrr::transpose(tutorials)
 

--- a/R/build.R
+++ b/R/build.R
@@ -440,7 +440,7 @@ build_site_local <- function(pkg = ".",
 
   pkgdown_sitrep(pkg)
 
-  init_site(pkg)
+  init_site(pkg, override = override)
 
   build_home(pkg, override = override, preview = FALSE)
   build_reference(

--- a/R/init.R
+++ b/R/init.R
@@ -20,8 +20,8 @@
 #'
 #' @inheritParams build_articles
 #' @export
-init_site <- function(pkg = ".") {
-  pkg <- as_pkgdown(pkg)
+init_site <- function(pkg = ".", override = list()) {
+  pkg <- section_init(pkg, depth = 0, override = override)
 
   if (is_non_pkgdown_site(pkg$dst_path)) {
     cli::cli_abort(c(

--- a/R/utils-fs.R
+++ b/R/utils-fs.R
@@ -53,9 +53,9 @@ file_copy_to <- function(src_paths,
 }
 
 # Checks init_site() first.
-create_subdir <- function(pkg, subdir) {
+create_subdir <- function(pkg, subdir, override = list()) {
   if (!dir_exists(pkg$dst_path)) {
-    init_site(pkg)
+    init_site(pkg, override = override)
   }
   dir_create(path(pkg$dst_path, subdir))
 

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -4,10 +4,13 @@
 \alias{init_site}
 \title{Initialise site infrastructure}
 \usage{
-init_site(pkg = ".")
+init_site(pkg = ".", override = list())
 }
 \arguments{
 \item{pkg}{Path to package.}
+
+\item{override}{An optional named list used to temporarily override
+values in \verb{_pkgdown.yml}}
 }
 \description{
 \code{init_site()}:


### PR DESCRIPTION
Fix #2644

 also add `section_init()` as suggested in https://github.com/r-lib/pkgdown/pull/2642#discussion_r1630237712

Not sure of the implications to be honest, but tests pass!