### PR TITLE
Fix typo which prevents finding templates

### DIFF
--- a/R/templates.R
+++ b/R/templates.R
@@ -44,7 +44,7 @@ template_candidates <- function(type, name, ext = ".html", pkg = list()) {
 templates_dir <- function(pkg = list(), call = caller_env()) {
   config_pluck_list(pkg, "template")
   path <- config_pluck_string(pkg, "template.path")
-  package <- config_pluck_string(pkg, "templates.package")
+  package <- config_pluck_string(pkg, "template.package")
 
   if (!is.null(path)) {
     if (!dir_exists(path)) {


### PR DESCRIPTION
Follow up from https://github.com/r-lib/pkgdown/pull/2556.

This triggers an error in template packages that provide template elements which don't exist in pkgdown, such as the [`carpentries/varnish`](https://github.com/carpentries/varnish) package.

```
Error in `purrr::map_chr()`:
ℹ In index: 5.
Caused by error in `map_()`:
! Can't find template for "content-chapter".
---
Backtrace:
    ▆
 1. └─sandpaper::build_lesson()
 2.   └─sandpaper:::build_site(...)
 3.     └─sandpaper::build_episode_html(...)
 4.       └─sandpaper:::build_html(...)
 5.         └─pkgdown::render_page(...)
 6.           └─pkgdown:::render_page_html(pkg, name = name, data = data, depth = depth)
 7.             └─purrr::map_chr(pieces, find_template, name = name, pkg = pkg)
 8.               └─purrr:::map_("character", .x, .f, ..., .progress = .progress)
```

It solves the issue locally and seems correct based on the fact docs indeed say `template.package`. 

With h/t to @froggleston for pinpointing where the issue may come from.