### PR TITLE
Clarify that Quarto 1.5 is required.

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Major changes
 
 * Added @olivroy and @salim-b as pkgdown authors in recognition of their contributions.
-* `build_articles()` and `build_article()` now support articles/vignettes written with quarto. Combining the disparate quarto and pkgdown templating systems is a delicate art, so while I've done my best to make it work, there may be some rough edges. So please file an issue you encounter quarto features that don't work quite right. Learn more in `vignette("quarto")`(#2210).
+* `build_articles()` and `build_article()` now support articles/vignettes written with quarto (version 1.5 and above). Combining the disparate quarto and pkgdown templating systems is a delicate art, so while I've done my best to make it work, there may be some rough edges. So please file an issue you encounter quarto features that don't work quite right. Learn more in `vignette("quarto")`(#2210).
 * New light switch makes it easy for users to switch between light and dark themes for the website (based on work in bslib by @gadenbuie). For now this behaviour is opt-in with `template.light-switch: true` but in the future we may turn it on automatically. See the customization vignette for details (#1696).
 * New `vignette("translations")` that discusses non-English sites including how to submit new translations (#2605).
 * New `vignette("accessibility")` describes what manual tasks you need to perform to make your site as accessible as possible (#2344).

--- a/R/build-quarto-articles.R
+++ b/R/build-quarto-articles.R
@@ -1,5 +1,8 @@
 build_quarto_articles <- function(pkg = ".", article = NULL, quiet = TRUE) {
   check_required("quarto")
+  if (quarto::quarto_version() < "1.5") {
+    cli::cli_abort("Quarto articles require version 1.5 and above.", call = NULL)
+  }
   pkg <- as_pkgdown(pkg)
 
   qmds <- pkg$vignettes[pkg$vignettes$type == "qmd", ]

--- a/R/build-quarto-articles.R
+++ b/R/build-quarto-articles.R
@@ -1,8 +1,4 @@
 build_quarto_articles <- function(pkg = ".", article = NULL, quiet = TRUE) {
-  check_required("quarto")
-  if (quarto::quarto_version() < "1.5") {
-    cli::cli_abort("Quarto articles require version 1.5 and above.", call = NULL)
-  }
   pkg <- as_pkgdown(pkg)
 
   qmds <- pkg$vignettes[pkg$vignettes$type == "qmd", ]
@@ -12,7 +8,10 @@ build_quarto_articles <- function(pkg = ".", article = NULL, quiet = TRUE) {
   if (nrow(qmds) == 0) {
     return()
   }
-
+  check_installed("quarto")
+  if (quarto::quarto_version() < "1.5") {
+    cli::cli_abort("Quarto articles require version 1.5 and above.", call = NULL)
+  }
   # Let user know what's happening
   old_digest <- purrr::map_chr(path(pkg$dst_path, qmds$file_out), file_digest)
   for (file in qmds$file_in) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -4,6 +4,7 @@ skip_if_no_pandoc <- function(version = "1.12.3") {
 skip_if_no_quarto <- function() {
   skip_on_os("windows") # quarto set up currently broken?
   skip_if(is.null(quarto::quarto_path()), "quarto not available")
+  skip_if_not(quarto::quarto_version() >= "1.5", "quarto 1.5 not available")
 }
 
 # Simulate a package --------------------------------------------------------

--- a/tests/testthat/test-figure.R
+++ b/tests/testthat/test-figure.R
@@ -1,5 +1,6 @@
 test_that("can override defaults in _pkgdown.yml", {
   skip_if_no_pandoc()
+  skip_if_no_quarto()
   withr::local_temp_libpaths()
 
   pkg <- local_pkgdown_site(test_path("assets/figure"))


### PR DESCRIPTION
partially addresses #2675 

I am seeing a lot of test-failure locally, maybe related to my setup? (under a proxy or without the right  quarto). I didn't see this last time I opened a PR #2645).

![image](https://github.com/r-lib/pkgdown/assets/52606734/24cf7b01-6e84-4128-ba60-bde14fa10ba9)

Maybe I misunderstood something? the netlify workflow doesn't require 1.5