### PR TITLE
Quarto1.5 is released

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,6 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: pre-release
           tinytex: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,7 +26,6 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: pre-release
           tinytex: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,6 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: pre-release
           tinytex: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
No need to specify pre-release in GitHub actions. (sorry for comitting to main directly. I will be more careful.