### PR TITLE
Update customise.Rmd to advice for `search` on the right.

### DIFF
--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -333,7 +333,7 @@ For example, the following yaml adds a new "twitter" component that appears to t
 ``` yaml
 navbar:
   structure:
-    right: [search, twitter, github]
+    right: [search, twitter, github, lightswitch]
   components:
     twitter:
       icon: fa-twitter

--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -282,6 +282,8 @@ It makes use of the the following built-in components:
 -   `github`, a link to the source repository (with an icon), if it can be automatically determined from the `DESCRIPTION`.
 -   `lightswitch`, a ["light switch"](#light-switch) to select light mode, dark mode, or auto mode.
 
+Note that customising `navbar` like this comes with a downside. If pkgdown later changes the defaults, you'll have to update your _pkgdown.yml.
+
 [^dots]: Note that dots (`.`) in the package name need to be replaced by hyphens (`-`) in the vignette filename to be recognized as the intro. That means for a
     package `foo.bar` the intro needs to be named `foo-bar.Rmd`.
 

--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -282,7 +282,7 @@ It makes use of the the following built-in components:
 -   `github`, a link to the source repository (with an icon), if it can be automatically determined from the `DESCRIPTION`.
 -   `lightswitch`, a ["light switch"](#light-switch) to select light mode, dark mode, or auto mode.
 
-Note that customising `navbar` like this comes with a downside. If pkgdown later changes the defaults, you'll have to update your _pkgdown.yml.
+Note that customising `navbar` like this comes with a downside: if pkgdown later changes the defaults, you'll have to update your `_pkgdown.yml`.
 
 [^dots]: Note that dots (`.`) in the package name need to be replaced by hyphens (`-`) in the vignette filename to be recognized as the intro. That means for a
     package `foo.bar` the intro needs to be named `foo-bar.Rmd`.

--- a/vignettes/customise.Rmd
+++ b/vignettes/customise.Rmd
@@ -333,7 +333,7 @@ For example, the following yaml adds a new "twitter" component that appears to t
 ``` yaml
 navbar:
   structure:
-    right: [twitter, github]
+    right: [search, twitter, github]
   components:
     twitter:
       icon: fa-twitter


### PR DESCRIPTION
I noticed that users who specify `right` have lost their `search` as part of pkgdown 2.1.0. So, I thought it'd be good to update the suggestion for template