### PR TITLE
Address caching issues

### DIFF
--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -238,7 +238,9 @@ user_cache_dir <- function(package) {
 }
 
 req_pkgdown_cache <- function(req) {
-  cache_path <- dir_create(path(user_cache_dir("pkgdown"), "http"))
+  cache_path <- path(user_cache_dir("pkgdown"), "http")
+  dir_create(cache_path)
+
   httr2::req_cache(
     req,
     path = cache_path,

--- a/R/build-home-index.R
+++ b/R/build-home-index.R
@@ -218,8 +218,27 @@ cran_link <- function(pkg) {
   NULL
 }
 
+# modified from wch/r-source/src/library/tools/R/userdir.R
+user_cache_dir <- function(package) {
+  home <- path_home_r()
+
+  if (Sys.getenv("R_USER_CACHE_DIR") != "") {
+    cache_dir <- path(Sys.getenv("R_USER_CACHE_DIR"))
+  } else if(Sys.getenv("XDG_CACHE_HOME") != "") {
+    cache_dir <- path(Sys.getenv("XDG_CACHE_DIR"))
+  } else if(.Platform$OS.type == "windows") {
+    cache_dir <- path(Sys.getenv("LOCALAPPDATA"), "R", "cache")
+  } else if(Sys.info()["sysname"] == "Darwin") {
+    cache_dir <- path(home, "Library", "Caches", "org.R-project.R")
+  } else {
+    cache_dir <- path(home, ".cache")
+  }
+
+  path(cache_dir, "R", package, "cache")
+}
+
 req_pkgdown_cache <- function(req) {
-  cache_path <- dir_create(path(tools::R_user_dir("pkgdown", "cache"), "http"))
+  cache_path <- dir_create(path(user_cache_dir("pkgdown"), "http"))
   httr2::req_cache(
     req,
     path = cache_path,

--- a/R/clean.R
+++ b/R/clean.R
@@ -24,6 +24,17 @@ clean_site <- function(pkg = ".", quiet = FALSE) {
   dir_delete(top_level[is_dir])
   file_delete(top_level[!is_dir])
 
+  # delete cache
+  cache_dir <- path(user_cache_dir("pkgdown"))
+
+  if (dir_exists(cache_dir)) {
+    if (!quiet) {
+      cli::cli_inform("Cleaning {.pkg {pkg$package}} pkgdown cache from {.path {cache_dir}}")
+    }
+
+    dir_delete(cache_dir)
+  }
+
   invisible(TRUE)
 }
 

--- a/R/external-deps.R
+++ b/R/external-deps.R
@@ -91,7 +91,7 @@ math_dependency <- function(pkg, call = caller_env()) {
 }
 
 cached_dependency <- function(name, version, files) {
-  cache_dir <- path(tools::R_user_dir("pkgdown", "cache"), name, version)
+  cache_dir <- path(user_cache_dir("pkgdown"), name, version)
   dir_create(cache_dir)
 
   for (file in files) {

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -146,6 +146,12 @@ test_that("package repo verification", {
   )
 })
 
+test_that("cache path is valid", {
+  cache_dir <- user_cache_dir("notarealpkg")
+  dir_create(cache_dir)
+  expect_true(is_dir(cache_dir))
+  dir_delete(cache_dir)
+})
 
 test_that("cran_unquote works", {
   expect_equal(


### PR DESCRIPTION
- New `user_dir_cache()` to find cache directory on user machine, because `tools::R_user_dir()` is available in R > 4.0.0 and pkgdown depends on >3.6. Approach modified from wch/r-source/src/library/tools/R/userdir.R

- Added cache cleaning to `clean_site()`

- Fixes #2714 