### PR TITLE
Resolve https://github.com/r-lib/pkgdown/issues/2727

### DIFF
--- a/R/usage.R
+++ b/R/usage.R
@@ -19,7 +19,7 @@ as_data.tag_usage <- function(x, ...) {
   lines <- strsplit(text, "\n", fixed = TRUE)[[1]]
   parsed <- lapply(lines, function(x) tryCatch(parse(text = x)[[1]], error = function(e) NULL))
   needs_tweak <- function(x) {
-    is_call(x) && !is_call(x, "=") && !is_syntactic(x[[1]])
+    is_call(x) && !is_call(x, "=") && (is_symbol(x[[1]]) && !is_syntactic(x[[1]]))
   }
   to_tweak <- vapply(parsed, needs_tweak, logical(1))
   lines[to_tweak] <- vapply(parsed[to_tweak], deparse1, character(1))

--- a/tests/testthat/test-usage.R
+++ b/tests/testthat/test-usage.R
@@ -186,6 +186,10 @@ test_that("can parse dots", {
   expect_equal(usage$name, "f")
 })
 
+test_that("usage2text can parse symbols (#2727)", {
+	expect_no_error(usage2text("viridisLite::viridis(21)"))
+})
+
 # short_name --------------------------------------------------------------
 
 test_that("infix functions left as", {


### PR DESCRIPTION
This commit implements the change @hadley proposed at https://github.com/r-lib/pkgdown/issues/2727#issuecomment-2233517302 to the internal function `needs_tweak()`. This does resolve the small reproducible example I described, though I ignore if there are other situations where it wouldn't work for.