### PR TITLE
Fixes #2708 eliminated stringsAsFactors from pkgdown

### DIFF
--- a/R/build-news.R
+++ b/R/build-news.R
@@ -192,7 +192,7 @@ data_news <- function(pkg, call = caller_env() ) {
   } else {
     timeline <- NULL
   }
-  
+
   purrr::walk2(
     sections,
     versions,
@@ -284,7 +284,6 @@ pkg_timeline <- function(package) {
   data.frame(
     version = names(timeline),
     date = as.Date(timeline),
-    stringsAsFactors = FALSE,
     row.names = NULL
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -109,7 +109,6 @@ re_match <- function(text, pattern, perl = TRUE, ...) {
   matchstr[ start == -1 ] <- NA_character_
 
   res <- data.frame(
-    stringsAsFactors = FALSE,
     .text = text,
     .match = matchstr
   )
@@ -124,7 +123,7 @@ re_match <- function(text, pattern, perl = TRUE, ...) {
     groupstr[ gstart == -1 ] <- NA_character_
     dim(groupstr) <- dim(gstart)
 
-    res <- cbind(groupstr, res, stringsAsFactors = FALSE)
+    res <- cbind(groupstr, res)
   }
 
   names(res) <- c(attr(match, "capture.names"), ".text", ".match")

--- a/tests/testthat/test-build-news.R
+++ b/tests/testthat/test-build-news.R
@@ -23,8 +23,8 @@ test_that("news is syntax highlighted once", {
   pkg <- local_pkgdown_site()
   pkg <- pkg_add_file(pkg, "NEWS.md", c(
     "# testpackage 1.0.0.9000",
-    "```r", 
-    "x <- 1", 
+    "```r",
+    "x <- 1",
     "```"
   ))
   suppressMessages(build_news(pkg, preview = FALSE))
@@ -117,8 +117,7 @@ test_that("correct timeline for first ggplot2 releases", {
   timeline <- pkg_timeline("ggplot2")[1:3, ]
   expected <- data.frame(
     version = c("0.5", "0.5.1", "0.5.2"),
-    date = as.Date(c("2007-06-01", "2007-06-09", "2007-06-18")),
-    stringsAsFactors = FALSE
+    date = as.Date(c("2007-06-01", "2007-06-09", "2007-06-18"))
   )
 
   expect_equal(timeline, expected)


### PR DESCRIPTION
Fixes #2708 Eliminated stringsAsFactors from build-news, utils.r and testthat/build-news since it defaults R >= 4.0.0 