### PR TITLE
updated gha instructions/workflows for quarto

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,6 +45,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
+      
+      - uses: r-lib/actions/setup-tinytex@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,12 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          tinytex: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,11 +21,13 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
+      
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::lintr, local::.
           needs: lint
+          
+      - uses: r-lib/actions/setup-tinytex@v2
 
       - name: Lint
         run: lintr::lint_package()

--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -16,11 +16,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,6 +36,8 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
+      
+      - uses: r-lib/actions/setup-tinytex@v2
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,12 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          tinytex: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,12 +21,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          tinytex: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           extra-packages: any::covr, any::xml2
           needs: coverage
+      
+      - uses: r-lib/actions/setup-tinytex@v2
 
       - name: Test coverage
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgdown
 Title: Make Static HTML Documentation for a Package
-Version: 2.1.0.9001
+Version: 2.1.0.9000
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4757-117X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgdown
 Title: Make Static HTML Documentation for a Package
-Version: 2.1.0.9000
+Version: 2.1.0.9001
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4757-117X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * New `clean_cache()` function removes the contents of the cache directory (#2718).
 * pkgdown now depends on R >= 4.0.0 (#2714)
+* Updated GitHub Actions advice and workflows around Quarto install (#2743)
 
 # pkgdown 2.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * New `clean_cache()` function removes the contents of the cache directory (#2718).
 * pkgdown now depends on R >= 4.0.0 (#2714)
-* Updated GitHub Actions advice and workflows around Quarto install (#2743)
+* Updated GitHub Actions advice and workflows around Quarto install (@tanho63, #2743)
 
 # pkgdown 2.1.0
 

--- a/vignettes/quarto.qmd
+++ b/vignettes/quarto.qmd
@@ -24,14 +24,10 @@ project:
   render: ['*.qmd']
 ```
 
-### GitHub actions
+### GitHub Actions
 
-Currently, you'll need to manually install Quarto in your GitHub actions. ([Hopefully this will change in the future](https://github.com/r-lib/actions/issues/866)). Add the following lines to install quarto:
+The `setup-r-dependencies` action will [automatically](https://github.com/r-lib/actions/tree/v2-branch/setup-r-dependencies#usage) install Quarto in your GitHub Actions if a .qmd file is present in your repository (see the `install-quarto` parameter for more details). 
 
-```yaml
-     - name: Set up Quarto
-       uses: quarto-dev/quarto-actions/setup@v2
-```
 
 ## Limitations
 


### PR DESCRIPTION
Closes #2743 

Updates quarto vignette and gha workflow files now that `setup-r-dependencies` automatically installs quarto as required. 