### PR TITLE
Support ANSI sequences in `index.md`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,12 @@
 
 # pkgdown 2.1.1
 
-* Added keyboard shortcut, `/`, to focus search bar (#2423)
+* Added keyboard shortcut, `/`, to focus search bar (#2423).
 * The `BugReports` field can now be an email (@catalamarti, #2275).
 * New `clean_cache()` function removes the contents of the cache directory (#2718).
-* pkgdown now depends on R >= 4.0.0 (#2714)
-* Updated GitHub Actions advice and workflows around Quarto install (@tanho63, #2743)
+* pkgdown now depends on R >= 4.0.0 (#2714).
+* Updated GitHub Actions advice and workflows around Quarto install (@tanho63, #2743).
+* Support ANSI sequences in `index.md` (@krlmlr, #2787).
 
 # pkgdown 2.1.0
 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -62,7 +62,7 @@ markdown_body <- function(pkg, path, strip_header = FALSE) {
 markdown_path_html <- function(pkg, path, strip_header = FALSE) {
   html_path <- withr::local_tempfile()
   convert_markdown_to_html(pkg, path, html_path)
-  xml <- xml2::read_html(html_path, encoding = "UTF-8")
+  xml <- read_html_keep_ansi(html_path)
   if (!inherits(xml, "xml_node")) {
     return(NULL)
   }

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -8,7 +8,7 @@ markdown_text <- function(pkg, text, ...) {
   markdown_path_html(pkg, md_path, ...)
 }
 
-markdown_text_inline <- function(pkg, 
+markdown_text_inline <- function(pkg,
                                  text,
                                  error_path,
                                  error_call = caller_env()) {

--- a/R/render.R
+++ b/R/render.R
@@ -163,7 +163,7 @@ check_open_graph <- function(pkg, og, file_path = NULL, call = caller_env()) {
   if (is.null(og)) {
     return()
   }
-  
+
   is_yaml <- is.null(file_path)
   base_path <- if (is_yaml) "template.opengraph" else "opengraph"
 
@@ -220,7 +220,7 @@ check_open_graph_list <- function(pkg,
   }
   not <- obj_type_friendly(x)
   config_abort(
-    pkg, 
+    pkg,
     "{.field {error_path}} must be a list, not {not}.",
     path = file_path,
     call = error_call
@@ -259,7 +259,7 @@ same_contents <- function(path, contents) {
 
   cur_contents <- paste0(read_lines(path), collapse = "\n")
   cur_hash <- digest::digest(cur_contents, serialize = FALSE)
-  
+
   identical(new_hash, cur_hash)
 }
 

--- a/R/tweak-page.R
+++ b/R/tweak-page.R
@@ -96,14 +96,19 @@ tweak_useless_toc <- function(html) {
 
 # Update file on disk -----------------------------------------------------
 
-update_html <- function(path, tweak, ...) {
-
+read_html_keep_ansi <- function(path) {
   raw <- read_file(path)
   # Following the xml 1.0 spec, libxml2 drops low-bit ASCII characters
   # so we convert to \u2029, relying on downlit to convert back in
   # token_escape().
   raw <- gsub("\033", "\u2029", raw, fixed = TRUE)
-  html <- xml2::read_html(raw, encoding = "UTF-8")
+  # Use charToRaw() to always interpret as string,
+  # even for length 1 vectors
+  xml2::read_html(charToRaw(raw), encoding = "UTF-8")
+}
+
+update_html <- function(path, tweak, ...) {
+  html <- read_html_keep_ansi(path)
   tweak(html, ...)
 
   xml2::write_html(html, path, format = FALSE)

--- a/tests/testthat/_snaps/markdown.md
+++ b/tests/testthat/_snaps/markdown.md
@@ -19,3 +19,12 @@
       Error in `config_math_rendering_()`:
       ! In _pkgdown.yml, template.math-rendering must be one of mathml, mathjax, and katex, not math.
 
+# preserves ANSI characters
+
+    Code
+      markdown_text(pkg, sprintf("prefer %s", cli::col_blue("a")))
+    Output
+      {html_document}
+      <html>
+      [1] <body><p>prefer \u2029[34ma\u2029[39m</p></body>
+

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -165,7 +165,7 @@ test_that("ANSI are handled", {
   withr::local_options(cli.num_colors = 256)
   pkg <- local_pkgdown_site()
 
-  pkg <- pkg_add_file(pkg, "README.md", sprintf("prefer %s", cli::col_blue("a")))
+  pkg <- pkg_add_file(pkg, "index.md", sprintf("prefer %s", cli::col_blue("a")))
   suppressMessages(build_home_index(pkg))
 
   html <- xml2::read_html(path(pkg$dst_path, "index.html"))

--- a/tests/testthat/test-build-home-index.R
+++ b/tests/testthat/test-build-home-index.R
@@ -160,3 +160,15 @@ test_that("allow email in BugReports", {
   html <- xml2::read_html(data_home_sidebar(pkg))
   expect_snapshot(xpath_xml(html, ".//li/a"))
 })
+
+test_that("ANSI are handled", {
+  withr::local_options(cli.num_colors = 256)
+  pkg <- local_pkgdown_site()
+
+  pkg <- pkg_add_file(pkg, "README.md", sprintf("prefer %s", cli::col_blue("a")))
+  suppressMessages(build_home_index(pkg))
+
+  html <- xml2::read_html(path(pkg$dst_path, "index.html"))
+  readme_p <- xml2::xml_find_first(html, ".//main[@id='main']/p")
+  expect_equal(xml2::xml_text(readme_p), "prefer \u2029[34ma\u2029[39m")
+})

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -63,3 +63,11 @@ test_that("validates math yaml", {
     config_math_rendering_(`math-rendering` = "math")
   })
 })
+
+test_that("preserves ANSI characters", {
+    withr::local_options(cli.num_colors = 256)
+    pkg <- local_pkgdown_site()
+    expect_snapshot(
+      markdown_text(pkg, sprintf("prefer %s", cli::col_blue("a")))
+    )
+})


### PR DESCRIPTION
They are being stripped out immediately after converting Markdown to HTML. This works for me in duckplyr: https://github.com/tidyverse/duckplyr/actions/runs/11086444293/job/30803979684 is built using this branch, the result is in https://duckplyr.tidyverse.org/ .

Not sure how to add tests here.