### PR TITLE
Respect DESCRIPTION language.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* The language of the site is set from the first `Language:` in the `DESCRIPTION` if it is available and no other language is specified (@jonthegeek, #2808).
+
 # pkgdown 2.1.1
 
 * Added keyboard shortcut, `/`, to focus search bar (#2423)

--- a/R/package.R
+++ b/R/package.R
@@ -112,7 +112,10 @@ get_pkg_lang <- function(pkg) {
   }
 
   if (pkg$desc$has_fields("Language")) {
-    return(pkg$desc$get_field("Language"))
+    field <- pkg$desc$get_field("Language")
+    if (length(field) && nchar(field) > 0) {
+      return(regmatches(field, regexpr("[^,]+", field)))
+    }
   }
 
   return("en")

--- a/R/package.R
+++ b/R/package.R
@@ -75,7 +75,7 @@ as_pkgdown <- function(pkg = ".", override = list()) {
   if (!is.null(pkg$meta$url)) {
     pkg$meta$url <- sub("/$", "", pkg$meta$url)
   }
-  
+
   pkg$development <- meta_development(pkg)
   pkg$prefix <- pkg$development$prefix
 
@@ -85,7 +85,7 @@ as_pkgdown <- function(pkg = ".", override = list()) {
     pkg$dst_path <- path(pkg$dst_path, pkg$development$destination)
   }
 
-  pkg$lang <- pkg$meta$lang %||% "en"
+  pkg$lang <- get_pkg_lang(pkg)
   pkg$install_metadata <- config_pluck_bool(pkg, "deploy.install_metadata", FALSE)
   pkg$figures <- meta_figures(pkg)
   pkg$repo <- package_repo(pkg)
@@ -104,6 +104,18 @@ read_desc <- function(path = ".") {
     cli::cli_abort("Can't find {.file DESCRIPTION}", call = caller_env())
   }
   desc::description$new(path)
+}
+
+get_pkg_lang <- function(pkg) {
+  if (!is.null(pkg$meta$lang)) {
+    return(pkg$meta$lang)
+  }
+
+  if (pkg$desc$has_fields("Language")) {
+    return(pkg$desc$get_field("Language"))
+  }
+
+  return("en")
 }
 
 get_bootstrap_version <- function(pkg,
@@ -270,7 +282,7 @@ extract_lifecycle <- function(x) {
   fig <- extract_figure(desc)
 
   if (!is.null(fig) && length(fig) > 0 && length(fig[[1]]) > 0) {
-    path <- as.character(fig[[1]][[1]])  
+    path <- as.character(fig[[1]][[1]])
     if (grepl("lifecycle", path)) {
       name <- gsub("lifecycle-", "", path)
       name <- path_ext_remove(name)
@@ -351,12 +363,12 @@ article_metadata <- function(path) {
   if (path_ext(path) == "qmd") {
     inspect <- quarto::quarto_inspect(path)
     meta <- inspect$formats[[1]]$metadata
-  
+
     out <- list(
       title = meta$title %||% "UNKNOWN TITLE",
       desc = meta$description %||% NA_character_,
       ext = path_ext(inspect$formats[[1]]$pandoc$`output-file`) %||% "html"
-    )  
+    )
   } else {
     yaml <- rmarkdown::yaml_front_matter(path)
     out <- list(

--- a/tests/testthat/assets/reference-language/one/DESCRIPTION
+++ b/tests/testthat/assets/reference-language/one/DESCRIPTION
@@ -1,0 +1,7 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A test package
+Authors@R: person("Hadley Wickham")
+RoxygenNote: 7.3.1
+Language: fr

--- a/tests/testthat/assets/reference-language/two/DESCRIPTION
+++ b/tests/testthat/assets/reference-language/two/DESCRIPTION
@@ -1,0 +1,7 @@
+Package: testpackage
+Version: 1.0.0
+Title: A test package
+Description: A test package
+Authors@R: person("Hadley Wickham")
+RoxygenNote: 7.3.1
+Language: en-US, fr

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -118,3 +118,32 @@ test_that("malformed figures fail gracefully", {
   expect_null(rd_lifecycle("{\\figure{deprecated.svg}}"))
   expect_null(rd_lifecycle("{\\figure{}}"))
 })
+
+# language ---------------------------------------------------------------------
+
+test_that("as_pkgdown sets language", {
+  # Default
+  pkg <- as_pkgdown(test_path("assets/reference"))
+  expect_equal(
+    pkg$lang,
+    "en"
+  )
+  # Single language specified in DESCRIPTION
+  pkg <- as_pkgdown(test_path("assets/reference-language/one"))
+  expect_equal(
+    pkg$lang,
+    "fr"
+  )
+  # Two languages specified in DESCRIPTION
+  pkg <- as_pkgdown(test_path("assets/reference-language/two"))
+  expect_equal(
+    pkg$lang,
+    "en-US"
+  )
+  # Language specified in _pkgdown.yml or override.
+  pkg <- as_pkgdown(test_path("assets/reference-language/two"), override = list(lang = "en-GB"))
+  expect_equal(
+    pkg$lang,
+    "en-GB"
+  )
+})


### PR DESCRIPTION
If the package authors have specified a Language in DESCRIPTION, default to that, rather than "en".