### PR TITLE
Retain forward slashes in HTML img src paths

### DIFF
--- a/R/tweak-page.R
+++ b/R/tweak-page.R
@@ -51,7 +51,7 @@ tweak_rmarkdown_html <- function(html, input_path, pkg = list(bs_version = 3)) {
     img_src_real <- path_real(xml2::url_unescape(src[abs_src]))
     input_path_real <- path_real(xml2::url_unescape(input_path))
     img_rel_paths <- path_rel(path = img_src_real, start = input_path_real)
-    img_rel_paths <- xml2::url_escape(img_rel_paths)
+    img_rel_paths <- xml2::url_escape(img_rel_paths, reserved="/")
 
     purrr::walk2(
       .x = img_target_nodes,

--- a/tests/testthat/test-tweak-page.R
+++ b/tests/testthat/test-tweak-page.R
@@ -135,3 +135,30 @@ test_that("h1 section headings adjusted to h2 (and so on)", {
     c("page-header", "section level2", "section level3", "section level2")
   )
 })
+
+test_that("slashes not URL encoded during relative path conversion", {
+  # Create a site
+  pkg <- local_pkgdown_site()
+
+  # Add the referenced image in a subdirectory of vignettes.
+  pkg <- pkg_add_kitten(pkg, "vignettes/img/")
+
+  # Get the full path to the image.
+  sim_path <- path(pkg$src_path, "vignettes/img/kitten.jpg")
+
+  # Simulate an output HTML file referencing the absolute path.
+  html <- xml2::read_html(
+    sprintf('
+    <body>
+      <img src="%s" />
+    </body>
+    ', sim_path)
+  )
+
+  # Function should update the absolute path to a relative path.
+  tweak_rmarkdown_html(html, path(pkg$src_path, "vignettes"))
+
+  # Check that the relative path has a non-encoded slash.
+  expect_equal(xpath_attr(html, ".//img", "src"), "img/kitten.jpg")
+
+})

--- a/tests/testthat/test-tweak-page.R
+++ b/tests/testthat/test-tweak-page.R
@@ -144,7 +144,7 @@ test_that("slashes not URL encoded during relative path conversion", {
   pkg <- pkg_add_kitten(pkg, "vignettes/img/")
 
   # Get the full path to the image.
-  sim_path <- path(pkg$src_path, "vignettes/img/kitten.jpg")
+  sim_path <- path_real(path(pkg$src_path, "vignettes/img/kitten.jpg"))
 
   # Simulate an output HTML file referencing the absolute path.
   html <- xml2::read_html(

--- a/tests/testthat/test-tweak-page.R
+++ b/tests/testthat/test-tweak-page.R
@@ -137,6 +137,12 @@ test_that("h1 section headings adjusted to h2 (and so on)", {
 })
 
 test_that("slashes not URL encoded during relative path conversion", {
+
+  # Since the URL conversion process in tweak_markdown_html() makes calls to
+  # fs::path_real() (which requires paths to exist), we create a
+  # temporary pkgdown site directory and populate it with an image file, which
+  # we can then reference in our test HTML file.
+
   # Create a site
   pkg <- local_pkgdown_site()
 


### PR DESCRIPTION
Currently, there is an issue in `tweak_rmarkdown_html` which causes forward slash characters in generated `<img>` tags to be escaped during the conversion from absolute to relative paths, causing the images to not load correctly.

i.e.
 `<img src="mysubdir/myimg.png">` 
becomes
`<img src="mysubdir%2Fmyimg.png">`
after the call to `tweak_rmarkdown_html`.

The proposed change preserves what I think is the intention of the original call to `xml2::url_esacpe` (to properly encode space characters) but adds the forward slash character as a reserved character to prevent it from being encoded. 

After this change, all existing tests continue to pass.

I'm happy to try and write a test case for this issue as well if necessary.

Thanks,
Andrew