### PR TITLE
Fix Google Analytic typo

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -197,14 +197,15 @@
 #'       includes:
 #'         in_header: |
 #'            <!-- Global site tag (gtag.js) - Google Analytics -->
-#'            <script async src="https://www.googletagmanager.com/gtag/js?id={YOUR TRACKING ID}"#' ></script>
+#'            <script async src="https://www.googletagmanager.com/gtag/js?id={YOUR MEASUREMENT ID}" ></script>
 #'            <script>
 #'              window.dataLayer = window.dataLayer || [];
 #'              function gtag(){dataLayer.push(arguments);}
 #'              gtag('js', new Date());
 #'
-#'              gtag('config', '{YOUR TRACKING ID}');
+#'              gtag('config', '{YOUR MEASUREMENT ID}');
 #'            </script>
+#'            <!-- Google tag (gtag.js) -->
 #'     ```
 #' *   [GoatCounter](https://www.goatcounter.com):
 #'

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -246,14 +246,15 @@ recommend getting the HTML directly from the tool:
   includes:
     in_header: |
        <!-- Global site tag (gtag.js) - Google Analytics -->
-       <script async src="https://www.googletagmanager.com/gtag/js?id=\{YOUR TRACKING ID\}"#' ></script>
+       <script async src="https://www.googletagmanager.com/gtag/js?id=\{YOUR MEASUREMENT ID\}" ></script>
        <script>
          window.dataLayer = window.dataLayer || [];
          function gtag()\{dataLayer.push(arguments);\}
          gtag('js', new Date());
 
-         gtag('config', '\{YOUR TRACKING ID\}');
+         gtag('config', '\{YOUR MEASUREMENT ID\}');
        </script>
+       <!-- Google tag (gtag.js) -->
 }\if{html}{\out{</div>}}
 \item \href{https://www.goatcounter.com}{GoatCounter}:
 

--- a/man/deploy_site_github.Rd
+++ b/man/deploy_site_github.Rd
@@ -50,7 +50,7 @@ new keypair specifically for deploying the site. The easiest way is to use
 which we no longer recommend, so this function is deprecated. There are
 two replacements:
 \itemize{
-\item \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown_github_pages()}} will setup a GitHub action to
+\item \code{\link[usethis:use_pkgdown_github_pages]{usethis::use_pkgdown_github_pages()}} will setup a GitHub action to
 automatically build and deploy your package website to GitHub pages.
 \item \code{\link[=deploy_to_branch]{deploy_to_branch()}} can be called locally to build and deploy your
 website to any desired branch.

--- a/man/deploy_to_branch.Rd
+++ b/man/deploy_to_branch.Rd
@@ -40,6 +40,6 @@ package documentation in the \verb{v.1.2.3/} directory of your site.}
 }
 \description{
 Assumes that you're in a git clone of the project, and the package is
-already installed. Use \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown_github_pages()}} to automate
+already installed. Use \code{\link[usethis:use_pkgdown_github_pages]{usethis::use_pkgdown_github_pages()}} to automate
 this process using GitHub actions.
 }

--- a/man/init_site.Rd
+++ b/man/init_site.Rd
@@ -35,7 +35,7 @@ See \code{vignette("customise")} for the various ways you can customise the
 display of your site.
 }
 \section{Build-ignored files}{
-We recommend using \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown_github_pages()}} to build-ignore \verb{docs/} and
+We recommend using \code{\link[usethis:use_pkgdown_github_pages]{usethis::use_pkgdown_github_pages()}} to build-ignore \verb{docs/} and
 \verb{_pkgdown.yml}. If use another directory, or create the site manually,
 you'll need to add them to \code{.Rbuildignore} yourself. A \code{NOTE} about
 an unexpected file during \verb{R CMD CHECK} is an indication you have not


### PR DESCRIPTION
- [x] Remove the extra `#'`
- [x] Add closing tag `<!-- Google tag (gtag.js) -->`
- [x] `TRACKING ID` -> `MEASUREMENT ID` to align name convension (e.g. https://support.google.com/analytics/answer/12270356?hl=en)