### PR TITLE
Test colors

### DIFF
--- a/vignettes/test/rendering.Rmd
+++ b/vignettes/test/rendering.Rmd
@@ -129,6 +129,20 @@ Some text
 stop(cli::style_italic("This is italic"))
 ```
 
+```{r}
+#| error: TRUE
+f <- function() {
+  cli::cli_abort(c(
+    "i" = "A bullet with color",
+    "v" = "A bullet with color",
+    "x" = "A bullet with color",
+    "!" =  "A bullet with color"
+  ))
+}
+f()
+```
+
+
 Some more text
 
 ## Quoted text


### PR DESCRIPTION
With rlang 1.1.5, it seems to have lost its color

https://rlang.r-lib.org/reference/topic-error-call.html

![image](https://github.com/user-attachments/assets/3f7cdd67-3dff-423d-b2ed-a03e93a2c5fd)

Just wanted to see if the recent updates to evaluate and rlang may have caused this.

Preview at https://678fa1d22912fe857e486c59--pkgdown-dev.netlify.app/dev/articles/test/rendering#crayon