### PR TITLE
test: fix `pandoc --fail-if-warnings` test

### DIFF
--- a/tests/testthat/_snaps/build-article.md
+++ b/tests/testthat/_snaps/build-article.md
@@ -27,22 +27,6 @@
 
     <span class="co">## <span style="color: #BB0000;">X</span></span>
 
-# build_article yields useful error if pandoc fails
-
-    Code
-      build_article("test", pkg, pandoc_args = "--fail-if-warnings")
-    Message
-      Reading vignettes/test.Rmd
-    Condition
-      Error in `build_article()`:
-      ! Failed to render 'vignettes/test.Rmd'.
-      x [WARNING] This document format requires a nonempty <title> element.
-      x  Defaulting to 'test.knit' as the title.
-      x  To specify a title, use 'title' in metadata or --metadata title="...".
-      x Failing because there were warnings.
-      Caused by error:
-      ! pandoc document conversion failed with error 3
-
 # build_article yields useful error if R fails
 
     Code

--- a/tests/testthat/test-build-article.R
+++ b/tests/testthat/test-build-article.R
@@ -176,11 +176,16 @@ test_that("build_article yields useful error if pandoc fails", {
   skip_if_no_pandoc("2.18")
 
   pkg <- local_pkgdown_site()
-  pkg <- pkg_add_file(pkg, "vignettes/test.Rmd", "Hi")
+  pkg <- pkg_add_file(pkg, "vignettes/test.Rmd", c(
+    "Some text.",
+    "",
+    "[^1]: Unreferenced footnote.",
+    ""
+  ))
 
-  expect_snapshot(
+  expect_error(
     build_article("test", pkg, pandoc_args = "--fail-if-warnings"),
-    error = TRUE
+    "Note with key .+ defined at .+ but not used"
   )
 })
 


### PR DESCRIPTION
for recent versions of Pandoc (which don't emit the `This document format requires a nonempty <title> element` warning for HTML output anymore).