### PR TITLE
fix: generate correct GitLab `/issues` URL

### DIFF
--- a/R/repo.R
+++ b/R/repo.R
@@ -73,7 +73,7 @@ package_repo <- function(pkg) {
 
   # Otherwise try and guess from `BugReports` (1st priority) and `URL`s (2nd priority)
   urls <- c(
-    sub("/issues/?", "/", pkg$desc$get_field("BugReports", default = character())),
+    sub("(/-)?/issues/?", "/", pkg$desc$get_field("BugReports", default = character())),
     pkg$desc$get_urls()
   )
 
@@ -101,11 +101,12 @@ repo_meta_gh_like <- function(link, branch = NULL) {
   gh <- parse_github_like_url(link)
   branch <- branch %||% gha_current_branch()
   blob <- if (grepl("^https?://codeberg\\.", link)) "/src/branch/" else "/blob/"
+  issues <- if (grepl("^https?://gitlab\\.", link)) "/-/issues/" else "/issues/"
 
   repo_meta(
     paste0(gh$host, "/", gh$owner, "/", gh$repo, "/"),
     paste0(gh$host, "/", gh$owner, "/", gh$repo, blob, branch, "/"),
-    paste0(gh$host, "/", gh$owner, "/", gh$repo, "/issues/"),
+    paste0(gh$host, "/", gh$owner, "/", gh$repo, issues),
     paste0(gh$host, "/")
   )
 }

--- a/R/repo.R
+++ b/R/repo.R
@@ -65,7 +65,7 @@ package_repo <- function(pkg) {
   # Use metadata if available
   repo <- config_pluck_list(pkg, "repo")
   url <- config_pluck_list(pkg, "repo.url")
-  
+
 
   if (!is.null(url)) {
     return(repo)
@@ -117,13 +117,13 @@ gha_current_branch <- function() {
   if (ref != "") {
     return(ref)
   }
-  
+
   # Set everywhere but might not be a branch
   ref <- Sys.getenv("GITHUB_REF_NAME")
   if (ref != "") {
     return(ref)
   }
-  
+
   "HEAD"
 }
 

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -140,12 +140,14 @@ test_that("GitLab subgroups are properly parsed", {
   }
 
   base <- "https://gitlab.com/salim_b/r/pkgs/pal"
-  expected <- paste0(base, "/issues/")
-  
-  expect_equal(issue_url(URL = base), expected)
-  expect_equal(issue_url(URL = paste0(base, "/")), expected)
-  expect_equal(issue_url(BugReports = paste0(base, "/issues")), expected)
-  expect_equal(issue_url(BugReports = paste0(base, "/issues/")), expected)
+  expected <- paste0(base, "/-/issues/")
+
+  expect_identical(issue_url(URL = base), expected)
+  expect_identical(issue_url(URL = paste0(base, "/")), expected)
+  expect_identical(issue_url(BugReports = paste0(base, "/issues")), expected)
+  expect_identical(issue_url(BugReports = paste0(base, "/issues/")), expected)
+  expect_identical(issue_url(BugReports = paste0(base, "/-/issues")), expected)
+  expect_identical(issue_url(BugReports = paste0(base, "/-/issues/")), expected)
 })
 
 test_that("can find github enterprise url", {


### PR DESCRIPTION
GitLab returns HTTP status code [301 Moved Permanently](https://developer.mozilla.org/docs/Web/HTTP/Status/301) for issue tracker URLs like `https://gitlab.com/rpkg.dev/pal/issues` with new `location` header set to `https://gitlab.com/rpkg.dev/pal/-/issues`. Hence a missing `/-/` in the URL  triggers a `NOTE` about a possibly invalid URL during `devtools::check(remote = TRUE)`.

This PR adapts pkgdown to always generate `/-/issues/` URLs for GitLab.