### PR TITLE
fix: better handle long inst/AUTHORS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     gt,
     htmltools,
     htmlwidgets,
-    knitr,
+    knitr (>= 1.50.3),
     lifecycle,
     magick,
     methods,
@@ -75,3 +75,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2.9000
 SystemRequirements: pandoc
+Remotes: yihui/knitr

--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -36,7 +36,7 @@ data_authors <- function(
 
   inst_path <- path(pkg$src_path, "inst", "AUTHORS")
   if (file_exists(inst_path)) {
-    inst <- read_lines(inst_path)
+    inst <- paste(read_lines(inst_path), collapse = "\n")
   } else {
     inst <- NULL
   }

--- a/tests/testthat/_snaps/build-article.md
+++ b/tests/testthat/_snaps/build-article.md
@@ -30,19 +30,6 @@
 # build_article yields useful error if R fails
 
     Code
-      build_article("test", pkg)
-    Message
-      Reading vignettes/test.Rmd
-    Condition
-      Error in `build_article()`:
-      ! Failed to render 'vignettes/test.Rmd'.
-      x Quitting from test.Rmd:4-9 [unnamed-chunk-1]
-      Caused by error:
-      ! Error!
-
----
-
-    Code
       summary(expect_error(build_article("test", pkg)))
     Message
       Reading vignettes/test.Rmd
@@ -50,7 +37,18 @@
       <error/rlang_error>
       Error in `build_article()`:
       ! Failed to render 'vignettes/test.Rmd'.
-      x Quitting from test.Rmd:4-9 [unnamed-chunk-1]
+      x Quitting from test.Rmd:4-10 [unnamed-chunk-1]
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      x <error/rlang_error>
+      x Error in `h()`:
+      x ! Error!
+      x ---
+      x Backtrace:
+      x  ▆
+      x  1. └─global f()
+      x  2.  └─global g()
+      x  3.  └─global h()
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       Caused by error:
       ! Error!
       ---

--- a/tests/testthat/_snaps/not-in-rcmcheck/build-article.md
+++ b/tests/testthat/_snaps/not-in-rcmcheck/build-article.md
@@ -1,0 +1,13 @@
+# build_article yields useful error if R fails
+
+    Code
+      build_article("test", pkg)
+    Message
+      Reading vignettes/test.Rmd
+    Condition
+      Error in `build_article()`:
+      ! Failed to render 'vignettes/test.Rmd'.
+      x Quitting from test.Rmd:4-9 [unnamed-chunk-1]
+      Caused by error:
+      ! Error!
+

--- a/tests/testthat/_snaps/rcmdcheck/build-article.md
+++ b/tests/testthat/_snaps/rcmdcheck/build-article.md
@@ -1,0 +1,24 @@
+# build_article yields useful error if R fails
+
+    Code
+      build_article("test", pkg)
+    Message
+      Reading vignettes/test.Rmd
+    Condition
+      Error in `build_article()`:
+      ! Failed to render 'vignettes/test.Rmd'.
+      x Quitting from test.Rmd:4-10 [unnamed-chunk-1]
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      x <error/rlang_error>
+      x Error in `h()`:
+      x ! Error!
+      x ---
+      x Backtrace:
+      x  ▆
+      x  1. └─global f()
+      x  2.  └─global g()
+      x  3.  └─global h()
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Caused by error:
+      ! Error!
+

--- a/tests/testthat/test-build-article.R
+++ b/tests/testthat/test-build-article.R
@@ -244,6 +244,7 @@ test_that("build_article yields useful error if R fails", {
       "title: title",
       "---",
       "```{r}",
+      "options(cli.num_colors = 1L)",
       "f <- function() g()",
       "g <- function() h()",
       "h <- function() rlang::abort('Error!')",
@@ -252,8 +253,12 @@ test_that("build_article yields useful error if R fails", {
     )
   )
 
-  # check that error looks good
-  expect_snapshot(build_article("test", pkg), error = TRUE)
+  # check that error looks good (opt out color)
+  expect_snapshot(
+    build_article("test", pkg),
+    error = TRUE,
+    variant = if (is_checking()) "rcmdcheck" else "not-in-rcmcheck"
+  )
   # check that traceback looks good - need extra work because rlang
   # avoids tracebacks in snapshots
   expect_snapshot(summary(expect_error(build_article("test", pkg))))

--- a/tests/testthat/test-build-home-authors.R
+++ b/tests/testthat/test-build-home-authors.R
@@ -7,6 +7,16 @@ test_that("authors page includes inst/AUTHORS", {
   expect_match(lines, "<pre>Hello</pre>", all = FALSE)
 })
 
+test_that("authors page includes multiline inst/AUTHORS", {
+  pkg <- local_pkgdown_site()
+  pkg <- pkg_add_file(pkg, "inst/AUTHORS", c("Hello", "------", "bla bla"))
+  suppressMessages(build_citation_authors(pkg))
+
+  lines <- read_lines(path(pkg$dst_path, "authors.html"))
+  content <- paste(lines, collapse = " ")
+  expect_match(content, "<pre>Hello ------ bla bla</pre>")
+})
+
 test_that("data_authors validates yaml inputs", {
   data_authors_ <- function(...) {
     pkg <- local_pkgdown_site(meta = list(...))


### PR DESCRIPTION
Follow up on #2506

@szhorvat noticed that [igraph's author page](https://r.igraph.org/authors.html) looked weird:

![image](https://github.com/user-attachments/assets/1fb648e7-0984-4322-8029-537331b4616d)

It's also the case for the pkgdown website of the package given as example by @eitsupi in #2332 https://prql.github.io/prqlc-r/authors.html

This PR simply collapses the content of `inst/AUTHORS` before passing it to the template.