### PR TITLE
fix issue with article error snapshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     gt,
     htmltools,
     htmlwidgets,
-    knitr,
+    knitr (>= 1.50.3),
     lifecycle,
     magick,
     methods,
@@ -75,3 +75,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2.9000
 SystemRequirements: pandoc
+Remotes: yihui/knitr

--- a/tests/testthat/_snaps/build-article.md
+++ b/tests/testthat/_snaps/build-article.md
@@ -30,19 +30,6 @@
 # build_article yields useful error if R fails
 
     Code
-      build_article("test", pkg)
-    Message
-      Reading vignettes/test.Rmd
-    Condition
-      Error in `build_article()`:
-      ! Failed to render 'vignettes/test.Rmd'.
-      x Quitting from test.Rmd:4-9 [unnamed-chunk-1]
-      Caused by error:
-      ! Error!
-
----
-
-    Code
       summary(expect_error(build_article("test", pkg)))
     Message
       Reading vignettes/test.Rmd
@@ -50,7 +37,18 @@
       <error/rlang_error>
       Error in `build_article()`:
       ! Failed to render 'vignettes/test.Rmd'.
-      x Quitting from test.Rmd:4-9 [unnamed-chunk-1]
+      x Quitting from test.Rmd:4-10 [unnamed-chunk-1]
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      x <error/rlang_error>
+      x Error in `h()`:
+      x ! Error!
+      x ---
+      x Backtrace:
+      x  ▆
+      x  1. └─global f()
+      x  2.  └─global g()
+      x  3.  └─global h()
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       Caused by error:
       ! Error!
       ---

--- a/tests/testthat/_snaps/not-in-rcmcheck/build-article.md
+++ b/tests/testthat/_snaps/not-in-rcmcheck/build-article.md
@@ -1,0 +1,13 @@
+# build_article yields useful error if R fails
+
+    Code
+      build_article("test", pkg)
+    Message
+      Reading vignettes/test.Rmd
+    Condition
+      Error in `build_article()`:
+      ! Failed to render 'vignettes/test.Rmd'.
+      x Quitting from test.Rmd:4-9 [unnamed-chunk-1]
+      Caused by error:
+      ! Error!
+

--- a/tests/testthat/_snaps/rcmdcheck/build-article.md
+++ b/tests/testthat/_snaps/rcmdcheck/build-article.md
@@ -1,0 +1,24 @@
+# build_article yields useful error if R fails
+
+    Code
+      build_article("test", pkg)
+    Message
+      Reading vignettes/test.Rmd
+    Condition
+      Error in `build_article()`:
+      ! Failed to render 'vignettes/test.Rmd'.
+      x Quitting from test.Rmd:4-10 [unnamed-chunk-1]
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      x <error/rlang_error>
+      x Error in `h()`:
+      x ! Error!
+      x ---
+      x Backtrace:
+      x  ▆
+      x  1. └─global f()
+      x  2.  └─global g()
+      x  3.  └─global h()
+      x ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Caused by error:
+      ! Error!
+

--- a/tests/testthat/test-build-article.R
+++ b/tests/testthat/test-build-article.R
@@ -244,6 +244,7 @@ test_that("build_article yields useful error if R fails", {
       "title: title",
       "---",
       "```{r}",
+      "options(cli.num_colors = 1L)",
       "f <- function() g()",
       "g <- function() h()",
       "h <- function() rlang::abort('Error!')",
@@ -252,8 +253,12 @@ test_that("build_article yields useful error if R fails", {
     )
   )
 
-  # check that error looks good
-  expect_snapshot(build_article("test", pkg), error = TRUE)
+  # check that error looks good (opt out color)
+  expect_snapshot(
+    build_article("test", pkg),
+    error = TRUE,
+    variant = if (is_checking()) "rcmdcheck" else "not-in-rcmcheck"
+  )
   # check that traceback looks good - need extra work because rlang
   # avoids tracebacks in snapshots
   expect_snapshot(summary(expect_error(build_article("test", pkg))))


### PR DESCRIPTION
This closes #2875

Basically, new CRAN knitr introduced error reporting with backtrace when inside R CMD check and R CMD build. This lead to new snapshot for this package. 
However, the CRAN release had a bug where `NULL` was output. Dev version of knitr has a fix following https://github.com/yihui/knitr/pull/2388

So this PR use  dev knitr to prevent NULL in output.  

However, this created some other changes in the snapshot because **rlang** errors are now printed in the error message. However, they were output with ANSI coloring. 

It took me some time to understand why, and how to opt-out. The coloring were showing because **pkgdown** is asking for it in `build_rmarkdown_article`
https://github.com/r-lib/pkgdown/blob/a9296fb261089ada7d76d7309b66d89e2048ab85/R/build-article.R#L99

`R_CLI_NUM_COLORS` is one of the first value checked in `cli::num_ansi_colors`, and it is set as part of `build_article()` process. So doing `with::local_envvar(list(R_CLI_NUM_COLORS = 1L))` in the test is not useful as it gets override. So I ended up setting `options(cli.num_colors = 1L)` in the Rmd to opt out coloring. 

This could be changed maybe if looking at a possibly set env var already 
````diff
diff --git a/R/build-article.R b/R/build-article.R
index 6780e43e..35fa9187 100644
--- a/R/build-article.R
+++ b/R/build-article.R
@@ -96,7 +96,7 @@ build_rmarkdown_article <- function(
 
   local_envvar_pkgdown(pkg)
   local_texi2dvi_envvars(input_path)
-  withr::local_envvar(R_CLI_NUM_COLORS = 256)
+  withr::local_envvar(R_CLI_NUM_COLORS = Sys.getenv("R_CLI_NUM_COLORS", 256))
 
   args <- list(
     input = input_path,
````

this way doing `with::local_envvar(list(R_CLI_NUM_COLORS = 1L))` would work I think. 

Anyhow, all impacted snapshot are updated. 

There is also introduction of variant in snapshot because 
- The error message with traceback is only shown when R CMD check or R CMD build. So it will be the case when test are ran as part of `rcmdcheck::rcmdcheck` on CI. 
- When using `devtools::test()` locally, the check or build context is not there, so the snapshot output will be different. 

This means that in the future to update the snapshot: 

- Either download from CI artifacts
- Either run `devtools::test()` locally, AND `devtools::check(check_dir = "check_dir")`, to get the updated snapshot inside `check_dir` output. 

Hope this helps.