### PR TITLE
Workaround for unreleased knitr version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,4 +75,3 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2.9000
 SystemRequirements: pandoc
-Remotes: yihui/knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     gt,
     htmltools,
     htmlwidgets,
-    knitr (>= 1.50.3),
+    knitr (>= 1.50),
     lifecycle,
     magick,
     methods,

--- a/tests/testthat/test-build-article.R
+++ b/tests/testthat/test-build-article.R
@@ -241,6 +241,10 @@ test_that("build_article yields useful error if R fails", {
     "R on Windows before 4.2 does not have UTF-8 support."
   )
 
+  # workaround an as-yet unreleassed knitr version
+  # https://github.com/yihui/knitr/issues/2399#issuecomment-2803554647
+  skip_if(packageVersion('knitr') < '1.50.3')
+
   pkg <- local_pkgdown_site()
   pkg <- pkg_add_file(
     pkg,


### PR DESCRIPTION
The next version of knitr will be a few months away, so this is a workaround for a patch pkgdown release that skips a snapshot test that depends on unreleased knitr.

https://github.com/yihui/knitr/issues/2399