### PR TITLE
fix: `create_absolute_links()` ignores `<a>` tags without `href` attribute

### DIFF
--- a/R/build-llm.R
+++ b/R/build-llm.R
@@ -181,7 +181,9 @@ create_absolute_links <- function(main_html, url = NULL) {
   xml2::xml_attr(a, "class") <- NULL
 
   href <- xml2::xml_attr(a, "href")
-  is_internal <- !startsWith(href, "https") & !startsWith(href, "#")
+  is_internal <- !is.na(href) &
+    !startsWith(href, "https") &
+    !startsWith(href, "#")
   if (!is.null(url)) {
     href[is_internal] <- xml2::url_absolute(href[is_internal], url)
   }


### PR DESCRIPTION
Since the introduction of `build_llm_docs()`, builds for the dm package fail: https://github.com/cynkra/dm/actions/runs/18861352196/job/53820159378#step:18:431 . I have tracked this down to one of the documents containing a tag of the form `<a xlink:title="Data Model">` . This PR ignores such tags where it matters.

Run using this package: https://github.com/cynkra/dm/actions/runs/18882666120