### PR TITLE
Add `.pkgdownignore` support (#2959)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdown (development version)
 
+* `build_home()` now supports a `.pkgdownignore` file to exclude markdown files
+  from being rendered to HTML. The file can be placed in the package root,
+  `pkgdown/`, or `_pkgdown/` directories (@kyleGrealis, #2959).
+
 # pkgdown 2.2.1
 
 * Test fix for `R CMD check`.

--- a/tests/testthat/test-pkgdownignore.R
+++ b/tests/testthat/test-pkgdownignore.R
@@ -1,0 +1,159 @@
+test_that("read_pkgdownignore returns empty when no file exists", {
+  pkg <- local_pkgdown_site()
+  expect_equal(read_pkgdownignore(pkg$src_path), character())
+})
+
+test_that("read_pkgdownignore reads from package root", {
+  pkg <- local_pkgdown_site()
+  writeLines(c("CLAUDE.md", "AGENTS.md"), path(pkg$src_path, ".pkgdownignore"))
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_equal(result, c("CLAUDE.md", "AGENTS.md"))
+})
+
+test_that("read_pkgdownignore reads from pkgdown/ directory", {
+  pkg <- local_pkgdown_site()
+  dir_create(path(pkg$src_path, "pkgdown"))
+  writeLines("INTERNAL.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_equal(result, "INTERNAL.md")
+})
+
+test_that("read_pkgdownignore reads from _pkgdown/ directory", {
+  pkg <- local_pkgdown_site()
+  dir_create(path(pkg$src_path, "_pkgdown"))
+  writeLines("NOTES.md", path(pkg$src_path, "_pkgdown", ".pkgdownignore"))
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_equal(result, "NOTES.md")
+})
+
+test_that("read_pkgdownignore combines files from multiple locations", {
+  pkg <- local_pkgdown_site()
+
+  # Root
+
+  writeLines("CLAUDE.md", path(pkg$src_path, ".pkgdownignore"))
+
+  # pkgdown/
+  dir_create(path(pkg$src_path, "pkgdown"))
+  writeLines("AGENTS.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_setequal(result, c("CLAUDE.md", "AGENTS.md"))
+})
+
+test_that("read_pkgdownignore ignores comments and empty lines", {
+  pkg <- local_pkgdown_site()
+  writeLines(
+    c(
+      "# This is a comment",
+      "CLAUDE.md",
+      "",
+      "  # Indented comment",
+      "AGENTS.md",
+      "   ",
+      "INTERNAL.md"
+    ),
+    path(pkg$src_path, ".pkgdownignore")
+  )
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_equal(result, c("CLAUDE.md", "AGENTS.md", "INTERNAL.md"))
+})
+
+test_that("read_pkgdownignore trims whitespace", {
+  pkg <- local_pkgdown_site()
+  writeLines(
+    c("  CLAUDE.md  ", "\tAGENTS.md\t"),
+    path(pkg$src_path, ".pkgdownignore")
+  )
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_equal(result, c("CLAUDE.md", "AGENTS.md"))
+})
+
+test_that("read_pkgdownignore deduplicates entries", {
+  pkg <- local_pkgdown_site()
+
+  # Same file in root and pkgdown/
+
+  writeLines("CLAUDE.md", path(pkg$src_path, ".pkgdownignore"))
+  dir_create(path(pkg$src_path, "pkgdown"))
+  writeLines("CLAUDE.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
+
+  result <- read_pkgdownignore(pkg$src_path)
+  expect_equal(result, "CLAUDE.md")
+})
+
+test_that("package_mds excludes files listed in .pkgdownignore", {
+  pkg <- local_pkgdown_site()
+
+  # Create test markdown files
+  writeLines("# CLAUDE", path(pkg$src_path, "CLAUDE.md"))
+  writeLines("# AGENTS", path(pkg$src_path, "AGENTS.md"))
+  writeLines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
+
+  # Create .pkgdownignore
+
+  writeLines(c("CLAUDE.md", "AGENTS.md"), path(pkg$src_path, ".pkgdownignore"))
+
+  result <- package_mds(pkg$src_path)
+  result_files <- path_file(result)
+
+  expect_false("CLAUDE.md" %in% result_files)
+  expect_false("AGENTS.md" %in% result_files)
+  expect_true("ROADMAP.md" %in% result_files)
+})
+
+test_that("package_mds excludes .github files listed in .pkgdownignore", {
+  pkg <- local_pkgdown_site()
+
+  # Create .github directory with markdown files
+  dir_create(path(pkg$src_path, ".github"))
+  writeLines("# Internal", path(pkg$src_path, ".github", "INTERNAL.md"))
+  writeLines("# Contributing", path(pkg$src_path, ".github", "CONTRIBUTING.md"))
+
+  # Ignore the internal one
+  writeLines("INTERNAL.md", path(pkg$src_path, ".pkgdownignore"))
+
+  result <- package_mds(pkg$src_path)
+  result_files <- path_file(result)
+
+  expect_false("INTERNAL.md" %in% result_files)
+  expect_true("CONTRIBUTING.md" %in% result_files)
+})
+
+test_that("package_mds works when .pkgdownignore is empty", {
+  pkg <- local_pkgdown_site()
+
+  # Create test file
+  writeLines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
+
+  # Empty ignore file
+  file_create(path(pkg$src_path, ".pkgdownignore"))
+
+  result <- package_mds(pkg$src_path)
+  result_files <- path_file(result)
+
+  expect_true("ROADMAP.md" %in% result_files)
+})
+
+test_that("package_mds works when .pkgdownignore has only comments", {
+  pkg <- local_pkgdown_site()
+
+  # Create test file
+  writeLines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
+
+  # Ignore file with only comments
+  writeLines(
+    c("# comment 1", "# comment 2"),
+    path(pkg$src_path, ".pkgdownignore")
+  )
+
+  result <- package_mds(pkg$src_path)
+  result_files <- path_file(result)
+
+  expect_true("ROADMAP.md" %in% result_files)
+})

--- a/tests/testthat/test-pkgdownignore.R
+++ b/tests/testthat/test-pkgdownignore.R
@@ -5,7 +5,7 @@ test_that("read_pkgdownignore returns empty when no file exists", {
 
 test_that("read_pkgdownignore reads from package root", {
   pkg <- local_pkgdown_site()
-  writeLines(c("CLAUDE.md", "AGENTS.md"), path(pkg$src_path, ".pkgdownignore"))
+  write_lines(c("CLAUDE.md", "AGENTS.md"), path(pkg$src_path, ".pkgdownignore"))
 
   result <- read_pkgdownignore(pkg$src_path)
   expect_equal(result, c("CLAUDE.md", "AGENTS.md"))
@@ -14,7 +14,7 @@ test_that("read_pkgdownignore reads from package root", {
 test_that("read_pkgdownignore reads from pkgdown/ directory", {
   pkg <- local_pkgdown_site()
   dir_create(path(pkg$src_path, "pkgdown"))
-  writeLines("INTERNAL.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
+  write_lines("INTERNAL.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
 
   result <- read_pkgdownignore(pkg$src_path)
   expect_equal(result, "INTERNAL.md")
@@ -23,7 +23,7 @@ test_that("read_pkgdownignore reads from pkgdown/ directory", {
 test_that("read_pkgdownignore reads from _pkgdown/ directory", {
   pkg <- local_pkgdown_site()
   dir_create(path(pkg$src_path, "_pkgdown"))
-  writeLines("NOTES.md", path(pkg$src_path, "_pkgdown", ".pkgdownignore"))
+  write_lines("NOTES.md", path(pkg$src_path, "_pkgdown", ".pkgdownignore"))
 
   result <- read_pkgdownignore(pkg$src_path)
   expect_equal(result, "NOTES.md")
@@ -34,11 +34,11 @@ test_that("read_pkgdownignore combines files from multiple locations", {
 
   # Root
 
-  writeLines("CLAUDE.md", path(pkg$src_path, ".pkgdownignore"))
+  write_lines("CLAUDE.md", path(pkg$src_path, ".pkgdownignore"))
 
   # pkgdown/
   dir_create(path(pkg$src_path, "pkgdown"))
-  writeLines("AGENTS.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
+  write_lines("AGENTS.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
 
   result <- read_pkgdownignore(pkg$src_path)
   expect_setequal(result, c("CLAUDE.md", "AGENTS.md"))
@@ -46,7 +46,7 @@ test_that("read_pkgdownignore combines files from multiple locations", {
 
 test_that("read_pkgdownignore ignores comments and empty lines", {
   pkg <- local_pkgdown_site()
-  writeLines(
+  write_lines(
     c(
       "# This is a comment",
       "CLAUDE.md",
@@ -65,7 +65,7 @@ test_that("read_pkgdownignore ignores comments and empty lines", {
 
 test_that("read_pkgdownignore trims whitespace", {
   pkg <- local_pkgdown_site()
-  writeLines(
+  write_lines(
     c("  CLAUDE.md  ", "\tAGENTS.md\t"),
     path(pkg$src_path, ".pkgdownignore")
   )
@@ -79,9 +79,9 @@ test_that("read_pkgdownignore deduplicates entries", {
 
   # Same file in root and pkgdown/
 
-  writeLines("CLAUDE.md", path(pkg$src_path, ".pkgdownignore"))
+  write_lines("CLAUDE.md", path(pkg$src_path, ".pkgdownignore"))
   dir_create(path(pkg$src_path, "pkgdown"))
-  writeLines("CLAUDE.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
+  write_lines("CLAUDE.md", path(pkg$src_path, "pkgdown", ".pkgdownignore"))
 
   result <- read_pkgdownignore(pkg$src_path)
   expect_equal(result, "CLAUDE.md")
@@ -91,13 +91,13 @@ test_that("package_mds excludes files listed in .pkgdownignore", {
   pkg <- local_pkgdown_site()
 
   # Create test markdown files
-  writeLines("# CLAUDE", path(pkg$src_path, "CLAUDE.md"))
-  writeLines("# AGENTS", path(pkg$src_path, "AGENTS.md"))
-  writeLines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
+  write_lines("# CLAUDE", path(pkg$src_path, "CLAUDE.md"))
+  write_lines("# AGENTS", path(pkg$src_path, "AGENTS.md"))
+  write_lines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
 
   # Create .pkgdownignore
 
-  writeLines(c("CLAUDE.md", "AGENTS.md"), path(pkg$src_path, ".pkgdownignore"))
+  write_lines(c("CLAUDE.md", "AGENTS.md"), path(pkg$src_path, ".pkgdownignore"))
 
   result <- package_mds(pkg$src_path)
   result_files <- path_file(result)
@@ -112,11 +112,11 @@ test_that("package_mds excludes .github files listed in .pkgdownignore", {
 
   # Create .github directory with markdown files
   dir_create(path(pkg$src_path, ".github"))
-  writeLines("# Internal", path(pkg$src_path, ".github", "INTERNAL.md"))
-  writeLines("# Contributing", path(pkg$src_path, ".github", "CONTRIBUTING.md"))
+  write_lines("# Internal", path(pkg$src_path, ".github", "INTERNAL.md"))
+  write_lines("# Contributing", path(pkg$src_path, ".github", "CONTRIBUTING.md"))
 
   # Ignore the internal one
-  writeLines("INTERNAL.md", path(pkg$src_path, ".pkgdownignore"))
+  write_lines("INTERNAL.md", path(pkg$src_path, ".pkgdownignore"))
 
   result <- package_mds(pkg$src_path)
   result_files <- path_file(result)
@@ -129,7 +129,7 @@ test_that("package_mds works when .pkgdownignore is empty", {
   pkg <- local_pkgdown_site()
 
   # Create test file
-  writeLines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
+  write_lines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
 
   # Empty ignore file
   file_create(path(pkg$src_path, ".pkgdownignore"))
@@ -144,10 +144,10 @@ test_that("package_mds works when .pkgdownignore has only comments", {
   pkg <- local_pkgdown_site()
 
   # Create test file
-  writeLines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
+  write_lines("# ROADMAP", path(pkg$src_path, "ROADMAP.md"))
 
   # Ignore file with only comments
-  writeLines(
+  write_lines(
     c("# comment 1", "# comment 2"),
     path(pkg$src_path, ".pkgdownignore")
   )


### PR DESCRIPTION
## Summary
This PR adds support for a `.pkgdownignore` file that allows users to exclude specific markdown files from being rendered to HTML during `build_home()`.

Fixes #2959


## Motivation
With the rise of AI coding assistants, developers are increasingly adding files like `CLAUDE.md`, `AGENTS.md`, and `COPILOT.md` to their package roots. These files are developer-facing and shouldn't appear in user documentation or site search results.
Currently, there's no way to exclude arbitrary markdown files from pkgdown builds. The only options are:
- Move files elsewhere (breaks tool conventions)
- Delete before CI builds (fragile)
- Prefix with _ (only works for vignettes)

## Solution
A simple `.pkgdownignore` file that lists filenames to exclude:
```
# AI assistant configuration
CLAUDE.md
AGENTS.md

# Internal docs
INTERNAL.md
Features
```

- Supports comments (#) and blank lines
- Can be placed in package root, pkgdown/, or _pkgdown/
- Files from all locations are combined and deduplicated
- Matches by basename (works for both root and .github/ files)
- Displays ignored files during build: Ignoring: CLAUDE.md and AGENTS.md

## Changes

+ `R/build-home-md.R`: Added read_pkgdownignore() helper and integrated into package_mds()
+ `tests/testthat/test-pkgdownignore.R`: 15 tests covering all functionality
+ `NEWS.md`: Added bullet for this feature

Example
```
# .pkgdownignore
CLAUDE.md
AGENTS.md
```

In the build output:
```
── Building home ───────────────────────────────────────────────────────
Ignoring: CLAUDE.md and AGENTS.md
Reading .github/CODE_OF_CONDUCT.md
Reading .github/CONTRIBUTING.md
```
