### PR TITLE
fix: do not autolink code that is in a link

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* do not autolink code that is in a link (href) in Rd files (#2972)
+
 # pkgdown 2.2.0
 
 * Make `build_llm_docs()` more robust to the use of old Pandoc (@nanxstats, @galachad, #2952, #2954)

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -160,7 +160,8 @@ as_html.tag_url <- function(x, ...) {
 }
 #' @export
 as_html.tag_href <- function(x, ...) {
-  a(flatten_text(x[[2]]), href = flatten_text(x[[1]]))
+  # don't link since we are in a link
+  a(flatten_text(x[[2]], auto_link = FALSE), href = flatten_text(x[[1]]))
 }
 #' @export
 as_html.tag_email <- function(x, ...) {

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -319,6 +319,13 @@ test_that("bad specs throw errors", {
   })
 })
 
+test_that("no autolink in href", {
+  expect_equal(
+    rd2html("\\href{https://example.com}{\\code{download.file()}}"),
+    "<a href='https://example.com'><code>download.file()</code></a>"
+  )
+})
+
 # Paragraphs --------------------------------------------------------------
 
 test_that("empty input gives empty output", {


### PR DESCRIPTION
Currently, pkgdown autolink the text of href tags.

Example:
https://github.com/maelle/mcpackageface 
- has `hello()` and `goodbye()` functions.
- the Rd page for `goodbye()` has `\href{https://github.com}{\code{hello()}}`
- in the pkgdown reference page this becomes `<a href="https://github.com" class="external-link"><code><a href="hello.html">hello()</a></code></a>`.

This PR fixes this.