### PR TITLE
Strip inline data URI images from LLM markdown output

### DIFF
--- a/R/build-llm.R
+++ b/R/build-llm.R
@@ -70,6 +70,7 @@ convert_md <- function(src_path, dst_path, url = NULL) {
   simplify_popovers_to_footnotes(main_html)
   simplify_lifecycle_badges(main_html)
   simplify_dls(main_html)
+  simplify_inline_images(main_html)
   create_absolute_links(main_html, url)
 
   path <- file_temp()
@@ -178,6 +179,22 @@ simplify_lifecycle_badges <- function(html) {
   )
   imgs <- xml2::xml_find_first(badges, ".//img")
   xml2::xml_replace(badges, "strong", tolower(xml2::xml_attr(imgs, "alt")))
+
+  invisible()
+}
+
+simplify_inline_images <- function(html) {
+  img_nodes <- xml2::xml_find_all(html, ".//img[contains(@src, 'data:')]")
+
+  purrr::walk(img_nodes, function(img) {
+    alt_text <- xml2::xml_attr(img, "alt")
+    replacement <- if (!is.na(alt_text) && nzchar(alt_text)) {
+      sprintf("[Image: %s]", alt_text)
+    } else {
+      "[Image]"
+    }
+    xml2::xml_replace(img, "span", replacement)
+  })
 
   invisible()
 }

--- a/tests/testthat/test-build-llm.R
+++ b/tests/testthat/test-build-llm.R
@@ -31,6 +31,22 @@ test_that("replaces lifecycle badges with strong text", {
   )
 })
 
+test_that("replaces inline data URI images with text placeholders", {
+  html <- xml2::read_html(
+    '<img src="data:image/png;base64,abc123" alt="A plot">'
+  )
+  simplify_inline_images(html)
+  expect_equal(xpath_text(html, ".//span"), "[Image: A plot]")
+})
+
+test_that("replaces inline data URI images without alt text", {
+  html <- xml2::read_html(
+    '<img src="data:image/png;base64,abc123">'
+  )
+  simplify_inline_images(html)
+  expect_equal(xpath_text(html, ".//span"), "[Image]")
+})
+
 test_that("converts internal urls to absolute with .md ending", {
   html <- xml2::read_html(
     r"(


### PR DESCRIPTION
Fixes #2973

Adds `simplify_inline_images()` to the HTML-to-markdown conversion pipeline in `convert_md()`. This replaces `<img>` tags with `data:` URI sources (including base64-encoded images) with text placeholders before pandoc conversion, preventing large encoded strings from polluting the `.md` output consumed by LLMs.

- Images with alt text become `[Image: <alt>]`
- Images without alt text become `[Image]`