### PR TITLE
report missing alt text in vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * When previewing a site, it is now served via a local http server. This enables dynamic features such as search to work correctly (@shikokuchuo, #2975).
 
+* `build_site()` now checks vignettes for missing images and alt-text, and also flags empty `alt=""` as missing (#2985).
+
 * do not autolink code that is in a link (href) in Rd files (#2972)
 
 # pkgdown 2.2.0

--- a/R/check-built.R
+++ b/R/check-built.R
@@ -6,11 +6,23 @@ check_built_site <- function(pkg = ".") {
   if (!is.null(index_path)) {
     check_missing_images(pkg, index_path, "index.html")
   }
+
+  if (NROW(pkg$vignettes) > 0) {
+    for (i in seq_len(nrow(pkg$vignettes))) {
+      vig <- pkg$vignettes[i, ]
+      check_missing_images(pkg, vig$file_in, vig$file_out)
+    }
+  }
 }
 
 check_missing_images <- function(pkg, src_path, dst_path) {
   html <- xml2::read_html(path(pkg$dst_path, dst_path), encoding = "UTF-8")
   img <- xml2::xml_find_all(html, ".//img")
+
+  # Exclude hex logo (class="logo"), which intentionally has no alt-text
+  is_hex_logo <- grepl("\\blogo\\b", xml2::xml_attr(img, "class"), perl = TRUE)
+  img <- img[!is_hex_logo]
+
   src <- xml2::xml_attr(img, "src")
 
   rel_src <- xml2::url_unescape(src[xml2::url_parse(src)$scheme == ""])
@@ -26,8 +38,9 @@ check_missing_images <- function(pkg, src_path, dst_path) {
   }
 
   alt <- xml2::xml_attr(img, "alt")
-  if (anyNA(alt)) {
-    problems <- src[is.na(alt)]
+  missing_alt <- is.na(alt) | alt == ""
+  if (any(missing_alt)) {
+    problems <- src[missing_alt]
     problems[grepl("^data:image", problems)] <- "<base64 encoded image>"
     cli::cli_inform(c(
       x = "Missing alt-text in {.file {path_rel(src_path, pkg$src_path)}}",


### PR DESCRIPTION
Issue #2357 asked for pkgdown to warn when images in vignettes lack alt text. The issue was closed as fixed, but the implementation only checks the home page (`index.html`), not articles or vignettes.

This PR does 2 things:
- have `check_missing_images()` loop over all the vignettes
- exclude `.logo` classes which typically would catch the hex logo