### PR TITLE
Fix spurious whitespace after inline \Sexpr[results=rd] (e.g. \doi{})

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* Inline `\Sexpr[results=rd]{}` (such as the `\doi{}` macro) no longer inserts spurious whitespace before following punctuation (#2809).
+
 * When previewing a site, it is now served via a local http server. This enables dynamic features such as search to work correctly (@shikokuchuo, #2975).
 
 * do not autolink code that is in a link (href) in Rd files (#2972)

--- a/R/rd-html.R
+++ b/R/rd-html.R
@@ -242,7 +242,10 @@ as_html.tag_Sexpr <- function(x, ...) {
     switch(
       results,
       text = as.character(res),
-      rd = flatten_text(rd_text(as.character(res))),
+      # tools::parse_Rd() appends a trailing newline TEXT node to fragments,
+      # which would introduce spurious whitespace after an inline \Sexpr
+      # (e.g. the \doi{} macro followed by punctuation), so strip it. #2809
+      rd = sub("\n$", "", flatten_text(rd_text(as.character(res)))),
       hide = "",
       cli::cli_abort(
         "unknown \\Sexpr option: results={results}",

--- a/tests/testthat/test-rd-html.R
+++ b/tests/testthat/test-rd-html.R
@@ -198,6 +198,20 @@ test_that("can control \\Sexpr output", {
   )
 })
 
+test_that("inline \\Sexpr[results=rd] doesn't add trailing whitespace (#2809)", {
+  local_context_eval()
+  # parse_Rd() appends a trailing newline to the re-parsed fragment, which used
+  # to surface as a space between the rendered macro and following punctuation.
+  expect_equal(
+    rd2html("\\Sexpr[results=rd]{\"\\\\\\emph{x}\"}."),
+    "<em>x</em>."
+  )
+  expect_equal(
+    rd2html("\\doi{10.2307/2413326}."),
+    "<a href='https://doi.org/10.2307/2413326'>doi:10.2307/2413326</a>."
+  )
+})
+
 test_that("Sexpr can contain multiple expressions", {
   local_context_eval()
   expect_equal(rd2html("\\Sexpr{a <- 1; a}"), "1")
@@ -210,7 +224,9 @@ test_that("Sexprs with multiple args are parsed", {
 
 test_that("Sexprs in file share environment", {
   local_context_eval()
-  expect_equal(rd2html("\\Sexpr{x <- 1}\\Sexpr{x}"), c("1", "1"))
+  # Adjacent inline \Sexpr render flush ("11"); the second reading x proves
+  # the evaluation environment is shared.
+  expect_equal(rd2html("\\Sexpr{x <- 1}\\Sexpr{x}"), "11")
 
   local_context_eval()
   expect_snapshot(rd2html("\\Sexpr{x}"), error = TRUE)


### PR DESCRIPTION
Fixes #2809.

`\doi{10.2307/2413326}.` renders as `doi:10.2307/2413326 .`, with a space between the link and the trailing full stop.

This PR was constructed with AI assistance; I have manually reviewed the modifications.

### Root cause

`\doi{}` is a system Rd macro that expands (via `\Sexpr[results=rd]`) to an `\ifelse`/`\href` fragment. pkgdown's `as_html.tag_Sexpr()` evaluates that `\Sexpr` and re-parses the result as an Rd fragment with `rd_text()`:

```r
rd = flatten_text(rd_text(as.character(res))),
```

`tools::parse_Rd(..., fragment = TRUE)` appends a trailing newline `TEXT` node to every fragment. So the re-parsed doi fragment flattens to `<a ...>doi:...</a>\n`, and the following `.` ends up on the next line:

```
<a href='https://doi.org/10.2307/2413326'>doi:10.2307/2413326</a>\n.\n
```

The interior `\n` renders as whitespace in HTML. R's own `Rd2HTML` doesn't hit this because it expands the macro in place during a single parse rather than re-parsing the macro output as a separate fragment.

Any inline `\Sexpr[results=rd]{}` followed by punctuation is affected (not just DOIs).

### Fix

The fix strips the trailing newline that fragment re-parsing adds, in the `rd` branch of `as_html.tag_Sexpr()`:

```r
rd = sub("\n$", "", flatten_text(rd_text(as.character(res)))),
```

This removes the node added by `parse_Rd()` without touching leading whitespace or valid `\Sexpr` content.

### Tests

* Added a regression test in `test-rd-html.R` covering both `\doi{...}.` and a bare   `\Sexpr[results=rd]{...}.`.
* Updated the "Sexprs in file share environment" test: two adjacent inline `\Sexpr` now correctly render flush (`"11"`) instead of being split across two lines by the newline artefact.

### NEWS

> * Inline `\Sexpr[results=rd]{}` (such as the `\doi{}` macro) no longer inserts
>   spurious whitespace before following punctuation (#2809).
