### PR TITLE
Remove menu_separator before the first navbar item

### DIFF
--- a/R/navbar.R
+++ b/R/navbar.R
@@ -211,8 +211,9 @@ navbar_articles <- function(pkg = ".") {
         )
         vig <- articles[idx, , drop = FALSE]
         vig <- vig[vig$name != pkg$package, , drop = FALSE]
+        is_first_section <- index == 1
         c(
-          if (!is.null(section$navbar) && index != 1) {
+          if (!is.null(section$navbar) && !is_first_section) {
             list(menu_separator(), menu_heading(section$navbar))
           },
           menu_links(vig$title, vig$href)

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -212,7 +212,7 @@ navbar_articles <- function(pkg = ".") {
         vig <- articles[idx, , drop = FALSE]
         vig <- vig[vig$name != pkg$package, , drop = FALSE]
         c(
-          if (!is.null(section$navbar)) {
+          if (!is.null(section$navbar) && index!=1) {
             list(menu_separator(), menu_heading(section$navbar))
           },
           menu_links(vig$title, vig$href)

--- a/R/navbar.R
+++ b/R/navbar.R
@@ -212,7 +212,7 @@ navbar_articles <- function(pkg = ".") {
         vig <- articles[idx, , drop = FALSE]
         vig <- vig[vig$name != pkg$package, , drop = FALSE]
         c(
-          if (!is.null(section$navbar) && index!=1) {
+          if (!is.null(section$navbar) && index != 1) {
             list(menu_separator(), menu_heading(section$navbar))
           },
           menu_links(vig$title, vig$href)


### PR DESCRIPTION
Hi,

This is a very minor PR to fix a very minor bug.

When the "Articles" navbar menu has sections, a separator is added before the section.

However, for the first section, this doesn't look very nice, as you can see for example on https://roxygen2.r-lib.org/:

<img width="687" height="284" alt="image" src="https://github.com/user-attachments/assets/6f739efc-7db6-4204-8f68-9eba4dcc39b6" />

The PR simply checks that the index is not 1.

Since the second argument of `imap()` was named `index` I used it, but maybe `purrr::map2(navbar, seq_along(navbar), ...)` would be more robust, as this might break in the case where `navbar` has names. I'm not familiar enough with the API to know if this can happen.