### PR TITLE
Require nanonext 1.10.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     jsonlite,
     lifecycle,
     openssl,
-    nanonext (>= 1.8.0),
+    nanonext (>= 1.10.0),
     purrr (>= 1.0.0),
     ragg (>= 1.4.0),
     rlang (>= 1.1.4),


### PR DESCRIPTION
nanonext 1.10.0 requires / bundles the latest system NNG (1.12.0) with updates to http server mime types.

Increasing the minimum version here ensures that users of pkgdown have a uniform experience, and don't encounter oddities from having an old version installed.