### PR TITLE
removes smart quotes for favicon in inst/BS5/templates/head.html

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
 # pkgdown (development version)
 
+* Ensure SVG favicons are parsed properly by fixing a bug in BS5 and BS3 favicon icon templates where curly/smart quotes (”…”, U+201D) were used instead of straight quotes("" or ''). This caused the SVG favicon to not be used and a fallback raster favicon to be used. If your fallback was low resolution, your favicon looked low quality (@njtierney, #3005).
+
 # pkgdown 2.2.1
 
 * Test fix for `R CMD check`.
 * When previewing a site, it is now served via a local http server. This enables dynamic features such as search to work correctly (@shikokuchuo, #2975).
 * Code in a link (href) is no longer autolinked (#2972)
-* Ensure SVG favicons are parsed properly by fixing a bug in BS5 and BS3 favicon icon templates where curly/smart quotes (”…”, U+201D) were used instead of straight quotes, which caused the SVG favicon to not be used and a fallback raster favicon to be used. If your fallback was low resolution, your favicon looked poor (@njtierney, #3005).
 
 # pkgdown 2.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Test fix for `R CMD check`.
 * When previewing a site, it is now served via a local http server. This enables dynamic features such as search to work correctly (@shikokuchuo, #2975).
 * Code in a link (href) is no longer autolinked (#2972)
-* Ensure SVG favicons are parsed properly by fixing a bug in BS5 and BS3 favicon icon templates where curly/smart quotes (”…”, U+201D) were used instead of straight quotes, which caused the SVG favicon to not be used and a fallback raster favicon to be used. If your fallback was low resolution, your favicon looked poor.
+* Ensure SVG favicons are parsed properly by fixing a bug in BS5 and BS3 favicon icon templates where curly/smart quotes (”…”, U+201D) were used instead of straight quotes, which caused the SVG favicon to not be used and a fallback raster favicon to be used. If your fallback was low resolution, your favicon looked poor (@njtierney, #3005).
 
 # pkgdown 2.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Test fix for `R CMD check`.
 * When previewing a site, it is now served via a local http server. This enables dynamic features such as search to work correctly (@shikokuchuo, #2975).
 * Code in a link (href) is no longer autolinked (#2972)
+* Ensure SVG favicons are parsed properly by fixing a bug in BS5 and BS3 favicon icon templates where curly/smart quotes (”…”, U+201D) were used instead of straight quotes, which caused the SVG favicon to not be used and a fallback raster favicon to be used. If your fallback was low resolution, your favicon looked poor.
 
 # pkgdown 2.2.0
 

--- a/inst/BS3/templates/head.html
+++ b/inst/BS3/templates/head.html
@@ -7,7 +7,7 @@
 {{#has_favicons}}
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="48x48" href="{{#site}}{{root}}{{/site}}favicon-48x48.png">
-<link rel="icon" type=”image/svg+xml” href="{{#site}}{{root}}{{/site}}favicon.svg">
+<link rel="icon" type="image/svg+xml" href="{{#site}}{{root}}{{/site}}favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="{{#site}}{{root}}{{/site}}apple-touch-icon.png">
 <link rel="icon" sizes="any" href="{{#site}}{{root}}{{/site}}favicon.ico" >
 <link rel="manifest" href="{{#site}}{{root}}{{/site}}site.webmanifest">

--- a/inst/BS5/templates/head.html
+++ b/inst/BS5/templates/head.html
@@ -6,7 +6,7 @@
 {{#has_favicons}}
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="96x96" href="{{#site}}{{root}}{{/site}}favicon-96x96.png">
-<link rel="icon" type=”image/svg+xml” href="{{#site}}{{root}}{{/site}}favicon.svg">
+<link rel="icon" type="image/svg+xml" href="{{#site}}{{root}}{{/site}}favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="{{#site}}{{root}}{{/site}}apple-touch-icon.png">
 <link rel="icon" sizes="any" href="{{#site}}{{root}}{{/site}}favicon.ico" >
 <link rel="manifest" href="{{#site}}{{root}}{{/site}}site.webmanifest">


### PR DESCRIPTION
Resolves #3005

Strangely I could not pull the /inst/BS5/templates/head.html file locally, unsure if the inst directories are managed differently?

