### PR TITLE
Fix function redirects

### DIFF
--- a/R/build-redirects.R
+++ b/R/build-redirects.R
@@ -79,7 +79,7 @@ reference_redirects <- function(pkg) {
     return(list())
   }
 
-  names(redirects) <- paste0(names(redirects), ".html")
+  names(redirects) <- rd_output_path(paste0(names(redirects), ".html"))
 
   # Ensure we don't create an invalid file name
   redirects <- redirects[valid_filename(names(redirects))]

--- a/tests/testthat/test-build-redirects.R
+++ b/tests/testthat/test-build-redirects.R
@@ -63,6 +63,21 @@ test_that("generates redirects only for non-name aliases", {
   )
 })
 
+test_that("index aliases use index-topic.html", {
+  pkg <- list(
+    meta = list(url = "http://foo.com"),
+    topics = list(
+      alias = list(c("foo", "index")),
+      name = "foo",
+      file_out = "foo.html"
+    )
+  )
+  expect_equal(
+    reference_redirects(pkg),
+    list(c("reference/index-topic.html", "reference/foo.html"))
+  )
+})
+
 test_that("doesn't generates redirect for aliases that can't be file names", {
   pkg <- list(
     meta = list(url = "http://foo.com"),


### PR DESCRIPTION
Use `rd_output_path()` for function redirects so as to not allow a Rd alias of `index` to overwrite `reference/index.html`

Closes #3015.