### PR TITLE
Support quarto callout blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgdown (development version)
 
+* `build_articles()` now restores styled callout blocks in Quarto articles, which previously rendered as plain, unstyled blockquotes (@BjarkeHautop, #3019).
+
 # pkgdown 2.2.1
 
 * Test fix for `R CMD check`.

--- a/R/build-quarto-articles.R
+++ b/R/build-quarto-articles.R
@@ -69,7 +69,11 @@ build_quarto_articles <- function(pkg = ".", article = NULL, quiet = TRUE) {
         data <- data_quarto_article(pkg, built_path, input_file)
         render_page(pkg, "quarto", data, output_file, quiet = TRUE)
 
-        update_html(path(pkg$dst_path, output_file), tweak_quarto_html)
+        update_html(
+          path(pkg$dst_path, output_file),
+          tweak_quarto_html,
+          qmd_path = path(pkg$src_path, input_file)
+        )
       } else {
         file_copy(built_path, path(pkg$dst_path, output_file), overwrite = TRUE)
       }
@@ -168,10 +172,132 @@ data_quarto_article <- function(pkg, path, input_path) {
   )
 }
 
-tweak_quarto_html <- function(html) {
+tweak_quarto_html <- function(html, qmd_path = NULL) {
   # If top-level headings use h1, move everything down one level
   h1 <- xml2::xml_find_all(html, "//h1")
   if (length(h1) > 1) {
     tweak_section_levels(html)
   }
+
+  tweak_quarto_callouts(html, qmd_path = qmd_path)
+}
+
+# pkgdown renders `.qmd` articles with `theme: "none"` and `minimal: TRUE`
+# (see `quarto_format()`), which strips the CSS Quarto callouts rely on.
+# Under those settings, Quarto's callout Lua filter falls back to a plain,
+# class-less blockquote:
+#
+#   <div>
+#   <blockquote>
+#   <p><strong>Note</strong></p>
+#   <p>Hello note</p>
+#   </blockquote>
+#   </div>
+#
+# This finds that pattern and rewrites it into Quarto's native callout markup
+# (div.callout.callout-style-default.callout-<type>), so it can be styled by
+# pkgdown's own CSS. A hand-written blockquote is never wrapped in a bare
+# `<div>` by Pandoc, so this signature does not collide.
+#
+# A custom title is lost. If `qmd_path` is supplied we reconstruct the title
+# from the original `.qmd`.
+tweak_quarto_callouts <- function(html, qmd_path = NULL) {
+  divs <- xml2::xml_find_all(html, "//div[not(@*)]")
+  candidates <- list()
+  for (div in divs) {
+    children <- xml2::xml_children(div)
+    if (length(children) != 1 || xml2::xml_name(children) != "blockquote") {
+      next
+    }
+    bq_children <- xml2::xml_children(children)
+    if (length(bq_children) < 1 || xml2::xml_name(bq_children[[1]]) != "p") {
+      next
+    }
+    first_p <- bq_children[[1]]
+    if (length(xml2::xml_children(first_p)) != 1) {
+      next
+    }
+    strong <- xml2::xml_find_first(first_p, "./strong")
+    if (is.na(xml2::xml_name(strong))) {
+      next
+    }
+    candidates[[length(candidates) + 1L]] <- list(
+      div = div,
+      strong = strong,
+      bq_children = bq_children
+    )
+  }
+
+  if (length(candidates) == 0) {
+    return(invisible())
+  }
+
+  source_types <- if (!is.null(qmd_path) && file_exists(qmd_path)) {
+    callout_types_from_qmd(qmd_path)
+  } else {
+    character()
+  }
+  use_source_types <- length(source_types) == length(candidates)
+
+  for (i in seq_along(candidates)) {
+    cand <- candidates[[i]]
+    known_type <- if (use_source_types) source_types[[i]] else NA_character_
+    xml2::xml_replace(
+      cand$div,
+      quarto_callout_node(cand$strong, cand$bq_children, known_type)
+    )
+  }
+
+  invisible()
+}
+
+quarto_callout_types <- c("note", "tip", "warning", "caution", "important")
+
+callout_types_from_qmd <- function(qmd_path) {
+  lines <- paste(read_lines(qmd_path), collapse = "\n")
+  pattern <- ":::+\\s*\\{[^}]*\\.callout-(note|tip|warning|caution|important)[^}]*\\}"
+  full <- regmatches(lines, gregexpr(pattern, lines, perl = TRUE))[[1]]
+  sub(".*\\.callout-(note|tip|warning|caution|important).*", "\\1", full)
+}
+
+quarto_callout_node <- function(
+  strong,
+  bq_children,
+  known_type = NA_character_
+) {
+  title <- trimws(xml2::xml_text(strong))
+  type <- if (!is.na(known_type) && known_type %in% quarto_callout_types) {
+    known_type
+  } else {
+    guess <- tolower(title)
+    if (guess %in% quarto_callout_types) guess else "note"
+  }
+
+  body_nodes <- bq_children[-1]
+  body_html <- paste(
+    vapply(body_nodes, as.character, character(1)),
+    collapse = "\n"
+  )
+
+  callout_html <- sprintf(
+    '<div class="callout callout-style-default callout-%s callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container"><i class="callout-icon"></i></div>
+<div class="callout-title-container flex-fill">%s</div>
+</div>
+<div class="callout-body-container callout-body">
+%s
+</div>
+</div>',
+    type,
+    title,
+    body_html
+  )
+
+  frag <- xml2::read_html(paste0(
+    "<html><body>",
+    callout_html,
+    "</body></html>"
+  ))
+  xml2::xml_find_first(frag, "//body/div")
 }

--- a/inst/BS5/assets/pkgdown.scss
+++ b/inst/BS5/assets/pkgdown.scss
@@ -772,6 +772,128 @@ ul.task-list li input[type="checkbox"] {
   vertical-align: middle;
 }
 
+// Callouts -------------------------------------------------------------
+// Restyles the callout markup that tweak_quarto_callouts() reconstructs
+// after pkgdown's minimal Quarto render strips Quarto's own callout CSS.
+// Colours and icons are lifted from Quarto's compiled bootstrap theme
+
+.callout {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+  border-radius: 0.375rem;
+  overflow-wrap: break-word;
+  border-left: 5px solid;
+  border-right: 1px solid rgb(221.7, 222.3, 222.9);
+  border-top: 1px solid rgb(221.7, 222.3, 222.9);
+  border-bottom: 1px solid rgb(221.7, 222.3, 222.9);
+}
+
+.callout .callout-title-container {
+  overflow-wrap: anywhere;
+}
+
+.callout-header {
+  border-bottom: none;
+  font-weight: 600;
+  opacity: 85%;
+  font-size: 0.9rem;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  padding-top: 0.2em;
+  margin-bottom: -0.2em;
+  border-top-right-radius: calc(0.375rem - 1px);
+}
+
+.callout-body {
+  font-size: 0.9rem;
+  font-weight: 400;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+
+.callout-body>:first-child {
+  padding-top: 0.5rem;
+  margin-top: 0;
+}
+
+.callout-body>:last-child {
+  margin-bottom: 0.5em;
+}
+
+.callout-icon-container {
+  padding-top: 0.2em;
+  padding-right: 0.55em;
+}
+
+.callout-icon::before {
+  content: "";
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+  background-repeat: no-repeat;
+  background-size: 1rem 1rem;
+}
+
+.callout-note {
+  border-left-color: #0d6efd;
+}
+
+.callout-note>.callout-header {
+  background-color: rgb(230.8, 240.5, 254.8);
+}
+
+.callout-note .callout-icon::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" style="fill: rgb(11.7, 99, 227.7)" class="bi bi-info-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg>');
+}
+
+.callout-tip {
+  border-left-color: #198754;
+}
+
+.callout-tip>.callout-header {
+  background-color: rgb(232, 243, 237.9);
+}
+
+.callout-tip .callout-icon::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" style="fill: rgb(22.5, 121.5, 75.6)" class="bi bi-lightbulb" viewBox="0 0 16 16"><path d="M2 6a6 6 0 1 1 10.174 4.31c-.203.196-.359.4-.453.619l-.762 1.769A.5.5 0 0 1 10.5 13a.5.5 0 0 1 0 1 .5.5 0 0 1 0 1l-.224.447a1 1 0 0 1-.894.553H6.618a1 1 0 0 1-.894-.553L5.5 15a.5.5 0 0 1 0-1 .5.5 0 0 1 0-1 .5.5 0 0 1-.46-.302l-.761-1.77a1.964 1.964 0 0 0-.453-.618A5.984 5.984 0 0 1 2 6zm6-5a5 5 0 0 0-3.479 8.592c.263.254.514.564.676.941L5.83 12h4.342l.632-1.467c.162-.377.413-.687.676-.941A5 5 0 0 0 8 1z"/></svg>');
+}
+
+.callout-warning {
+  border-left-color: #ffc107;
+}
+
+.callout-warning>.callout-header {
+  background-color: rgb(255, 248.8, 230.2);
+}
+
+.callout-warning .callout-icon::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" style="fill: rgb(229.5, 173.7, 6.3)" class="bi bi-exclamation-triangle" viewBox="0 0 16 16"><path d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z"/><path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z"/></svg>');
+}
+
+.callout-caution {
+  border-left-color: #fd7e14;
+}
+
+.callout-caution>.callout-header {
+  background-color: rgb(254.8, 242.1, 231.5);
+}
+
+.callout-caution .callout-icon::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" style="fill: rgb(227.7, 113.4, 18)" class="bi bi-cone-striped" viewBox="0 0 16 16"><path d="M9.97 4.88l.953 3.811C10.158 8.878 9.14 9 8 9c-1.14 0-2.159-.122-2.923-.309L6.03 4.88C6.635 4.957 7.3 5 8 5s1.365-.043 1.97-.12zm-.245-.978L8.97.88C8.718-.13 7.282-.13 7.03.88L6.274 3.9C6.8 3.965 7.382 4 8 4c.618 0 1.2-.036 1.725-.098zm4.396 8.613a.5.5 0 0 1 .037.96l-6 2a.5.5 0 0 1-.316 0l-6-2a.5.5 0 0 1 .037-.96l2.391-.598.565-2.257c.862.212 1.964.339 3.165.339s2.303-.127 3.165-.339l.565 2.257 2.391.598z"/></svg>');
+}
+
+.callout-important {
+  border-left-color: #dc3545;
+}
+
+.callout-important>.callout-header {
+  background-color: rgb(251.5, 234.8, 236.4);
+}
+
+.callout-important .callout-icon::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" style="fill: rgb(198, 47.7, 62.1)" class="bi bi-exclamation-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/></svg>');
+}
+
 // Figure and layout --------------------------------------------------------
 
 figure.figure {

--- a/tests/testthat/test-build-quarto-articles.R
+++ b/tests/testthat/test-build-quarto-articles.R
@@ -205,7 +205,7 @@ test_that("tweak_quarto_callouts custom titles", {
 
 test_that("tweak_quarto_callouts recovers type from qmd source for custom titles", {
   qmd <- withr::local_tempfile(fileext = ".qmd")
-  writeLines(
+  write_lines(
     c(
       "::: {.callout-warning}",
       "## Careful now",

--- a/tests/testthat/test-build-quarto-articles.R
+++ b/tests/testthat/test-build-quarto-articles.R
@@ -139,3 +139,92 @@ test_that("can build quarto articles in articles folder", {
   expect_true(file_exists(path(pkg$dst_path, "articles/vig3.html")))
   expect_true(file_exists(path(pkg$dst_path, "articles/vig4.html")))
 })
+
+test_that("tweak_quarto_callouts rewrites degraded default-titled callouts", {
+  html <- xml2::read_html(paste(
+    "<html><body>",
+    "<div><blockquote><p><strong>Note</strong></p><p>Hello note</p></blockquote></div>",
+    "</body></html>"
+  ))
+
+  tweak_quarto_callouts(html)
+
+  callout <- xpath_xml(
+    html,
+    "//div[contains(concat(' ', @class, ' '), ' callout-style-default ')]"
+  )
+  expect_length(callout, 1)
+  expect_true(grepl("callout-note", xml2::xml_attr(callout, "class")))
+  expect_equal(
+    trimws(xpath_text(
+      callout,
+      ".//div[@class='callout-body-container callout-body']"
+    )),
+    "Hello note"
+  )
+})
+
+test_that("tweak_quarto_callouts leaves blockquotes untouched", {
+  html <- xml2::read_html(paste(
+    "<html><body>",
+    "<blockquote><p>This is a genuine quote.</p></blockquote>",
+    "</body></html>"
+  ))
+
+  tweak_quarto_callouts(html)
+
+  expect_length(
+    xpath_xml(
+      html,
+      "//div[contains(concat(' ', @class, ' '), ' callout-style-default ')]"
+    ),
+    0
+  )
+  expect_length(xpath_xml(html, "//blockquote"), 1)
+})
+
+test_that("tweak_quarto_callouts custom titles", {
+  html <- xml2::read_html(paste(
+    "<html><body>",
+    "<div><blockquote><p><strong>Custom title</strong></p><p>Body.</p></blockquote></div>",
+    "</body></html>"
+  ))
+
+  tweak_quarto_callouts(html)
+
+  callout <- xpath_xml(
+    html,
+    "//div[contains(concat(' ', @class, ' '), ' callout-style-default ')]"
+  )
+  expect_true(grepl("callout-note", xml2::xml_attr(callout, "class")))
+  expect_match(
+    xpath_text(callout, ".//div[contains(@class,'callout-title-container')]"),
+    "Custom title"
+  )
+})
+
+test_that("tweak_quarto_callouts recovers type from qmd source for custom titles", {
+  qmd <- withr::local_tempfile(fileext = ".qmd")
+  writeLines(
+    c(
+      "::: {.callout-warning}",
+      "## Careful now",
+      "Body.",
+      ":::"
+    ),
+    qmd
+  )
+  html <- xml2::read_html(paste(
+    "<html><body>",
+    "<div><blockquote><p><strong>Careful now</strong></p><p>Body.</p></blockquote></div>",
+    "</body></html>"
+  ))
+
+  tweak_quarto_callouts(html, qmd_path = qmd)
+
+  callout <- xpath_xml(
+    html,
+    "//div[contains(concat(' ', @class, ' '), ' callout-style-default ')]"
+  )
+  expect_true(grepl("callout-warning", xml2::xml_attr(callout, "class")))
+})

--- a/vignettes/quarto.qmd
+++ b/vignettes/quarto.qmd
@@ -31,8 +31,6 @@ The `setup-r-dependencies` action will [automatically](https://github.com/r-lib/
 
 ## Limitations
 
-* Callouts are not currently supported (<https://github.com/quarto-dev/quarto-cli/issues/9963>).
-
 * pkgdown assumes that you're using [quarto vignette style](https://quarto-dev.github.io/quarto-r/articles/hello.html), or more generally an html format with [`minimal: true`](https://quarto.org/docs/output-formats/html-basics.html#minimal-html). Specifically, only HTML vignettes are currently supported.
 
 * You can't customise mermaid styles with quarto mermaid themes. If you want to change the colours, you'll need to provide your own custom CSS as shown in [the quarto docs](https://quarto.org/docs/authoring/diagrams.html#customizing-mermaid).


### PR DESCRIPTION
Quarto articles have their CSS stripped, which makes callouts appear as plain blockquotes instead of styled callouts. This PR searches for that specific pattern in the rendered HTML (while avoiding real blockquotes) and replaces them with the proper styling.

Ported from my proof-of-concept package https://bjarkehautop.github.io/quartofix/, where you can see it work. As you'll see there, I also have fixes for tabsets and code annotation, and I can open up PRs for those too if you want.

Fixes #2701